### PR TITLE
feat: add hybrid search for pgvector and Weaviate

### DIFF
--- a/dynamiq/components/retrievers/pgvector.py
+++ b/dynamiq/components/retrievers/pgvector.py
@@ -46,6 +46,8 @@ class PGVectorDocumentRetriever:
         filters: dict[str, Any] | None = None,
         content_key: str | None = None,
         embedding_key: str | None = None,
+        query: str | None = None,
+        alpha: float | None = None,
     ):
         """
         Retrieves documents from the PGVectorStore that are similar to the provided query embedding.
@@ -67,14 +69,27 @@ class PGVectorDocumentRetriever:
         top_k = top_k or self.top_k
         filters = filters or self.filters
 
-        docs = self.vector_store._embedding_retrieval(
-            query_embedding=query_embedding,
-            filters=filters,
-            top_k=top_k,
-            exclude_document_embeddings=exclude_document_embeddings,
-            content_key=content_key,
-            embedding_key=embedding_key,
-        )
+        if query:
+            docs = self.vector_store._hybrid_retrieval(
+                query_embedding=query_embedding,
+                query=query,
+                filters=filters,
+                top_k=top_k,
+                exclude_document_embeddings=exclude_document_embeddings,
+                content_key=content_key,
+                embedding_key=embedding_key,
+                alpha=alpha,
+            )
+        else:
+            docs = self.vector_store._embedding_retrieval(
+                query_embedding=query_embedding,
+                filters=filters,
+                top_k=top_k,
+                exclude_document_embeddings=exclude_document_embeddings,
+                content_key=content_key,
+                embedding_key=embedding_key,
+            )
+
         logger.debug(f"Retrieved {len(docs)} documents from pgvector Vector Store.")
 
         return {"documents": docs}

--- a/dynamiq/components/retrievers/pgvector.py
+++ b/dynamiq/components/retrievers/pgvector.py
@@ -61,6 +61,12 @@ class PGVectorDocumentRetriever:
             filters (Optional[dict[str, Any]]): Filters to apply for retrieving specific documents. Defaults to None.
             content_key (Optional[str]): The field used to store content in the storage. Defaults to None.
             embedding_key (Optional[str]): The field used to store vector in the storage. Defaults to None.
+            query(Optional[str]): The query string to search for (when using keyword search). Defaults to None.
+            alpha (Optional[float]): The alpha value for hybrid retrieval. Defaults to 0.5.
+
+            When using hybrid retrieval, the alpha value determines the weight of the keyword search score in the
+            final ranking. A value of 0.0 means only keyword search score will be used, and a value of 1.0 means only
+            vector similarity score will be considered.
 
         Returns:
             List[Document]: A list of Document instances sorted by their relevance to the query_embedding.

--- a/dynamiq/components/retrievers/pgvector.py
+++ b/dynamiq/components/retrievers/pgvector.py
@@ -47,7 +47,7 @@ class PGVectorDocumentRetriever:
         content_key: str | None = None,
         embedding_key: str | None = None,
         query: str | None = None,
-        alpha: float | None = None,
+        alpha: float | None = 0.5,
     ):
         """
         Retrieves documents from the PGVectorStore that are similar to the provided query embedding.

--- a/dynamiq/components/retrievers/weaviate.py
+++ b/dynamiq/components/retrievers/weaviate.py
@@ -43,6 +43,8 @@ class WeaviateDocumentRetriever:
         top_k: int | None = None,
         filters: dict[str, Any] | None = None,
         content_key: str | None = None,
