### PR TITLE
refactor: move llm evaluator to evaluations

### DIFF
--- a/dynamiq/evaluations/__init__.py
+++ b/dynamiq/evaluations/__init__.py
@@ -1,2 +1,3 @@
 from .base_evaluator import BaseEvaluator
+from .llm_evaluator import LLMEvaluator
 from .python_evaluator import PythonEvaluator

--- a/dynamiq/evaluations/llm_evaluator.py
+++ b/dynamiq/evaluations/llm_evaluator.py
@@ -158,9 +158,7 @@ class LLMEvaluator:
             # No type check on 'type' to allow types from 'typing' module
 
         # Validate examples
-        if not isinstance(examples, list) or not all(
-            isinstance(example, dict) for example in examples
-        ):
+        if not isinstance(examples, list) or not all(isinstance(example, dict) for example in examples):
             msg = f"LLM evaluator expects examples to be a list of dictionaries but received {examples}."
             raise ValueError(msg)
 
@@ -168,11 +166,7 @@ class LLMEvaluator:
             if (
                 not all(k in example for k in ("inputs", "outputs"))
                 or not all(isinstance(example[param], dict) for param in ["inputs", "outputs"])
-                or not all(
-                    isinstance(key, str)
-                    for param in ["inputs", "outputs"]
-                    for key in example[param]
-                )
+                or not all(isinstance(key, str) for param in ["inputs", "outputs"] for key in example[param])
             ):
                 msg = (
                     f"Each example must have 'inputs' and 'outputs' as dictionaries with string keys, "

--- a/dynamiq/evaluations/metrics/answer_correctness.py
+++ b/dynamiq/evaluations/metrics/answer_correctness.py
@@ -2,8 +2,8 @@ import json
 
 from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
-from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
 from dynamiq.evaluations import BaseEvaluator
+from dynamiq.evaluations.llm_evaluator import LLMEvaluator
 from dynamiq.nodes.llms import BaseLLM
 from dynamiq.utils.logger import logger
 

--- a/dynamiq/evaluations/metrics/bleu_score.py
+++ b/dynamiq/evaluations/metrics/bleu_score.py
@@ -78,7 +78,7 @@ class BleuScoreEvaluator(BaseEvaluator):
 
         self._corpus_bleu = corpus_bleu
 
-    def run(self, references: list[str], responses: list[str]) -> list[float]:
+    def run(self, ground_truth_answers: list[str], answers: list[str]) -> list[float]:
         """
         Compute BLEU scores for each reference-response pair.
 
@@ -92,7 +92,7 @@ class BleuScoreEvaluator(BaseEvaluator):
         Returns:
             list[float]: BLEU scores, one per pair.
         """
-        input_data = RunInput(ground_truth_answers=references, answers=responses)
+        input_data = RunInput(ground_truth_answers=ground_truth_answers, answers=answers)
         scores: list[float] = []
 
         for ref, resp in zip(input_data.ground_truth_answers, input_data.answers):

--- a/dynamiq/evaluations/metrics/context_precision.py
+++ b/dynamiq/evaluations/metrics/context_precision.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, PrivateAttr, field_validator, model_validator
 
-from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
 from dynamiq.evaluations import BaseEvaluator
+from dynamiq.evaluations.llm_evaluator import LLMEvaluator
 from dynamiq.nodes.llms import BaseLLM
 from dynamiq.utils.logger import logger
 

--- a/dynamiq/evaluations/metrics/context_recall.py
+++ b/dynamiq/evaluations/metrics/context_recall.py
@@ -3,8 +3,8 @@ from typing import Any
 
 from pydantic import BaseModel, PrivateAttr, field_validator, model_validator
 
-from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
 from dynamiq.evaluations import BaseEvaluator
+from dynamiq.evaluations.llm_evaluator import LLMEvaluator
 from dynamiq.nodes.llms import BaseLLM
 from dynamiq.utils.logger import logger
 

--- a/dynamiq/evaluations/metrics/factual_correctness.py
+++ b/dynamiq/evaluations/metrics/factual_correctness.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from pydantic import BaseModel, PrivateAttr, field_validator, model_validator
 
-from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
 from dynamiq.evaluations import BaseEvaluator
+from dynamiq.evaluations.llm_evaluator import LLMEvaluator
 from dynamiq.nodes.llms import BaseLLM
 from dynamiq.utils.logger import logger
 

--- a/dynamiq/evaluations/metrics/faithfulness.py
+++ b/dynamiq/evaluations/metrics/faithfulness.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from pydantic import BaseModel, PrivateAttr, field_validator, model_validator
 
-from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
 from dynamiq.evaluations import BaseEvaluator
+from dynamiq.evaluations.llm_evaluator import LLMEvaluator
 from dynamiq.nodes.llms import BaseLLM
 from dynamiq.utils.logger import logger
 

--- a/examples/evaluation/llm_evaluator.py
+++ b/examples/evaluation/llm_evaluator.py
@@ -1,4 +1,4 @@
-from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
+from dynamiq.evaluations.llm_evaluator import LLMEvaluator
 from dynamiq.nodes.llms import BaseLLM, OpenAI
 
 

--- a/examples/evaluation/metrics/bleu_score.py
+++ b/examples/evaluation/metrics/bleu_score.py
@@ -34,7 +34,7 @@ def main():
     bleu_evaluator = BleuScoreEvaluator()
 
     # Run evaluator
-    bleu_scores = bleu_evaluator.run(references=ground_truth_answers, responses=answers)
+    bleu_scores = bleu_evaluator.run(ground_truth_answers=ground_truth_answers, answers=answers)
 
     # Display the results
     for idx, score in enumerate(bleu_scores):

--- a/tests/integration/evaluations/metrics/test_bleu_score.py
+++ b/tests/integration/evaluations/metrics/test_bleu_score.py
@@ -22,7 +22,7 @@ def test_bleu_score_evaluator():
     bleu_evaluator = BleuScoreEvaluator()
 
     # Run evaluator
-    bleu_scores = bleu_evaluator.run(references=ground_truth_answers, responses=answers)
+    bleu_scores = bleu_evaluator.run(ground_truth_answers=ground_truth_answers, answers=answers)
 
     expected_scores = [1.0, 0.47, 0.24]  # Replace with actual printed scores
     for computed, expected in zip(bleu_scores, expected_scores):

--- a/tests/integration/evaluations/test_llm_evaluator.py
+++ b/tests/integration/evaluations/test_llm_evaluator.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
+from dynamiq.evaluations.llm_evaluator import LLMEvaluator
 from dynamiq.nodes.llms import BaseLLM
 
 

--- a/tests/unit/components/evaluators/test_llm_evaluator_unit.py
+++ b/tests/unit/components/evaluators/test_llm_evaluator_unit.py
@@ -1,4 +1,4 @@
-from dynamiq.components.evaluators.llm_evaluator import LLMEvaluator
+from dynamiq.evaluations.llm_evaluator import LLMEvaluator
 
 
 def test_prepare_prompt_template():


### PR DESCRIPTION
- Move LLM Evaluator to evaluations folder where all metrics are located
- Refactor input params for BLEU score
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `LLMEvaluator` to `dynamiq/evaluations` and update BLEU score input parameters for consistency.
> 
>   - **Refactor**:
>     - Move `LLMEvaluator` from `dynamiq/components/evaluators` to `dynamiq/evaluations`.
>     - Update imports in `answer_correctness.py`, `context_precision.py`, `context_recall.py`, `factual_correctness.py`, `faithfulness.py`, `llm_evaluator.py`, and `test_llm_evaluator.py` to reflect new location.
>   - **BLEU Score**:
>     - Refactor `run()` method in `bleu_score.py` to use `ground_truth_answers` and `answers` as input parameters instead of `references` and `responses`.
>     - Update related examples and tests in `examples/evaluation/metrics/bleu_score.py` and `test_bleu_score.py`.
>   - **Misc**:
>     - Remove `__init__.py` from `dynamiq/components/evaluators`.
>     - Minor formatting changes in `llm_evaluator.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 2f9b6bdf383a737b5f32fcd60a9984d470d23dd1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->