### PR TITLE
fix: change ibm text models endpoint

### DIFF
--- a/dynamiq/nodes/llms/watsonx.py
+++ b/dynamiq/nodes/llms/watsonx.py
@@ -12,7 +12,7 @@ class WatsonX(BaseLLM):
         MODEL_PREFIX (str): The prefix for the WatsonX model name.
     """
     connection: WatsonXConnection | None = None
-    MODEL_PREFIX = "watsonx/"
+    MODEL_PREFIX = "watsonx_text/"
 
     def __init__(self, **kwargs):
         """Initialize the WatsonX LLM node.

--- a/tests/integration/nodes/llms/test_watsonx.py
+++ b/tests/integration/nodes/llms/test_watsonx.py
@@ -42,8 +42,8 @@ def get_watsonx_workflow(
 @pytest.mark.parametrize(
     ("model", "expected_model"),
     [
-        ("watsonx/ibm/granite-13b-chat-v2", "watsonx/ibm/granite-13b-chat-v2"),
-        ("ibm/granite-13b-chat-v2", "watsonx/ibm/granite-13b-chat-v2"),
+        ("watsonx_text/ibm/granite-13b-chat-v2", "watsonx_text/ibm/granite-13b-chat-v2"),
+        ("ibm/granite-13b-chat-v2", "watsonx_text/ibm/granite-13b-chat-v2"),
     ],
 )
 def test_workflow_with_watsonx_ai(mock_llm_response_text, mock_llm_executor, model, expected_model):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `MODEL_PREFIX` in `WatsonX` class and corresponding tests to use `"watsonx_text/"`.
> 
>   - **Behavior**:
>     - Update `MODEL_PREFIX` in `WatsonX` class in `watsonx.py` from `"watsonx/"` to `"watsonx_text/"`.
>   - **Tests**:
>     - Update test cases in `test_watsonx.py` to use `"watsonx_text/ibm/granite-13b-chat-v2"` as the model prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 6808ee5ad96937623b98e4938d84981dbf6345d8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->