+        query: str | None = None,
+        alpha: float | None = None,
     ) -> dict[str, list[Document]]:
         """
         Retrieves documents from the WeaviateDocumentStore that are similar to the provided query embedding.
@@ -61,13 +63,26 @@ class WeaviateDocumentRetriever:
         top_k = top_k or self.top_k
         filters = filters or self.filters
 
-        docs = self.vector_store._embedding_retrieval(
-            query_embedding=query_embedding,
-            filters=filters,
-            top_k=top_k,
-            exclude_document_embeddings=exclude_document_embeddings,
-            content_key=content_key,
-        )
+        if query:
+            docs = self.vector_store._hybrid_retrieval(
+                query_embedding=query_embedding,
+                query=query,
+                filters=filters,
+                top_k=top_k,
+                exclude_document_embeddings=exclude_document_embeddings,
+                content_key=content_key,
+                alpha=alpha,
+            )
+
+        else:
+            docs = self.vector_store._embedding_retrieval(
+                query_embedding=query_embedding,
+                filters=filters,
+                top_k=top_k,
+                exclude_document_embeddings=exclude_document_embeddings,
+                content_key=content_key,
+            )
+
         logger.debug(f"Retrieved {len(docs)} documents from Weaviate Vector Store.")
 
         return {"documents": docs}

--- a/dynamiq/components/retrievers/weaviate.py
+++ b/dynamiq/components/retrievers/weaviate.py
@@ -44,7 +44,7 @@ class WeaviateDocumentRetriever:
         filters: dict[str, Any] | None = None,
         content_key: str | None = None,
         query: str | None = None,
-        alpha: float | None = None,
+        alpha: float | None = 0.5,
     ) -> dict[str, list[Document]]:
         """
         Retrieves documents from the WeaviateDocumentStore that are similar to the provided query embedding.

--- a/dynamiq/components/retrievers/weaviate.py
+++ b/dynamiq/components/retrievers/weaviate.py
@@ -56,6 +56,12 @@ class WeaviateDocumentRetriever:
             top_k (int, optional): The maximum number of documents to return. Defaults to None.
             filters (Optional[dict[str, Any]]): Filters to apply for retrieving specific documents. Defaults to None.
             content_key (Optional[str]): The field used to store content in the storage.
+            query(Optional[str]): The query string to search for (when using keyword search). Defaults to None.
+            alpha (Optional[float]): The alpha value for hybrid retrieval. Defaults to 0.5.
+
+            When using hybrid retrieval, the alpha value determines the weight of the keyword search score in the
+            final ranking. A value of 0.0 means only keyword search score will be used, and a value of 1.0 means only
+            vector similarity score will be considered.
 
         Returns:
             List[Document]: A list of Document instances sorted by their relevance to the query_embedding.

--- a/dynamiq/nodes/retrievers/base.py
+++ b/dynamiq/nodes/retrievers/base.py
@@ -14,6 +14,8 @@ class RetrieverInputSchema(BaseModel):
     top_k: int = Field(default=0, description="Parameter to provided how many documents to retrieve.")
     content_key: str = Field(default=None, description="Parameter to provide content key.")
     embedding_key: str = Field(default=None, description="Parameter to provide embedding key.")
+    query: str = Field(default=None, description="Parameter to provide query for search.")
+    alpha: float = Field(default=0.5, description="Parameter to provide alpha for hybrid retrieval.")
 
 
 class Retriever(VectorStoreNode, ABC):

--- a/dynamiq/nodes/retrievers/base.py
+++ b/dynamiq/nodes/retrievers/base.py
@@ -15,7 +15,7 @@ class RetrieverInputSchema(BaseModel):
     content_key: str = Field(default=None, description="Parameter to provide content key.")
     embedding_key: str = Field(default=None, description="Parameter to provide embedding key.")
     query: str = Field(default=None, description="Parameter to provide query for search.")
-    alpha: float = Field(default=0.5, description="Parameter to provide alpha for hybrid retrieval.")
+    alpha: float = Field(default=None, description="Parameter to provide alpha for hybrid retrieval.")
 
 
 class Retriever(VectorStoreNode, ABC):

--- a/dynamiq/nodes/retrievers/pgvector.py
+++ b/dynamiq/nodes/retrievers/pgvector.py
@@ -7,10 +7,10 @@ from dynamiq.nodes.node import ensure_config
 from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import PGVectorStore
