### PR TITLE
chore: add missing environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,38 @@ REPLICATE_API_KEY=your_replicate_api_key
 AI21_API_KEY=your_ai21_api_key
 
 #SambaNova
-SAMBANOVA_API_KEY = your_sambanova_api_key
+SAMBANOVA_API_KEY=your_sambanova_api_key
 
 #Milvus
-MILVUS_URI = your_milvus_uri
-MILVUS_API_TOKEN = your_milvus_api_key
+MILVUS_URI=your_milvus_uri
+MILVUS_API_TOKEN=your_milvus_api_key
+
+#Gemini
+GEMINI_API_KEY=your_gemini_api_key
+
+#Cohere
+COHERE_API_KEY=your_cohere_api_key
+
+#AWS
+AWS_ACCESS_KEY_ID=your_aws_access_key_id
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+AWS_DEFAULT_REGION=your_aws_default_region
+AWS_DEFALT_PROFILE=your_aws_default_profile
+
+#Tavily
+TAVILY_API_KEY=your_tavily_api_key
+
+#Serp
+SERP_API_KEY=your_serp_api_key
+
+#Zenrows
+ZENROWS_API_KEY=your_zenrows_api_key
+
+#Firecrawl
+FIRECRAWL_API_KEY=your_firecrawl_api_key
+
+#E2B
+E2B_API_KEY=your_e2b_api_key
+
+#Perplexity
+PERPLEXITYAI_API_KEY=your_perplexity_api_key


### PR DESCRIPTION
Adds missing environment variables to `.env.example` 