### PR TITLE
fix: update llm tools output

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -192,7 +192,7 @@ class BaseLLM(ConnectionNode):
             **kwargs: Additional keyword arguments.
 
         Returns:
-            dict: A dictionary containing the generated content and tool calls.
+            dict: A dictionary containing the generated content and tool calls if present.
         """
         content = response.choices[0].message.content
         result = {"content": content}
@@ -203,7 +203,7 @@ class BaseLLM(ConnectionNode):
                 call["function"]["arguments"] = json.loads(call["function"]["arguments"])
                 tool_calls_parsed.append(call)
 
-            result |= {"tool_calls": tool_calls_parsed}
+            result["tool_calls"] = tool_calls_parsed
 
         usage_data = self.get_usage_data(model=self.model, completion=response).model_dump()
         self.run_on_node_execute_run(callbacks=config.callbacks, usage_data=usage_data, **kwargs)

--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
@@ -194,13 +195,20 @@ class BaseLLM(ConnectionNode):
             dict: A dictionary containing the generated content and tool calls.
         """
         content = response.choices[0].message.content
+        result = {"content": content}
         if tool_calls := response.choices[0].message.tool_calls:
-            tool_calls = [tc.model_dump() for tc in tool_calls]
+            tool_calls_parsed = []
+            for tc in tool_calls:
+                call = tc.model_dump()
+                call["function"]["arguments"] = json.loads(call["function"]["arguments"])
+                tool_calls_parsed.append(call)
+
+            result |= {"tool_calls": tool_calls_parsed}
 
         usage_data = self.get_usage_data(model=self.model, completion=response).model_dump()
         self.run_on_node_execute_run(callbacks=config.callbacks, usage_data=usage_data, **kwargs)
 
-        return {"content": content, "tool_calls": tool_calls}
+        return result
 
     def _handle_streaming_completion_response(
         self,

--- a/examples/llm/function_calling.py
+++ b/examples/llm/function_calling.py
@@ -88,7 +88,7 @@ def main():
             logger.info(f"\nExecuting tool call\n{tool_call}")
             function_name = tool_call["function"]["name"]
             function_to_call = available_functions[function_name]
-            function_args = json.loads(tool_call["function"]["arguments"])
+            function_args = tool_call["function"]["arguments"]
             function_response = function_to_call(
                 location=function_args.get("location"),
             )

--- a/tests/integration/flows/test_flow.py
+++ b/tests/integration/flows/test_flow.py
@@ -69,14 +69,14 @@ def test_workflow_with_depend_nodes_with_tracing(
         "c": encode_bytes(bytes_content),
         "d": encode_bytes(bytes_content_non_utf8),
     }
-    expected_output_openai = {"content": mock_llm_response_text, "tool_calls": None}
+    expected_output_openai = {"content": mock_llm_response_text}
     expected_result_openai = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input=expected_input_openai,
         output=expected_output_openai,
     )
     expected_input_anthropic = input_data | {openai_node.id: expected_result_openai.to_tracing_depend_dict()}
-    expected_output_anthropic = {"content": mock_llm_response_text, "tool_calls": None}
+    expected_output_anthropic = {"content": mock_llm_response_text}
     expected_result_anthropic = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input=expected_input_anthropic,
@@ -386,7 +386,7 @@ def test_workflow_with_input_mappings(
     )
 
     expected_input_openai = input_data
-    expected_output_openai = {"content": mock_llm_response_text, "tool_calls": None}
+    expected_output_openai = {"content": mock_llm_response_text}
     expected_result_openai = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input=expected_input_openai,