-from dynamiq.storages.vector.pgvector.pgvector import PGVectorStoreParams
+from dynamiq.storages.vector.pgvector.pgvector import PGVectorStoreParams, PGVectorStoreRetrieverParams
 
 
-class PGVectorDocumentRetriever(Retriever, PGVectorStoreParams):
+class PGVectorDocumentRetriever(Retriever, PGVectorStoreRetrieverParams):
     """
     Document Retriever using PGVector.
 
@@ -103,7 +103,7 @@ class PGVectorDocumentRetriever(Retriever, PGVectorStoreParams):
         filters = input_data.filters or self.filters
         top_k = input_data.top_k or self.top_k
 
-        alpha = input_data.alpha
+        alpha = input_data.alpha or self.alpha
         query = input_data.query
 
         output = self.document_retriever.run(

--- a/dynamiq/nodes/retrievers/pgvector.py
+++ b/dynamiq/nodes/retrievers/pgvector.py
@@ -103,8 +103,17 @@ class PGVectorDocumentRetriever(Retriever, PGVectorStoreParams):
         filters = input_data.filters or self.filters
         top_k = input_data.top_k or self.top_k
 
+        alpha = input_data.alpha
+        query = input_data.query
+
         output = self.document_retriever.run(
-            query_embedding, filters=filters, top_k=top_k, content_key=content_key, embedding_key=embedding_key
+            query_embedding,
+            filters=filters,
+            top_k=top_k,
+            content_key=content_key,
+            embedding_key=embedding_key,
+            query=query,
+            alpha=alpha,
         )
 
         return {

--- a/dynamiq/nodes/retrievers/weaviate.py
+++ b/dynamiq/nodes/retrievers/weaviate.py
@@ -91,7 +91,17 @@ class WeaviateDocumentRetriever(Retriever):
         filters = input_data.filters or self.filters
         top_k = input_data.top_k or self.top_k
 
-        output = self.document_retriever.run(query_embedding, filters=filters, top_k=top_k, content_key=content_key)
+        alpha = input_data.alpha
+        query = input_data.query
+
+        output = self.document_retriever.run(
+            query_embedding,
+            filters=filters,
+            top_k=top_k,
+            content_key=content_key,
+            query=query,
+            alpha=alpha,
+        )
 
         return {
             "documents": output["documents"],

--- a/dynamiq/nodes/retrievers/weaviate.py
+++ b/dynamiq/nodes/retrievers/weaviate.py
@@ -7,9 +7,10 @@ from dynamiq.nodes.node import ensure_config
 from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import WeaviateVectorStore
+from dynamiq.storages.vector.weaviate.weaviate import WeaviteRetrieverVectorStoreParams
 
 
-class WeaviateDocumentRetriever(Retriever):
+class WeaviateDocumentRetriever(Retriever, WeaviteRetrieverVectorStoreParams):
     """Document Retriever using Weaviate.
 
     This class implements a document retriever that uses Weaviate as the vector store backend.
@@ -91,7 +92,7 @@ class WeaviateDocumentRetriever(Retriever):
         filters = input_data.filters or self.filters
         top_k = input_data.top_k or self.top_k
 
