### PR TITLE
fix: handle default deletion behavior when index_type is None

### DIFF
--- a/dynamiq/storages/vector/pinecone/pinecone.py
+++ b/dynamiq/storages/vector/pinecone/pinecone.py
@@ -230,7 +230,7 @@ class PineconeVectorStore:
             filters (dict[str, Any]): Filters to select documents to delete.
             top_k (int): Maximum number of documents to retrieve for deletion. Defaults to 1000.
         """
-        if self.index_type == PineconeIndexType.SERVERLESS:
+        if self.index_type is None or self.index_type == PineconeIndexType.SERVERLESS:
             """
             Serverless and Starter indexes do not support deleting with metadata filtering.
             """


### PR DESCRIPTION
Pinecone has a limitation where deleting items using metadata filtering is only available to paid users or those using pod-based deployments.

To address this, a workaround has been implemented that allows deletion in two steps instead of one: first, documents are identified using metadata filtering, and then those documents are deleted.

Paid users can directly delete documents using metadata filtering.

With some deployment parameters moved from the connection to storage, the default index type is now set to None, which attempts to use the one-step deletion approach.

This fix ensures that when the index type is undefined, the two-step deletion approach is used.