### PR TITLE
fix: input/output nodes execution

### DIFF
--- a/tests/integration/flows/test_flow.py
+++ b/tests/integration/flows/test_flow.py
@@ -188,6 +188,7 @@ def test_workflow_with_depend_nodes_with_tracing(
     assert output_node_run.output == format_value(expected_input_output)
     assert output_node_run.status == RunStatus.SUCCEEDED
     assert output_node_run.tags == tags
+    assert output_node_run.executions
 
 
 def test_workflow_with_depend_nodes_and_depend_fail(
@@ -325,6 +326,7 @@ def test_workflow_with_depend_nodes_and_depend_fail(
     assert output_node_run.output == expected_output_output_node
     assert output_node_run.status == RunStatus.SKIPPED
     assert output_node_run.tags == []
+    assert not output_node_run.executions
 
 
 def test_workflow_with_failed_flow(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `execute_with_retry` from `Pass` class and streamline `execute` method; add assertions in `test_flow.py` to check executions.
> 
>   - **Code Changes**:
>     - Remove `execute_with_retry` method from `Pass` class in `operators.py`.
>     - Simplify `execute` method in `Pass` class by removing redundant logic and ensuring transformers are applied correctly.
>   - **Tests**:
>     - Add assertion `assert output_node_run.executions` in `test_workflow_with_depend_nodes_with_tracing()` in `test_flow.py`.
>     - Add assertion `assert not output_node_run.executions` in `test_workflow_with_depend_nodes_and_depend_fail()` in `test_flow.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for ed10085c64e5b6d4acb3662e6bb7fd5cb9d57b2b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->