-        alpha = input_data.alpha
+        alpha = input_data.alpha or self.alpha
         query = input_data.query
 
         output = self.document_retriever.run(

--- a/dynamiq/storages/vector/pgvector/pgvector.py
+++ b/dynamiq/storages/vector/pgvector/pgvector.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from decimal import Decimal
 from enum import Enum
 from typing import Any
 
@@ -47,6 +48,7 @@ VECTOR_FUNCTION_TO_SCORE_DEFINITION = {
 
 DEFAULT_TABLE_NAME = "dynamiq_vector_store"
 DEFAULT_SCHEMA_NAME = "public"
+DEFAULT_LANGUAGE = "english"
 
 
 class PGVectorStoreParams(BaseVectorStoreParams):
@@ -55,6 +57,8 @@ class PGVectorStoreParams(BaseVectorStoreParams):
     dimension: int = 1536
     vector_function: PGVectorVectorFunction = PGVectorVectorFunction.COSINE_SIMILARITY
     embedding_key: str = "embedding"
+    # query: str | None = None
+    # alpha: float | None = 0.5
 
 
 class PGVectorStoreWriterParams(PGVectorStoreParams, BaseWriterVectorStoreParams):
@@ -78,6 +82,9 @@ class PGVectorStore:
         create_if_not_exist: bool = False,
         content_key: str = "content",
         embedding_key: str = "embedding",
+        keyword_index_name: str | None = None,
+        language: str = DEFAULT_LANGUAGE,
+        query: str | None = None,
     ):
         """
         Initialize a PGVectorStore instance.
@@ -129,9 +136,12 @@ class PGVectorStore:
         self.dimension = dimension
         self.index_method = index_method
         self.vector_function = vector_function
+        self.keyword_index_name = keyword_index_name
+        self.language = language
 
         self.content_key = content_key
         self.embedding_key = embedding_key
+        self.query = query
 
         if (
             self.index_method == PGVectorIndexMethod.IVFFLAT
@@ -147,6 +157,7 @@ class PGVectorStore:
                 if self.index_method in [PGVectorIndexMethod.IVFFLAT, PGVectorIndexMethod.HNSW]:
                     self.index_name = index_name or f"{self.index_method}_index"
                     self._create_index(conn)
+                self._create_keyword_index(conn)
         else:
             if not self._check_if_schema_exists(self._conn):
                 msg = f"Schema '{self.schema_name}' does not exist"
@@ -355,6 +366,55 @@ class PGVectorStore:
         with conn.cursor() as cur:
             self._execute_sql_query(query, cursor=cur)
             conn.commit()
+
+    def _create_keyword_index(
+        self,
+        conn: psycopg.Connection,
+        content_key: str | None = None,
+    ) -> None:
+        """
+        Internal method to create the keyword index in the database (if it does not exist).
+
+        Args:
+            conn (psycopg.Connection): The connection to the database.
+            content_key (str | None): The field used to store content in the storage. Defaults to None.
+        """
+
+        content_key = content_key or self.content_key
+
+        check_if_keyword_index_exists_query = SQL(
+            """
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = {schema_name}
+            AND tablename = {table_name}
+            AND indexname = {index_name};
+            """
+        ).format(
+            schema_name=SQLLiteral(self.schema_name),
+            table_name=SQLLiteral(self.table_name),
+            index_name=SQLLiteral(self.keyword_index_name),
+        )
+
+        create_keyword_index_query = SQL(
+            """
+            CREATE INDEX IF NOT EXISTS {index_name}
+            ON {schema_name}.{table_name} USING gin(to_tsvector('english', {content_key}));
+            """
+        ).format(
+            index_name=SQLLiteral(self.keyword_index_name),
+            schema_name=SQLLiteral(self.schema_name),
+            table_name=SQLLiteral(self.table_name),
+            content_key=SQLLiteral(content_key),
+        )
+
+        with conn.cursor() as cur:
+            self._execute_sql_query(check_if_keyword_index_exists_query, cursor=cur)
+            index_exists = bool(cur.fetchone())
+
+            if not index_exists:
+                self._execute_sql_query(create_keyword_index_query, cursor=cur)
+                conn.commit()
 
     def _drop_index(self, conn: psycopg.Connection) -> None:
         """
@@ -617,6 +677,9 @@ class PGVectorStore:
 
             if doc.get("score") is not None:
                 document.score = doc["score"]
+
+                if isinstance(doc["score"], Decimal):
+                    document.score = float(doc["score"])
             else:
                 document.score = None
 
@@ -733,6 +796,168 @@ class PGVectorStore:
 
         # Combine all parts into final query
         sql_query = base_select + where_clause + order_by
+
+        with self._get_connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cur:
+                result = self._execute_sql_query(sql_query, params, cursor=cur)
+                records = result.fetchall()
+
+                documents = self._convert_query_result_to_documents(records)
+                return documents
+
+    def _hybrid_retrieval(
+        self,
+        query: str,
+        query_embedding: list[float],
+        top_k: int = 10,
+        exclude_document_embeddings: bool = True,
+        keyword_rank_constant: int = 40,
+        filters: dict[str, Any] | None = None,
+        alpha: float = 0.5,
+        content_key: str | None = None,
+        embedding_key: str | None = None,
+    ) -> list[Document]:
+        """
+        Retrieve documents similar to the given query using a hybrid approach.
+
+        Args:
+            query (str): The query string.
+            query_embedding (list[float] | None): The query embedding vector. Defaults to None.
+            filters (dict[str, Any] | None): Filters for the query. Defaults to None.
+            top_k (int): Maximum number of documents to retrieve. Defaults to 10.
+            alpha (float): The weight to give to the keyword search. Defaults to 0.5.
+            content_key (str): The field used to store content in the storage. Defaults to None.
+            embedding_key (str): The field used to store embeddings in the storage. Defaults to None.
+
+        Returns:
+            list[Document]: List of retrieved Document objects.
+
+        Raises:
+            ValueError: If query_embedding is empty or filter format is incorrect.
+        """
+
+        if not query:
+            msg = "query must be provided for hybrid retrieval"
+            raise ValueError(msg)
+
+        if query_embedding and len(query_embedding) != self.dimension:
+            msg = f"query_embedding must be of dimension {self.dimension}"
+            raise ValueError(msg)
+
+        vector_function = self.vector_function
+        content_key = content_key or self.content_key
+        embedding_key = embedding_key or self.embedding_key
+        query = query or self.query
+
+        query_embedding = self._convert_query_embedding_to_pgvector_format(query_embedding)
+
+        # Generate the score calculation based on the vector function
+        score_definition = VECTOR_FUNCTION_TO_SCORE_DEFINITION[vector_function].format(
+            embedding_key=embedding_key, query_embedding=query_embedding
+        )
+
+        # Determine sort order based on vector function type
+        is_distance_metric = vector_function in ["l2_distance", "l1_distance"]
+
+        # Sort by score in ascending order if using a distance metric
+        # as the smaller the distance, the more similar the vectors are
+        sort_order = "ASC" if is_distance_metric else "DESC"
+
+        # Set alpha to 0.0001 when it is 0 and 0.9999 when it is 1 to avoid division by zero
+        alpha = min(max(alpha, 0.0001), 0.9999)
+
+        # Set the limit for the subquery to 4 times the top_k
+        top_k_subquery_limit = top_k * 4
+
+        # Extract the filters from the query
+        where_clause = SQL("")
+        where_clause_for_keyword_search = SQL("")
+        params = ()
+        if filters:
+            where_clause, params = _convert_filters_to_query(filters)
+
+            where_clause_for_keyword_search = SQL(where_clause.as_string().replace("WHERE", "AND"))
+
+        # Build the semantic search query with rank and filters
+        semantic_search_query = SQL(
+            """
+            WITH semantic_search AS (
+                SELECT *, RANK() OVER (ORDER BY {score_definition} {sort_order}) AS rank
+                FROM {schema_name}.{table_name}
+                {where_clause}
+                LIMIT {top_k_subquery_limit}
+            ),
+            """
+        ).format(
+            score_definition=SQL(score_definition),
+            schema_name=Identifier(self.schema_name),
+            table_name=Identifier(self.table_name),
+            top_k_subquery_limit=SQLLiteral(top_k * 4),
+            sort_order=SQL(sort_order),
+            where_clause=where_clause,
+        )
+
+        # Build the keyword search query with filters
+        keyword_search_query = SQL(
+            """
+            keyword_search AS (
+                SELECT *, RANK() OVER (ORDER BY ts_rank_cd(to_tsvector({language}, {content_key}), query) DESC) AS rank
+                FROM {schema_name}.{table_name}, plainto_tsquery({language}, {query}) query
+                WHERE to_tsvector('english', {content_key}) @@ query
+                {where_clause_for_keyword_search}
+                LIMIT {top_k_subquery_limit}
+            )
+            """
+        ).format(
+            schema_name=Identifier(self.schema_name),
+            table_name=Identifier(self.table_name),
+            content_key=Identifier(content_key),
+            language=SQLLiteral(self.language),
+            query=SQLLiteral(query),
+            top_k_subquery_limit=SQLLiteral(top_k * 4),
+            where_clause_for_keyword_search=where_clause_for_keyword_search,
+        )
+
+        embedding_key_select = (
+            ""
+            if exclude_document_embeddings
+            else "COALESCE(semantic_search.{embedding_key}, keyword_search.{embedding_key}) AS {embedding_key},"
+        )
+
+        # Build the final query to merge the results and sort them by score
+        merge_query = SQL(
+            """
+            SELECT
+                COALESCE(semantic_search.id, keyword_search.id) AS id,
+                COALESCE(semantic_search.{content_key}, keyword_search.{content_key}) AS {content_key},
+                COALESCE(semantic_search.metadata, keyword_search.metadata) AS metadata,
+                {embedding_key_select}
+                COALESCE({alpha} / ({k} + semantic_search.rank), 0.0) +
+                COALESCE((1 - {alpha}) / ({k} + keyword_search.rank), 0.0) AS score
+            FROM semantic_search
+            FULL OUTER JOIN keyword_search ON semantic_search.id = keyword_search.id
+            ORDER BY score DESC
+            LIMIT {top_k}
+            """
+        ).format(
+            schema_name=Identifier(self.schema_name),
+            table_name=Identifier(self.table_name),
+            content_key=Identifier(content_key),
+            embedding_key=Identifier(embedding_key),
+            query_embedding=SQLLiteral(query_embedding),
+            top_k=SQLLiteral(top_k),
+            query=SQLLiteral(query),
+            alpha=SQLLiteral(alpha),
+            k=SQLLiteral(keyword_rank_constant),
+            score_definition=SQL(score_definition),
+            top_k_subquery_limit=SQLLiteral(top_k_subquery_limit),
+            language=SQLLiteral(self.language),
+            embedding_key_select=SQL(embedding_key_select),
+        )
+
+        sql_query = semantic_search_query + keyword_search_query + merge_query
+
+        params = params + params
 
         with self._get_connection() as conn:
             with conn.cursor(row_factory=dict_row) as cur:

--- a/dynamiq/storages/vector/pgvector/pgvector.py
+++ b/dynamiq/storages/vector/pgvector/pgvector.py
@@ -396,14 +396,16 @@ class PGVectorStore:
 
         create_keyword_index_query = SQL(
             """
-            CREATE INDEX IF NOT EXISTS {index_name}
-            ON {schema_name}.{table_name} USING gin(to_tsvector('english', {content_key}));
+            CREATE INDEX {index_name}
+            ON {schema_name}.{table_name} 
+            USING gin(to_tsvector({language}, {content_key}));
             """
         ).format(
             index_name=SQLLiteral(self.keyword_index_name),
             schema_name=SQLLiteral(self.schema_name),
             table_name=SQLLiteral(self.table_name),
             content_key=SQLLiteral(content_key),
+            language=SQLLiteral(self.language),
         )
 
         with conn.cursor() as cur:

--- a/dynamiq/storages/vector/pgvector/pgvector.py
+++ b/dynamiq/storages/vector/pgvector/pgvector.py
@@ -397,7 +397,7 @@ class PGVectorStore:
         create_keyword_index_query = SQL(
             """
             CREATE INDEX {index_name}
-            ON {schema_name}.{table_name} 
+            ON {schema_name}.{table_name}
             USING gin(to_tsvector({language}, {content_key}));
             """
         ).format(

--- a/dynamiq/storages/vector/pgvector/pgvector.py
+++ b/dynamiq/storages/vector/pgvector/pgvector.py
@@ -59,6 +59,10 @@ class PGVectorStoreParams(BaseVectorStoreParams):
     embedding_key: str = "embedding"
 
 
+class PGVectorStoreRetrieverParams(PGVectorStoreParams):
+    alpha: float = 0.5
+
+
 class PGVectorStoreWriterParams(PGVectorStoreParams, BaseWriterVectorStoreParams):
     create_if_not_exist: bool = False
 
@@ -82,7 +86,6 @@ class PGVectorStore:
         embedding_key: str = "embedding",
         keyword_index_name: str | None = None,
         language: str = DEFAULT_LANGUAGE,
-        query: str | None = None,
     ):
         """
         Initialize a PGVectorStore instance.
@@ -139,7 +142,6 @@ class PGVectorStore:
 
         self.content_key = content_key
         self.embedding_key = embedding_key
-        self.query = query
 
         if (
             self.index_method == PGVectorIndexMethod.IVFFLAT

--- a/dynamiq/storages/vector/weaviate/weaviate.py
+++ b/dynamiq/storages/vector/weaviate/weaviate.py
@@ -6,6 +6,7 @@ from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateQueryError
 from weaviate.util import generate_uuid5
 
 from dynamiq.connections import Weaviate
+from dynamiq.storages.vector.base import BaseVectorStoreParams
 from dynamiq.storages.vector.exceptions import VectorStoreDuplicateDocumentException, VectorStoreException
 from dynamiq.storages.vector.policies import DuplicatePolicy
 from dynamiq.storages.vector.utils import create_file_id_filter
@@ -27,6 +28,10 @@ DOCUMENT_COLLECTION_PROPERTIES = [
 ]
 
 DEFAULT_QUERY_LIMIT = 9999
+
+
+class WeaviteRetrieverVectorStoreParams(BaseVectorStoreParams):
+    alpha: float = 0.5
 
 
 class WeaviateVectorStore:

--- a/dynamiq/storages/vector/weaviate/weaviate.py
+++ b/dynamiq/storages/vector/weaviate/weaviate.py
@@ -409,7 +409,7 @@ class WeaviateVectorStore:
         filters = create_file_id_filter(file_id)
         self.delete_documents_by_filters(filters)
 
-    def _bm25_retrieval(
+    def _keyword_retrieval(
         self,
         query: str,
         filters: dict[str, Any] | None = None,

--- a/tests/unit/components/retrievers/test_pgvector_document_retriever.py
+++ b/tests/unit/components/retrievers/test_pgvector_document_retriever.py
@@ -30,6 +30,34 @@ class TestPGVectorDocumentRetriever:
 
         assert result == {"documents": mock_documents}
 
+    def test_run_method_hybrid(self, mock_documents):
+        mock_vector_store = MagicMock(spec=PGVectorStore)
+        mock_vector_store._hybrid_retrieval.return_value = mock_documents
+
+        retriever = PGVectorDocumentRetriever(vector_store=mock_vector_store, filters={"field": "value"}, top_k=5)
+
+        result = retriever.run(
+            query_embedding=[0.1, 0.2, 0.3],
+            exclude_document_embeddings=True,
+            top_k=2,
+            filters={"new_field": "new_value"},
+            query="query",
+            alpha=0.5,
+        )
+
+        mock_vector_store._hybrid_retrieval.assert_called_once_with(
+            query_embedding=[0.1, 0.2, 0.3],
+            query="query",
+            filters={"new_field": "new_value"},
+            top_k=2,
+            exclude_document_embeddings=True,
+            content_key=None,
+            embedding_key=None,
+            alpha=0.5,
+        )
+
+        assert result == {"documents": mock_documents}
+
     def test_run_method_with_defaults(self, mock_documents, mock_filters):
         mock_vector_store = MagicMock(spec=PGVectorStore)
         mock_vector_store._embedding_retrieval.return_value = mock_documents

--- a/tests/unit/components/retrievers/test_weaviate_document_retriever.py
+++ b/tests/unit/components/retrievers/test_weaviate_document_retriever.py
@@ -28,6 +28,33 @@ class TestWeaviateDocumentRetriever:
 
         assert result == {"documents": mock_documents}
 
+    def test_run_method_hybrid(self, mock_documents):
+        mock_vector_store = MagicMock(spec=WeaviateVectorStore)
+        mock_vector_store._hybrid_retrieval.return_value = mock_documents
+
+        retriever = WeaviateDocumentRetriever(vector_store=mock_vector_store, filters={"field": "value"}, top_k=5)
+
+        result = retriever.run(
+            query_embedding=[0.1, 0.2, 0.3],
+            exclude_document_embeddings=True,
+            top_k=2,
+            filters={"new_field": "new_value"},
+            query="query",
+            alpha=0.5,
+        )
+
+        mock_vector_store._hybrid_retrieval.assert_called_once_with(
+            query_embedding=[0.1, 0.2, 0.3],
+            query="query",
+            filters={"new_field": "new_value"},
+            top_k=2,
+            exclude_document_embeddings=True,
+            content_key=None,
+            alpha=0.5,
+        )
+
+        assert result == {"documents": mock_documents}
+
     def test_run_method_with_defaults(self, mock_documents, mock_filters):
         mock_vector_store = MagicMock(spec=WeaviateVectorStore)
         mock_vector_store._embedding_retrieval.return_value = mock_documents

--- a/tests/unit/nodes/retrievers/test_pgvector_retriever.py
+++ b/tests/unit/nodes/retrievers/test_pgvector_retriever.py
@@ -79,6 +79,31 @@ def test_execute(pgvector_document_retriever):
         top_k=input_data.top_k,
         content_key=None,
         embedding_key=None,
+        query=None,
+        alpha=0.5,
+    )
+
+    assert result == {"documents": mock_output["documents"]}
+
+
+def test_execute_hybrid(pgvector_document_retriever):
+    input_data = RetrieverInputSchema(embedding=[0.1, 0.2, 0.3], query="query", filters={"field": "value"}, top_k=5)
+    config = RunnableConfig(callbacks=[])
+
+    mock_output = {"documents": [{"id": "1", "content": "Document 1"}]}
+    pgvector_document_retriever.document_retriever = MagicMock(spec=PGVectorDocumentRetrieverComponent)
+    pgvector_document_retriever.document_retriever.run.return_value = mock_output
+
+    result = pgvector_document_retriever.execute(input_data, config)
+
+    pgvector_document_retriever.document_retriever.run.assert_called_once_with(
+        input_data.embedding,
+        filters=input_data.filters,
+        top_k=input_data.top_k,
+        content_key=None,
+        embedding_key=None,
+        query=input_data.query,
+        alpha=0.5,
     )
 
     assert result == {"documents": mock_output["documents"]}
@@ -107,6 +132,8 @@ def test_execute_with_default_filters_and_top_k(pgvector_document_retriever):
         top_k=pgvector_document_retriever.top_k,
         content_key=None,
         embedding_key=None,
+        query=None,
+        alpha=0.5,
     )
 
     assert result == {"documents": mock_output["documents"]}

--- a/tests/unit/nodes/retrievers/test_weaviate_retriever.py
+++ b/tests/unit/nodes/retrievers/test_weaviate_retriever.py
@@ -64,7 +64,36 @@ def test_execute(weaviate_document_retriever):
     result = weaviate_document_retriever.execute(input_data, config)
 
     weaviate_document_retriever.document_retriever.run.assert_called_once_with(
-        input_data.embedding, filters=input_data.filters, top_k=input_data.top_k, content_key=None
+        input_data.embedding,
+        filters=input_data.filters,
+        top_k=input_data.top_k,
+        content_key=None,
+        query=None,
+        alpha=0.5,
+    )
+
+    assert result == {"documents": mock_output["documents"]}
+
+
+def test_execute_hybrid(weaviate_document_retriever):
+    input_data = RetrieverInputSchema(
+        embedding=[0.1, 0.2, 0.3], filters={"field": "value"}, top_k=5, query="query", alpha=0.5
+    )
+    config = RunnableConfig(callbacks=[])
+
+    mock_output = {"documents": [{"id": "1", "content": "Document 1"}]}
+    weaviate_document_retriever.document_retriever = MagicMock(spec=WeaviateDocumentRetrieverComponent)
+    weaviate_document_retriever.document_retriever.run.return_value = mock_output
+
+    result = weaviate_document_retriever.execute(input_data, config)
+
+    weaviate_document_retriever.document_retriever.run.assert_called_once_with(
+        input_data.embedding,
+        filters=input_data.filters,
+        top_k=input_data.top_k,
+        content_key=None,
+        query=input_data.query,
+        alpha=input_data.alpha,
     )
 
     assert result == {"documents": mock_output["documents"]}
@@ -92,6 +121,8 @@ def test_execute_with_default_filters_and_top_k(weaviate_document_retriever):
         filters=weaviate_document_retriever.filters,
         top_k=weaviate_document_retriever.top_k,
         content_key=None,
+        query=None,
+        alpha=0.5,
     )
 
     assert result == {"documents": mock_output["documents"]}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add hybrid search functionality to PGVector and Weaviate retrievers, combining keyword and vector similarity searches.
> 
>   - **Hybrid Search**:
>     - Added `query` and `alpha` parameters to `run()` in `pgvector.py` and `weaviate.py` for hybrid retrieval.
>     - Implemented `_hybrid_retrieval()` in `pgvector.py` and `weaviate.py` to combine keyword and vector similarity searches.
>   - **Storage Enhancements**:
>     - Added `PGVectorStoreRetrieverParams` and `WeaviteRetrieverVectorStoreParams` for hybrid search parameters.
>     - Created `_create_keyword_index()` in `pgvector.py` to support keyword search.
>   - **Node Updates**:
>     - Updated `execute()` in `pgvector.py` and `weaviate.py` to handle hybrid search parameters.
>   - **Testing**:
>     - Added tests for hybrid retrieval in `test_pgvector_document_retriever.py` and `test_weaviate_document_retriever.py`.
>     - Updated node tests in `test_pgvector_retriever.py` and `test_weaviate_retriever.py` to cover hybrid search scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for b9c758c2f4f211fd14f287758d45179fb77347c3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->