### PR TITLE
fix: usage of `o3` reasoning param

### DIFF
--- a/dynamiq/nodes/llms/openai.py
+++ b/dynamiq/nodes/llms/openai.py
@@ -55,7 +55,8 @@ class OpenAI(BaseLLM):
         new_params = params.copy()
         if self.is_o_series_model:
             new_params["max_completion_tokens"] = self.max_tokens
-            new_params["reasoning_effort"] = self.reasoning_effort
+            if self.model.lower().startswith("o3"):
+                new_params["reasoning_effort"] = self.reasoning_effort
             new_params.pop("max_tokens", None)
             new_params.pop("temperature", None)
         return new_params


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix conditional addition of `reasoning_effort` in `update_completion_params()` for 'o3' models in `openai.py`.
> 
>   - **Behavior**:
>     - In `update_completion_params()` in `openai.py`, `reasoning_effort` is now only added for models starting with 'o3'.
>     - Previously, `reasoning_effort` was added for all O-series models.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for f1fc46c076b3caa71f82b893d40bc347de8ec056. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->