### PR TITLE
fix: add fix for None default files per agent

### DIFF
--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -66,7 +66,7 @@ class AgentIntermediateStep(BaseModel):
 
 class AgentInputSchema(BaseModel):
     input: str = Field(..., description="Parameter to provide input to the agent.")
-    files: list[io.BytesIO | bytes] = Field(default=[], description="Parameter to provide files to the agent.")
+    files: list[io.BytesIO | bytes] = Field(default=None, description="Parameter to provide files to the agent.")
 
     user_id: str = Field(default=None, description="Parameter to provide user ID.")
     session_id: str = Field(default=None, description="Parameter to provide session ID.")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default `files` value in `AgentInputSchema` from `[]` to `None` in `base.py` to handle absence of files differently.
> 
>   - **Behavior**:
>     - Change default value of `files` in `AgentInputSchema` from `[]` to `None` in `base.py`.
>     - This affects how the absence of files is handled, potentially impacting file-related logic in the agent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for c0ba8f6b06be1ea496c3c4cafdb06fee9aa02946. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->