### PR TITLE
fix: caching and entity parent_run_id

### DIFF
--- a/dynamiq/cache/managers/workflow.py
+++ b/dynamiq/cache/managers/workflow.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from dynamiq.cache.config import CacheConfig
 from dynamiq.cache.managers import CacheManager
+from dynamiq.utils import format_value
 
 
 class WorkflowCacheManager(CacheManager):
@@ -29,60 +30,65 @@ class WorkflowCacheManager(CacheManager):
             serializer=serializer,
         )
 
-    def get_entity_output(self, entity_id: str, input_data: Any) -> Any:
+    def get_entity_output(self, entity_id: str, input_data: dict, **kwargs) -> Any:
         """Retrieve cached entity output.
 
         Args:
             entity_id (str): Entity identifier.
-            input_data (Any): Input data for the entity.
+            input_data (dict): Input data for the entity.
+            kwargs (Any): Additional keyword arguments.
 
         Returns:
             Any: Cached output data.
         """
-        key = self.get_key(entity_id=entity_id, input_data=input_data)
+        key = self.get_key(entity_id=entity_id, input_data=input_data, **kwargs)
         return super().get(key=key)
 
-    def set_entity_output(
-        self, entity_id: str, input_data: Any, output_data: Any
-    ) -> Any:
+    def set_entity_output(self, entity_id: str, input_data: dict, output_data: Any, **kwargs) -> Any:
         """Cache entity output.
 
         Args:
             entity_id (str): Entity identifier.
-            input_data (Any): Input data for the entity.
+            input_data (dict): Input data for the entity.
             output_data (Any): Output data to cache.
+            kwargs (Any): Additional keyword arguments.
 
         Returns:
             Any: Result of cache set operation.
         """
-        key = self.get_key(entity_id=entity_id, input_data=input_data)
+        key = self.get_key(entity_id=entity_id, input_data=input_data, **kwargs)
         return super().set(key=key, value=output_data)
 
-    def delete_entity_output(self, entity_id: str, input_data: Any) -> Any:
+    def delete_entity_output(self, entity_id: str, input_data: dict, **kwargs) -> Any:
         """Delete cached entity output.
 
         Args:
             entity_id (str): Entity identifier.
-            input_data (Any): Input data for the entity.
+            input_data (dict): Input data for the entity.
+            kwargs (Any): Additional keyword arguments.
 
         Returns:
             Any: Result of cache delete operation.
         """
-        key = self.get_key(entity_id=entity_id, input_data=input_data)
+        key = self.get_key(entity_id=entity_id, input_data=input_data, **kwargs)
         return super().delete(key=key)
 
-    def get_key(self, entity_id: str, input_data: Any) -> str:
+    def get_key(self, entity_id: str, input_data: dict, **kwargs) -> str:
         """Generate cache key for entity.
 
         Args:
             entity_id (str): Entity identifier.
-            input_data (Any): Input data for the entity.
+            input_data (dict): Input data for the entity.
+            kwargs (Any): Additional keyword arguments.
 
         Returns:
             str: Generated cache key.
         """
-        input_data_hash = self.hash(self.serializer.dumps(input_data))
-        return f"{entity_id}:{input_data_hash}"
+        input_data_formatted = format_value(self._sort_dict(input_data))
+        input_data_hash = self.hash(self.serializer.dumps(input_data_formatted))
+        kwargs_formatted = format_value(self._sort_dict(kwargs))
+        kwargs_hash = self.hash(self.serializer.dumps(kwargs_formatted))
+        return f"{entity_id}:{input_data_hash}:{kwargs_hash}"
 
     @staticmethod
     def hash(data: str) -> str:
@@ -95,3 +101,14 @@ class WorkflowCacheManager(CacheManager):
             str: SHA-256 hash.
         """
         return hashlib.sha256(data.encode()).hexdigest()
+
+    def _sort_dict(self, d: dict) -> dict:
+        """Recursively sort dictionary keys, including nested dictionaries.
+
+        Args:
+            d (dict): Dictionary to sort.
+
+        Returns:
+            dict: Sorted dictionary.
+        """
+        return {k: self._sort_dict(v) if isinstance(v, dict) else v for k, v in sorted(d.items())}

--- a/dynamiq/cache/utils.py
+++ b/dynamiq/cache/utils.py
@@ -6,11 +6,21 @@ from dynamiq.cache.managers import WorkflowCacheManager
 from dynamiq.utils.logger import logger
 
 
+FUNC_KWARGS_TO_REMOVE = (
+    "input_data",
+    "config",
+    "run_id",
+    "parent_run_id",
+    "wf_run_id",
+)
+
+
 def cache_wf_entity(
     entity_id: str,
     cache_enabled: bool = False,
     cache_manager_cls: type[WorkflowCacheManager] = WorkflowCacheManager,
     cache_config: CacheConfig | None = None,
+    func_kwargs_to_remove: tuple[str] = FUNC_KWARGS_TO_REMOVE,
 ) -> Callable:
     """Decorator to cache workflow entity outputs.
 
