### PR TITLE
chore: update input for context precision and recall

### DIFF
--- a/dynamiq/evaluations/metrics/factual_correctness.py
+++ b/dynamiq/evaluations/metrics/factual_correctness.py
@@ -2,7 +2,7 @@ import logging
 from functools import cached_property
 from typing import Any
 
-from pydantic import BaseModel, PrivateAttr, computed_field, model_validator
+from pydantic import BaseModel, PrivateAttr, computed_field, field_validator, model_validator
 
 from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
 from dynamiq.nodes.llms import BaseLLM
@@ -62,23 +62,46 @@ class RunInput(BaseModel):
     Input model for running factual correctness evaluation.
 
     Attributes:
-        answers (List[str]): List of response texts.
-        contexts (List[str]): List of reference texts.
-        mode (Optional[str]): Evaluation mode ('precision', 'recall', or 'f1').
-        beta (Optional[float]): Beta value for F-beta score.
+        answers (list[str]): List of response texts.
+        contexts (list[str] | list[list[str]]): List of reference texts, or list of lists of reference texts.
+        mode (str | None): Evaluation mode ('precision', 'recall', or 'f1').
+        beta (float | None): Beta value for F-beta score.
         verbose (bool): Flag to enable verbose logging.
     """
 
     answers: list[str]
-    contexts: list[str]
+    contexts: list[str] | list[list[str]]
     mode: str | None = None
     beta: float | None = None
     verbose: bool = False
 
+    @field_validator("contexts", mode="before")
+    def unify_contexts(cls, v):
+        """
+        Allow contexts to be either list[str] or list[list[str]]. If list[list[str]],
+        each sub-list is joined into one string. Otherwise, if it's already list[str],
+        we leave it as-is.
+        """
+        if not isinstance(v, list):
+            raise ValueError("contexts must be a list of strings or a list of list of strings.")
+
+        # Check if it's a list[list[str]] -> join each sublist
+        if all(isinstance(item, list) and all(isinstance(x, str) for x in item) for item in v):
+            return [" ".join(sublist) for sublist in v]
+
+        # Check if it's already list[str]
+        if all(isinstance(item, str) for item in v):
+            return v
+
+        raise ValueError("contexts must be either a list of strings or a list of lists of strings.")
+
     @model_validator(mode="after")
     def check_equal_length(self):
+        """
+        By this time, contexts should be list[str]. Ensure answers and contexts have the same length.
+        """
         if len(self.answers) != len(self.contexts):
-            raise ValueError("Answer and context must have the same length.")
+            raise ValueError("answers and contexts must have the same length.")
         return self
 
 
@@ -290,7 +313,7 @@ class FactualCorrectnessEvaluator(BaseModel):
     def run(
         self,
         answers: list[str],
-        contexts: list[str],
+        contexts: list[str] | list[list[str]],
         mode: str | None = None,
         beta: float | None = None,
         verbose: bool = False,
@@ -299,15 +322,16 @@ class FactualCorrectnessEvaluator(BaseModel):
         Evaluate the factual correctness of answers against contexts.
 
         Args:
-            answers (List[str]): List of response texts.
-            contexts (List[str]): List of reference texts.
-            mode (Optional[str]): Evaluation mode ('precision', 'recall', or 'f1').
-            beta (Optional[float]): Beta value for F-beta score.
-            verbose (bool): Flag to enable verbose logging.
+            answers: List of response texts.
+            contexts: Either a list of context strings or a list of lists of context strings.
+            mode: 'precision', 'recall', or 'f1' (if None, defaults to self.mode).
+            beta: Beta value for F-beta score (if None, defaults to self.beta).
+            verbose: Flag for verbose debugging logs.
 
         Returns:
-            List[float]: List of factual correctness scores.
+            List[float]: List of factual correctness scores for each answer/context pair.
         """
+        # Validate and normalize the inputs via Pydantic
         input_data = RunInput(
             answers=answers,
             contexts=contexts,
@@ -315,6 +339,7 @@ class FactualCorrectnessEvaluator(BaseModel):
             beta=beta,
             verbose=verbose,
         )
