### PR TITLE
fix: drop temperature  for reasoning models

### DIFF
--- a/dynamiq/nodes/llms/openai.py
+++ b/dynamiq/nodes/llms/openai.py
@@ -1,8 +1,19 @@
+import enum
 from functools import cached_property
 from typing import Any, ClassVar
 
 from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.nodes.llms.base import BaseLLM
+
+
+class ReasoningEffort(str, enum.Enum):
+    """
+    The reasoning effort to use for the OpenAI LLM.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
 
 
 class OpenAI(BaseLLM):
@@ -14,6 +25,7 @@ class OpenAI(BaseLLM):
         connection (OpenAIConnection | None): The connection to use for the OpenAI LLM.
     """
     connection: OpenAIConnection | None = None
+    reasoning_effort: ReasoningEffort | None = ReasoningEffort.MEDIUM
     O_SERIES_MODEL_PREFIXES: ClassVar[tuple[str, ...]] = ("o1", "o3")
 
     def __init__(self, **kwargs):
@@ -43,6 +55,7 @@ class OpenAI(BaseLLM):
         new_params = params.copy()
         if self.is_o_series_model:
             new_params["max_completion_tokens"] = self.max_tokens
+            new_params["reasoning_effort"] = self.reasoning_effort
             new_params.pop("max_tokens", None)
             new_params.pop("temperature", None)
         return new_params


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `ReasoningEffort` enum and removes `temperature` from completion parameters in `OpenAI` LLM node.
> 
>   - **Behavior**:
>     - Introduces `ReasoningEffort` enum in `openai.py` with values `LOW`, `MEDIUM`, `HIGH`.
>     - Adds `reasoning_effort` attribute to `OpenAI` class, defaulting to `ReasoningEffort.MEDIUM`.
>     - Modifies `update_completion_params()` in `OpenAI` to include `reasoning_effort` and remove `temperature` for O-series models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 666828cc84e70a0a3c169142c8dd9f97b1714628. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->