@@ -19,6 +29,7 @@ def cache_wf_entity(
         cache_enabled (bool): Flag to enable caching.
         cache_manager_cls (type[WorkflowCacheManager]): Cache manager class.
         cache_config (CacheConfig | None): Cache configuration.
+        func_kwargs_to_remove (tuple[str]): List of params to remove from callable function kwargs.
 
     Returns:
         Callable: Wrapped function with caching.
@@ -45,18 +56,23 @@ def cache_wf_entity(
             """
             cache_manager = None
             from_cache = False
-            input_data = kwargs.get("input_data", args[0] if args else None)
+            input_data = kwargs.pop("input_data", args[0] if args else {})
+            cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in func_kwargs_to_remove}
             if cache_enabled and cache_config:
                 logger.debug(f"Entity_id {entity_id}: cache used")
                 cache_manager = cache_manager_cls(config=cache_config)
-                if output := cache_manager.get_entity_output(entity_id, input_data):
+                if output := cache_manager.get_entity_output(
+                    entity_id=entity_id, input_data=input_data, **cleaned_kwargs
+                ):
                     from_cache = True
                     return output, from_cache
 
             output = func(*args, **kwargs)
 
             if cache_manager:
-                cache_manager.set_entity_output(entity_id, input_data, output)
+                cache_manager.set_entity_output(
+                    entity_id=entity_id, input_data=input_data, output_data=output, **cleaned_kwargs
+                )
 
             return output, from_cache
 

--- a/dynamiq/components/serializers.py
+++ b/dynamiq/components/serializers.py
@@ -1,6 +1,8 @@
 import json
 from typing import Any
 
+from dynamiq.utils import JsonWorkflowEncoder
+
 
 class BaseSerializer:
     """
@@ -83,7 +85,7 @@ class JsonSerializer(BaseSerializer):
         Returns:
             str: The JSON string representation of the value.
         """
-        return json.dumps(value)
+        return json.dumps(value, cls=JsonWorkflowEncoder)
 
     def loads(self, value: str | None) -> Any:
         """

--- a/dynamiq/flows/flow.py
+++ b/dynamiq/flows/flow.py
@@ -186,7 +186,7 @@ class Flow(BaseFlow):
         run_id = uuid4()
         merged_kwargs = kwargs | {
             "run_id": run_id,
-            "parent_run_id": kwargs.get("parent_run_id"),
+            "parent_run_id": kwargs.get("parent_run_id", run_id),
         }
 
         logger.info(f"Flow {self.id}: execution started.")

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -366,9 +366,8 @@ class Node(BaseModel, Runnable, ABC):
         time_start = datetime.now()
 
         config = ensure_config(config)
-        merged_kwargs = merge(
-            kwargs, {"run_id": uuid4(), "parent_run_id": kwargs.get("parent_run_id")}
-        )
+        run_id = uuid4()
+        merged_kwargs = merge(kwargs, {"run_id": run_id, "parent_run_id": kwargs.get("parent_run_id", run_id)})
         if depends_result is None:
             depends_result = {}
 

--- a/dynamiq/prompts/__init__.py
+++ b/dynamiq/prompts/__init__.py
@@ -1,6 +1,7 @@
 from .prompts import (
     BasePrompt,
     Message,
+    MessageRole,
     Prompt,
     VisionMessage,
     VisionMessageImageContent,

--- a/tests/integration/nodes/test_caching.py
+++ b/tests/integration/nodes/test_caching.py
@@ -1,11 +1,19 @@
+from io import BytesIO
+
 import pytest
 
-from dynamiq import Workflow, flows
 from dynamiq.cache import RedisCacheConfig
 from dynamiq.callbacks import TracingCallbackHandler
 from dynamiq.callbacks.tracing import RunType
 from dynamiq.nodes import CachingConfig, NodeGroup
+from dynamiq.prompts import Message, MessageRole, Prompt
 from dynamiq.runnables import RunnableConfig, RunnableResult, RunnableStatus
+
+PROMPT = Prompt(messages=[Message(content="What is LLM?")])
+PROMPT_SYSTEM = Prompt(messages=[Message(content="What is LLM?", role=MessageRole.SYSTEM)])
+FILE_CONTENT = b"file content"
+FILE = BytesIO(FILE_CONTENT)
+FILE_DIFF = BytesIO(FILE_CONTENT + b"_")
 
 
 @pytest.fixture()
@@ -14,12 +22,36 @@ def node_with_caching(openai_node):
     return openai_node
 
 
+@pytest.mark.parametrize(
+    ("first_input_data", "first_kwargs", "second_input_data", "second_kwargs", "is_second_use_cache"),
+    [
+        # # Value of keys should count
+        ({"a": 1, "b": 2}, {}, {"a": 1, "b": 2}, {}, True),
+        ({"a": 1, "b": 2}, {}, {"b": 2, "a": 2}, {}, False),
+        # # Order of keys should not count
+        ({"a": 1, "b": 2}, {}, {"b": 2, "a": 1}, {}, True),
+        # # FUNC_KWARGS_TO_REMOVE should not count
+        ({"a": 1, "b": 2}, {"run_id": 1}, {"a": 1, "b": 2}, {"run_id": 2}, True),
+        # # Value of kwargs should count
+        ({"a": 1, "b": 2}, {"run_id": 1, "test": 1}, {"a": 1, "b": 2}, {"run_id": 2, "test": 1}, True),
+        ({"a": 1, "b": 2}, {"run_id": 1, "test": 1}, {"a": 1, "b": 2}, {"run_id": 2, "test": 2}, False),
+        # Different types should count
+        ({"a": 1, "files": [FILE]}, {"prompt": PROMPT}, {"a": 1, "files": [FILE]}, {"prompt": PROMPT}, True),
+        ({"a": 1, "files": [FILE]}, {"prompt": PROMPT}, {"a": 1, "files": [FILE_DIFF]}, {"prompt": PROMPT}, False),
+        ({"a": 1, "files": [FILE]}, {"prompt": PROMPT}, {"a": 1, "files": [FILE]}, {"prompt": PROMPT_SYSTEM}, False),
+    ],
+)
 def test_node_caching(
     node_with_caching,
     mock_redis,
     mock_redis_backend,
     mock_llm_response_text,
     mock_llm_executor,
+    first_input_data,
+    first_kwargs,
+    second_input_data,
+    second_kwargs,
+    is_second_use_cache,
 ):
     # Run 1st time and fill cache
     cache_namespace = "dynamiq"
@@ -27,23 +59,18 @@ def test_node_caching(
         host="redis-test-sv", port=6379, db=0, namespace=cache_namespace
     )
     tracing = TracingCallbackHandler()
-    input_data = {"a": 1, "b": 2}
-    wf = Workflow(flow=flows.Flow(nodes=[node_with_caching]))
-    response = wf.run(
-        input_data=input_data,
+    result = node_with_caching.run(
+        input_data=first_input_data,
         config=RunnableConfig(callbacks=[tracing], cache=cache_config),
+        **first_kwargs,
     )
 
-    expected_output = {
-        node_with_caching.id: RunnableResult(
-            status=RunnableStatus.SUCCESS,
-            input=input_data,
-            output={"content": mock_llm_response_text, "tool_calls": None},
-        ).to_dict()
-    }
-    assert response == RunnableResult(
-        status=RunnableStatus.SUCCESS, input=input_data, output=expected_output
+    expected_result = RunnableResult(
+        status=RunnableStatus.SUCCESS,
+        input=first_input_data,
+        output={"content": mock_llm_response_text, "tool_calls": None},
     )
+    assert result == expected_result
     assert mock_llm_executor.call_count == 1
     for run in tracing.runs.values():
         if (
@@ -62,24 +89,28 @@ def test_node_caching(
     mock_llm_executor.reset_mock()
 
     tracing = TracingCallbackHandler()
-    response = wf.run(
-        input_data=input_data,
+    result = node_with_caching.run(
+        input_data=second_input_data,
         config=RunnableConfig(callbacks=[tracing], cache=cache_config),
+        **second_kwargs,
     )
 
-    assert response == RunnableResult(
-        status=RunnableStatus.SUCCESS, input=input_data, output=expected_output
-    )
-    assert mock_llm_executor.call_count == 0
+    expected_result.input = second_input_data
+    if is_second_use_cache:
+        llm_call_count = 0
+        is_output_from_cache = True
+        node_redis_keys = 1
+    else:
+        llm_call_count = 1
+        is_output_from_cache = False
+        node_redis_keys = 2
+
+    assert result == expected_result
+    assert mock_llm_executor.call_count == llm_call_count
     for run in tracing.runs.values():
         if (
             run.type == RunType.NODE
             and run.metadata["node"]["group"] == NodeGroup.LLMS.value
         ):
-            assert run.metadata["is_output_from_cache"]
-            assert (
-                len(
-                    mock_redis.keys(f"{cache_namespace}:{run.metadata['node']['id']}:*")
-                )
-                == 1
-            )
+            assert bool(run.metadata["is_output_from_cache"]) is is_output_from_cache
+            assert len(mock_redis.keys(f"{cache_namespace}:{run.metadata['node']['id']}:*")) == node_redis_keys


### PR DESCRIPTION
- handle different input types, kwargs, dict order, common workflow kwargs in caching
- fix parent_run_id in case of missed parent