--- a/tests/integration/nodes/llms/test_ai21.py
+++ b/tests/integration/nodes/llms/test_ai21.py
@@ -62,7 +62,7 @@ def test_workflow_with_ai21_llm(mock_llm_response_text, mock_llm_executor, model
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_ai21_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_anyscale.py
+++ b/tests/integration/nodes/llms/test_anyscale.py
@@ -62,7 +62,7 @@ def test_workflow_with_anyscale_llm(mock_llm_response_text, mock_llm_executor, m
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_anyscale_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_azure.py
+++ b/tests/integration/nodes/llms/test_azure.py
@@ -61,7 +61,7 @@ def test_workflow_with_azure_llm(mock_llm_response_text, mock_llm_executor, mode
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_azure.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_bedrock.py
+++ b/tests/integration/nodes/llms/test_bedrock.py
@@ -63,7 +63,7 @@ def test_workflow_with_bedrock_llm(mock_llm_response_text, mock_llm_executor, mo
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_bedrock_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_cerebras.py
+++ b/tests/integration/nodes/llms/test_cerebras.py
@@ -59,7 +59,7 @@ def test_workflow_with_cerebras_llm(mock_llm_response_text, mock_llm_executor, m
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_cerebras_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_customllm.py
+++ b/tests/integration/nodes/llms/test_customllm.py
@@ -55,7 +55,7 @@ def test_workflow_with_custom_llm(mock_llm_response_text, mock_llm_executor):
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_customllm_studio.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_deepinfra.py
+++ b/tests/integration/nodes/llms/test_deepinfra.py
@@ -62,7 +62,7 @@ def test_workflow_with_deepinfra_llm(mock_llm_response_text, mock_llm_executor, 
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_deepinfra_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_deepseek.py
+++ b/tests/integration/nodes/llms/test_deepseek.py
@@ -61,7 +61,7 @@ def test_workflow_with_deepseek_llm(mock_llm_response_text, mock_llm_executor, m
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_deepseek_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_gemini.py
+++ b/tests/integration/nodes/llms/test_gemini.py
@@ -60,7 +60,7 @@ def test_workflow_with_gemini_llm_and_gemini_ai_studio_conn(
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_gemini_ai_studio.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(
@@ -109,7 +109,7 @@ def test_workflow_with_gemini_llm_and_gemini_vertex_ai_conn(
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_gemini_vertex_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_groq.py
+++ b/tests/integration/nodes/llms/test_groq.py
@@ -59,7 +59,7 @@ def test_workflow_with_groq_llm(mock_llm_response_text, mock_llm_executor, model
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_groq_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_huggingface.py
+++ b/tests/integration/nodes/llms/test_huggingface.py
@@ -62,7 +62,7 @@ def test_workflow_with_huggingface_llm(mock_llm_response_text, mock_llm_executor
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_huggingface_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_mistral.py
+++ b/tests/integration/nodes/llms/test_mistral.py
@@ -60,7 +60,7 @@ def test_workflow_with_mistral_llm(mock_llm_response_text, mock_llm_executor, mo
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_mistral_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_ollama.py
+++ b/tests/integration/nodes/llms/test_ollama.py
@@ -62,7 +62,7 @@ def test_workflow_with_ollama_llm(mock_llm_response_text, mock_llm_executor, mod
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_ollama_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_perplexity.py
+++ b/tests/integration/nodes/llms/test_perplexity.py
@@ -61,7 +61,7 @@ def test_workflow_with_perplexity_llm(mock_llm_response_text, mock_llm_executor,
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_perplexity_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_replicate.py
+++ b/tests/integration/nodes/llms/test_replicate.py
@@ -62,7 +62,7 @@ def test_workflow_with_replicate_llm(mock_llm_response_text, mock_llm_executor, 
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_replicate_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_together.py
+++ b/tests/integration/nodes/llms/test_together.py
@@ -62,7 +62,7 @@ def test_workflow_with_together_ai(mock_llm_response_text, mock_llm_executor, mo
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_together_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/llms/test_watsonx.py
+++ b/tests/integration/nodes/llms/test_watsonx.py
@@ -64,7 +64,7 @@ def test_workflow_with_watsonx_ai(mock_llm_response_text, mock_llm_executor, mod
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     ).to_dict()
     expected_output = {wf_watsonx_ai.flow.nodes[0].id: expected_result}
     assert response == RunnableResult(

--- a/tests/integration/nodes/operators/test_map.py
+++ b/tests/integration/nodes/operators/test_map.py
@@ -45,7 +45,7 @@ def get_map_workflow(
     [
         (
             [{"test": "OK"}, {"test": "BAD"}],
-            [{"content": "mocked_response", "tool_calls": None}, {"content": "mocked_response", "tool_calls": None}],
+            [{"content": "mocked_response"}, {"content": "mocked_response"}],
         ),
     ],
 )

--- a/tests/integration/nodes/test_caching.py
+++ b/tests/integration/nodes/test_caching.py
@@ -68,7 +68,7 @@ def test_node_caching(
     expected_result = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input=first_input_data,
-        output={"content": mock_llm_response_text, "tool_calls": None},
+        output={"content": mock_llm_response_text},
     )
     assert result == expected_result
     assert mock_llm_executor.call_count == 1

--- a/tests/integration/nodes/test_streaming.py
+++ b/tests/integration/nodes/test_streaming.py
@@ -47,7 +47,7 @@ def test_node_streaming(
         node_with_streaming.id: RunnableResult(
             status=RunnableStatus.SUCCESS,
             input=input_data,
-            output={"content": mock_llm_response_text, "tool_calls": None},
+            output={"content": mock_llm_response_text},
         ).to_dict()
     }
     assert response == RunnableResult(

--- a/tests/integration/nodes/tools/test_python.py
+++ b/tests/integration/nodes/tools/test_python.py
@@ -192,7 +192,7 @@ def test_workflow_with_python(openai_node, anthropic_node, mock_llm_executor, mo
 
     response = wf.run(input_data=input_data, config=RunnableConfig(callbacks=[tracing]))
 
-    expected_output_openai_anthropic = {"content": mock_llm_response_text, "tool_calls": None}
+    expected_output_openai_anthropic = {"content": mock_llm_response_text}
     expected_result_openai_anthropic = RunnableResult(
         status=RunnableStatus.SUCCESS,
         input=input_data,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates `base.py` to parse `tool_calls` arguments as JSON and adjusts test cases to reflect this change.
> 
>   - **Behavior**:
>     - In `base.py`, `_handle_completion_response()` now parses `tool_calls` arguments as JSON.
>     - Updates `function_calling.py` to use parsed `tool_calls` arguments directly.
>   - **Tests**:
>     - Updates expected outputs in `test_flow.py`, `test_ai21.py`, and `test_anyscale.py` to omit `tool_calls` when not present.
>     - Similar updates in `test_azure.py`, `test_bedrock.py`, and `test_cerebras.py`.
>     - Consistent changes across `test_customllm.py`, `test_deepinfra.py`, and `test_deepseek.py`.
>     - Further updates in `test_gemini.py`, `test_groq.py`, and `test_huggingface.py`.
>     - Additional updates in `test_mistral.py`, `test_ollama.py`, and `test_perplexity.py`.
>     - Final updates in `test_replicate.py`, `test_together.py`, and `test_watsonx.py`.
>     - Adjustments in `test_map.py`, `test_caching.py`, and `test_streaming.py`.
>     - Updates in `test_python.py` to reflect new `tool_calls` handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 0f0563b922a9fd7184e748739cb3c268565b9316. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->