+        # If mode/beta not specified in the input, default to self.mode/self.beta
         mode = input_data.mode or self.mode
         beta = input_data.beta or self.beta
 
@@ -322,7 +347,7 @@ class FactualCorrectnessEvaluator(BaseModel):
 
         for idx in range(len(input_data.answers)):
             answer = input_data.answers[idx]
-            context = input_data.contexts[idx]
+            context = input_data.contexts[idx]  # Guaranteed to be a single string now
 
             # Decompose claims from answer and context
             answer_claims_list = self.decompose_claims([answer])
@@ -342,7 +367,7 @@ class FactualCorrectnessEvaluator(BaseModel):
             fp = len(context_verdicts) - tp
 
             if mode != "precision":
-                # Verify context claims against answer (recall)
+                # If mode is recall or F1, verify context claims against answer (recall)
                 answer_verdicts_list = self.verify_claims(
                     premises=[answer],
                     claims_list=[context_claims],

--- a/tests/integration/evaluations/metrics/test_context_recall.py
+++ b/tests/integration/evaluations/metrics/test_context_recall.py
@@ -108,3 +108,112 @@ def test_context_recall_evaluator(openai_node):
     # Assert that the recall scores are as expected
     for computed, expected in zip(recall_scores, expected_scores):
         assert abs(computed - expected) < 0.01, f"Expected {expected}, got {computed}"
+
+
+def test_context_recall_evaluator_with_list_of_lists_of_contexts(openai_node):
+    """
+    Test that the ContextRecallEvaluator can accept contexts as list[list[str]].
+    The code should join each sub-list into a single string for each question.
+    """
+
+    # Sample data with two questions, each question having two context strings
+    questions = ["What can you tell me about Albert Einstein?", "Tell me about the Great Wall of China."]
+    contexts = [
+        [
+            "Albert Einstein (14 March 1879 - 18 April 1955) was a German-born theoretical physicist.",
+            "He developed the theory of relativity and also made contributions to quantum mechanics.",
+        ],
+        [
+            "The Great Wall of China is a series of fortifications built across the historical northern borders.",
+            "It was built to protect against various nomadic groups, but doesn't mention visibility from space.",
+        ],
+    ]
+    answers = [
+        (
+            "Albert Einstein was a theoretical physicist. He developed the theory of relativity "
+            "and contributed to quantum mechanics. He was born in Germany and won the Nobel Prize "
+            "in Physics in 1921. He loved playing the violin."
+        ),
+        (
+            "The Great Wall of China is visible from space. It was built to protect against invasions. "
+            "It stretches over 13,000 miles and is thousands of years old."
+        ),
+    ]
+
+    # Initialize evaluator with the provided openai_node
+    evaluator = ContextRecallEvaluator(llm=openai_node)
+
+    # Mocked results for each question
+    # (We assume the joined contexts match the content of each sub-list.)
+    mocked_run_results = [
+        # First question
+        {
+            "results": [
+                {
+                    "classifications": [
+                        {
+                            "statement": "Albert Einstein was a theoretical physicist.",
+                            "reason": "Appears in the joined context.",
+                            "attributed": "1",
+                        },
+                        {
+                            "statement": "He developed the theory of relativity and contributed to quantum mechanics.",
+                            "reason": "Both are mentioned in the joined context.",
+                            "attributed": "1",
+                        },
+                        {
+                            "statement": "He was born in Germany and won the Nobel Prize in Physics in 1921.",
+                            "reason": "Birthplace and Nobel Prize are not explicitly in the joined context.",
+                            "attributed": "0",
+                        },
+                        {
+                            "statement": "He loved playing the violin.",
+                            "reason": "This is not mentioned at all.",
+                            "attributed": "0",
+                        },
+                    ]
+                }
+            ]
+        },
+        # Second question
+        {
+            "results": [
+                {
+                    "classifications": [
+                        {
+                            "statement": "The Great Wall of China is visible from space.",
+                            "reason": "Not mentioned (common myth), so not in the context.",
+                            "attributed": "0",
+                        },
+                        {
+                            "statement": "It was built to protect against invasions.",
+                            "reason": "Yes, that is mentioned in the context.",
+                            "attributed": "1",
+                        },
+                        {
+                            "statement": "It stretches over 13,000 miles and is thousands of years old.",
+                            "reason": "Not in the context.",
+                            "attributed": "0",
+                        },
+                    ]
+                }
+            ]
+        },
+    ]
+
+    # Mock the run method of the evaluator's internal LLMEvaluator
+    evaluator._classification_evaluator.run = MagicMock(side_effect=mocked_run_results)
+
+    # Run the evaluator
+    recall_scores = evaluator.run(
+        questions=questions, contexts=contexts, answers=answers, verbose=False  # passing list[list[str]]
+    )
+
+    # Expected scores based on the mocked data:
+    # First question: 2 out of 4 => 0.5
+    # Second question: 1 out of 3 => ~0.3333
+    expected_scores = [0.5, 0.3333]
+
+    # Assert that the recall scores match our expectations
+    for computed, expected in zip(recall_scores, expected_scores):
+        assert abs(computed - expected) < 0.01, f"Expected {expected}, got {computed}"

--- a/tests/integration/evaluations/metrics/test_factual_correctness.py
+++ b/tests/integration/evaluations/metrics/test_factual_correctness.py
@@ -169,3 +169,189 @@ def test_factual_correctness_evaluator(openai_node):
     # Assert that the correctness scores are as expected
     for computed, expected in zip(correctness_scores, expected_scores):
         assert abs(computed - expected) < 0.01, f"Expected {expected}, got {computed}"
+
+
+def test_factual_correctness_evaluator_with_list_of_lists(openai_node):
+    """
+    Test that the FactualCorrectnessEvaluator can handle contexts passed as list[list[str]].
+    It should join each sub-list into a single string under the hood, then proceed as normal.
+    """
+
+    # Same answers as in the original test
+    answers = [
+        (
+            "Albert Einstein was a German theoretical physicist. "
+            "He developed the theory of relativity and contributed "
+            "to quantum mechanics."
+        ),
+        ("The Eiffel Tower is located in Berlin, Germany. " "It was constructed in 1889."),
+    ]
+
+    # contexts passed as list[list[str]] instead of list[str]
+    contexts = [
+        [
+            "Albert Einstein was a German-born theoretical physicist.",
+            "He developed the theory of relativity.",
+        ],
+        [
+            "The Eiffel Tower is located in Paris, France.",
+            "It was constructed in 1887 and opened in 1889.",
+        ],
+    ]
+
+    # Initialize evaluator with the provided openai_node
+    evaluator = FactualCorrectnessEvaluator(llm=openai_node)
+
+    # Mock the run method of the claim decomposer (decompose_claims)
+    evaluator._claim_decomposer.run = MagicMock(
+        side_effect=[
+            # 1) Decompose claims from first response
+            {
+                "results": [
+                    {
+                        "claims": [
+                            "Albert Einstein was a German theoretical physicist.",
+                            "He developed the theory of relativity.",
+                            "He contributed to quantum mechanics.",
+                        ]
+                    }
+                ]
+            },
+            # 2) Decompose claims from first context (joined from sub-list)
+            {
+                "results": [
+                    {
+                        "claims": [
+                            "Albert Einstein was a German-born theoretical physicist.",
+                            "He developed the theory of relativity.",
+                        ]
+                    }
+                ]
+            },
+            # 3) Decompose claims from second response
+            {
+                "results": [
+                    {
+                        "claims": [
+                            "The Eiffel Tower is located in Berlin, Germany.",
+                            "It was constructed in 1889.",
+                        ]
+                    }
+                ]
+            },
+            # 4) Decompose claims from second context (joined from sub-list)
+            {
+                "results": [
+                    {
+                        "claims": [
+                            "The Eiffel Tower is located in Paris, France.",
+                            "It was constructed in 1887.",
+                            "It opened in 1889.",
+                        ]
+                    }
+                ]
+            },
+        ]
+    )
+
+    # Mock the run method of the NLI evaluator (verify_claims)
+    evaluator._nli_evaluator.run = MagicMock(
+        side_effect=[
+            # 1) Verify first response claims against first context (precision)
+            {
+                "results": [
+                    {
+                        "results": [
+                            {
+                                "claim": "Albert Einstein was a German theoretical physicist.",
+                                "verdict": "1",
+                                "reason": "The reference mentions he was German-born.",
+                            },
+                            {
+                                "claim": "He developed the theory of relativity.",
+                                "verdict": "1",
+                                "reason": "Explicitly mentioned in the reference text.",
+                            },
+                            {
+                                "claim": "He contributed to quantum mechanics.",
+                                "verdict": "0",
+                                "reason": "The reference doesn't mention quantum mechanics.",
+                            },
+                        ]
+                    }
+                ]
+            },
+            # 2) Verify first context claims against first response (recall)
+            {
+                "results": [
+                    {
+                        "results": [
+                            {
+                                "claim": "Albert Einstein was a German-born theoretical physicist.",
+                                "verdict": "1",
+                                "reason": "The response says 'German theoretical physicist'.",
+                            },
+                            {
+                                "claim": "He developed the theory of relativity.",
+                                "verdict": "1",
+                                "reason": "Mentioned in the response.",
+                            },
+                        ]
+                    }
+                ]
+            },
+            # 3) Verify second response claims against second context (precision)
+            {
+                "results": [
+                    {
+                        "results": [
+                            {
+                                "claim": "The Eiffel Tower is located in Berlin, Germany.",
+                                "verdict": "0",
+                                "reason": "Reference says it's in Paris, France.",
+                            },
+                            {
+                                "claim": "It was constructed in 1889.",
+                                "verdict": "1",
+                                "reason": "Reference mentions it opened in 1889 (close enough).",
+                            },
+                        ]
+                    }
+                ]
+            },
+            # 4) Verify second context claims against second response (recall)
+            {
+                "results": [
+                    {
+                        "results": [
+                            {
+                                "claim": "The Eiffel Tower is located in Paris, France.",
+                                "verdict": "0",
+                                "reason": "Response says Berlin, Germany.",
+                            },
+                            {
+                                "claim": "It was constructed in 1887.",
+                                "verdict": "0",
+                                "reason": "Response doesn't mention 1887 start date.",
+                            },
+                            {
+                                "claim": "It opened in 1889.",
+                                "verdict": "1",
+                                "reason": "Response says it was constructed in 1889.",
+                            },
+                        ]
+                    }
+                ]
+            },
+        ]
+    )
+
+    # Run the evaluator
+    correctness_scores = evaluator.run(answers=answers, contexts=contexts, verbose=False)
+
+    # Expected scores based on the mocked data
+    expected_scores = [0.8, 0.4]  # same as in the original test
+
+    # Assert that the correctness scores match our expectations
+    for computed, expected in zip(correctness_scores, expected_scores):
+        assert abs(computed - expected) < 0.01, f"Expected {expected}, got {computed}"

--- a/tests/integration/evaluations/metrics/test_faithfulness.py
+++ b/tests/integration/evaluations/metrics/test_faithfulness.py
@@ -143,3 +143,149 @@ def test_faithfulness_evaluator(openai_node):
     # Assert that the faithfulness scores are as expected
     for computed, expected in zip(faithfulness_scores, expected_scores):
         assert abs(computed - expected) < 0.01, f"Expected {expected}, got {computed}"
+
+
+def test_faithfulness_evaluator_with_list_of_lists(openai_node):
+    """
+    Test that the FaithfulnessEvaluator can handle contexts as list[list[str]].
+    Each sub-list should get joined into a single string for each question/answer pair.
+    """
+
+    # The same questions/answers but contexts is now list[list[str]]
+    questions = ["Who was Albert Einstein and what is he best known for?", "Tell me about the Great Wall of China."]
+    answers = [
+        (
+            "He was a German-born theoretical physicist, widely acknowledged to be one "
+            "of the greatest and most influential physicists of all time. "
+            "He was best known for developing the theory of relativity, he also made "
+            "important contributions to the development of the theory of quantum mechanics."
+        ),
+        (
+            "The Great Wall of China is a large wall in China. "
+            "It was built to keep out invaders. "
+            "It is visible from space."
+        ),
+    ]
+    contexts = [
+        [
+            "Albert Einstein (14 March 1879 - 18 April 1955) was a German-born theoretical physicist, "
+            "widely held to be one of the greatest and most influential scientists of all time.",
+            "Best known for developing the theory of relativity, he also made important contributions "
+            "to quantum mechanics.",
+        ],
+        [
+            "The Great Wall of China is a series of fortifications that were built across the "
+            "historical northern borders of ancient Chinese states and Imperial China as protection "
+            "against various nomadic groups."
+        ],
+    ]
+
+    # Initialize evaluator
+    evaluator = FaithfulnessEvaluator(llm=openai_node)
+
+    # Mock the statement simplifier
+    evaluator._statement_simplifier.run = MagicMock(
+        side_effect=[
+            # Simplify statements for the first answer
+            {
+                "results": [
+                    {
+                        "statements": [
+                            "Albert Einstein was a German-born theoretical physicist.",
+                            "He is widely acknowledged to be one of the most influential physicists of all time.",
+                            "He was best known for developing the theory of relativity.",
+                            "He made important contributions to the development of the theory of quantum mechanics.",
+                        ]
+                    }
+                ]
+            },
+            # Simplify statements for the second answer
+            {
+                "results": [
+                    {
+                        "statements": [
+                            "The Great Wall of China is a large wall in China.",
+                            "It was built to keep out invaders.",
+                            "It is visible from space.",
+                        ]
+                    }
+                ]
+            },
+        ]
+    )
+
+    # Mock the NLI evaluator
+    evaluator._nli_evaluator.run = MagicMock(
+        side_effect=[
+            # First call: Check faithfulness for the first question
+            {
+                "results": [
+                    {
+                        "results": [
+                            {
+                                "statement": "Albert Einstein was a German-born theoretical physicist.",
+                                "verdict": "1",
+                                "reason": "This is mentioned in the context.",
+                            },
+                            {
+                                "statement": "He is widely acknowledged to be one of the greatest "
+                                "and most influential physicists of all time.",
+                                "verdict": "1",
+                                "reason": "This is mentioned in the context.",
+                            },
+                            {
+                                "statement": "He was best known for developing the theory of relativity.",
+                                "verdict": "1",
+                                "reason": "This is mentioned in the context.",
+                            },
+                            {
+                                "statement": "He also made important contributions to the development "
+                                "of the theory of quantum mechanics.",
+                                "verdict": "1",
+                                "reason": "This is mentioned in the context.",
+                            },
+                        ]
+                    }
+                ]
+            },
+            # Second call: Check faithfulness for the second question
+            {
+                "results": [
+                    {
+                        "results": [
+                            {
+                                "statement": "The Great Wall of China is a large wall in China.",
+                                "verdict": "1",
+                                "reason": "This is consistent with the context.",
+                            },
+                            {
+                                "statement": "It was built to keep out invaders.",
+                                "verdict": "1",
+                                "reason": "This is mentioned in the context.",
+                            },
+                            {
+                                "statement": "It is visible from space.",
+                                "verdict": "0",
+                                "reason": "The context does not mention this, and it is a common myth.",
+                            },
+                        ]
+                    }
+                ]
+            },
+        ]
+    )
+
+    # Run
+    faithfulness_scores = evaluator.run(
+        questions=questions, answers=answers, contexts=contexts, verbose=False  # list[list[str]]
+    )
+
+    # Expected scores based on the mocked data
+    expected_scores = [
+        1.0,  # First question: 4/4 statements faithful
+        0.6667,  # Second question: 2/3 statements faithful
+    ]
+
+    # Check final scores
+    for computed, expected in zip(faithfulness_scores, expected_scores):
+        assert abs(computed - expected) < 0.01, f"Expected {expected}, got {computed}"


### PR DESCRIPTION
Adds support for both `list[str]` and `list[list[str]]` inputs via a Pydantic validator that joins sub-lists into single strings. New tests confirm correctness for each evaluator.