### PR TITLE
fix: vector storages connections and creation flag

### DIFF
--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -980,7 +980,8 @@ class VectorStoreNode(ConnectionNode, BaseVectorStoreParams, ABC):
     @property
     def vector_store_params(self):
         return self.model_dump(include=set(BaseVectorStoreParams.model_fields)) | {
-            "client": self.client
+            "connection": self.connection,
+            "client": self.client,
         }
 
     def connect_to_vector_store(self):

--- a/dynamiq/nodes/retrievers/pinecone.py
+++ b/dynamiq/nodes/retrievers/pinecone.py
@@ -56,7 +56,8 @@ class PineconeDocumentRetriever(VectorStoreNode, PineconeVectorStoreParams):
     @property
     def vector_store_params(self):
         return self.model_dump(include=set(PineconeVectorStoreParams.model_fields)) | {
-            "client": self.client
+            "connection": self.connection,
+            "client": self.client,
         }
 
     @property

--- a/dynamiq/nodes/writers/chroma.py
+++ b/dynamiq/nodes/writers/chroma.py
@@ -44,7 +44,10 @@ class ChromaDocumentWriter(VectorStoreNode, BaseWriterVectorStoreParams):
 
     @property
     def vector_store_params(self):
-        return self.model_dump(include=set(BaseWriterVectorStoreParams.model_fields)) | {"client": self.client}
+        return self.model_dump(include=set(BaseWriterVectorStoreParams.model_fields)) | {
+            "connection": self.connection,
+            "client": self.client,
+        }
 
     def execute(
         self, input_data: dict[str, Any], config: RunnableConfig = None, **kwargs

--- a/dynamiq/nodes/writers/pinecone.py
+++ b/dynamiq/nodes/writers/pinecone.py
@@ -45,7 +45,10 @@ class PineconeDocumentWriter(VectorStoreNode, PineconeWriterVectorStoreParams):
 
     @property
     def vector_store_params(self):
-        return self.model_dump(include=set(PineconeWriterVectorStoreParams.model_fields)) | {"client": self.client}
+        return self.model_dump(include=set(PineconeWriterVectorStoreParams.model_fields)) | {
+            "connection": self.connection,
+            "client": self.client,
+        }
 
     def execute(
         self, input_data: dict[str, Any], config: RunnableConfig = None, **kwargs

--- a/dynamiq/nodes/writers/qdrant.py
+++ b/dynamiq/nodes/writers/qdrant.py
@@ -44,7 +44,10 @@ class QdrantDocumentWriter(VectorStoreNode, QdrantWriterVectorStoreParams):
 
     @property
     def vector_store_params(self):
-        return self.model_dump(include=set(QdrantWriterVectorStoreParams.model_fields)) | {"client": self.client}
+        return self.model_dump(include=set(QdrantWriterVectorStoreParams.model_fields)) | {
+            "connection": self.connection,
+            "client": self.client,
+        }
 
     def execute(self, input_data: dict[str, Any], config: RunnableConfig = None, **kwargs):
         """

--- a/dynamiq/nodes/writers/weaviate.py
+++ b/dynamiq/nodes/writers/weaviate.py
@@ -45,7 +45,10 @@ class WeaviateDocumentWriter(VectorStoreNode, BaseWriterVectorStoreParams):
 
     @property
     def vector_store_params(self):
-        return self.model_dump(include=set(BaseWriterVectorStoreParams.model_fields)) | {"client": self.client}
+        return self.model_dump(include=set(BaseWriterVectorStoreParams.model_fields)) | {
+            "connection": self.connection,
+            "client": self.client,
+        }
 
     def execute(
         self, input_data: dict[str, Any], config: RunnableConfig = None, **kwargs

--- a/dynamiq/storages/vector/chroma/chroma.py
+++ b/dynamiq/storages/vector/chroma/chroma.py
@@ -41,7 +41,7 @@ class ChromaVectorStore:
         connection: Chroma | None = None,
         client: Optional["ClientAPI"] = None,
         index_name: str = "default",
-        create_if_not_exist: bool = True,
+        create_if_not_exist: bool = False,
     ):
         """
         Initialize the ChromaVectorStore.

--- a/dynamiq/storages/vector/pinecone/pinecone.py
+++ b/dynamiq/storages/vector/pinecone/pinecone.py
@@ -36,7 +36,7 @@ class PineconeVectorStore:
         batch_size: int = 100,
         dimension: int = 1536,
         metric: str = "cosine",
-        create_if_not_exist: bool = True,
+        create_if_not_exist: bool = False,
         **index_creation_kwargs,
     ):
         """

--- a/dynamiq/storages/vector/qdrant/qdrant.py
+++ b/dynamiq/storages/vector/qdrant/qdrant.py
@@ -123,7 +123,7 @@ class QdrantVectorStore:
         sparse_idf: bool = False,
         metric: QdrantSimilarityMetric = QdrantSimilarityMetric.COSINE,
         return_embedding: bool = False,
-        create_if_not_exist: bool = True,
+        create_if_not_exist: bool = False,
         recreate_index: bool = False,
         shard_number: int | None = None,
         replication_factor: int | None = None,
@@ -189,9 +189,10 @@ class QdrantVectorStore:
             payload_fields_to_index: List of payload fields to index.
         """
 
-        self._client = None
-        self.connection = connection or QdrantConnection()
-        self._client = client or self.connection.connect()
+        self._client = client
+        if self._client is None:
+            connection = connection or QdrantConnection()
+            self._client = connection.connect()
 
         # Store the Qdrant client specific attributes
         self.location = location

--- a/dynamiq/storages/vector/weaviate/weaviate.py
+++ b/dynamiq/storages/vector/weaviate/weaviate.py
@@ -42,7 +42,7 @@ class WeaviateVectorStore:
         connection: Weaviate | None = None,
         client: Optional["WeaviateClient"] = None,
         index_name: str = "default",
-        create_if_not_exist: bool = True,
+        create_if_not_exist: bool = False,
     ):
         """
         Initialize a new instance of WeaviateDocumentStore and connect to the Weaviate instance.


### PR DESCRIPTION
- pass connection to vector store component as we don’t do this by default
- change `create_if_not_exist` flag default value to `False` to skip creation for retrievers