### PR TITLE
fix: add None as default input per agent

### DIFF
--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -65,7 +65,7 @@ class AgentIntermediateStep(BaseModel):
 
 
 class AgentInputSchema(BaseModel):
-    input: str = Field(default=None, description="Parameter to provide input to the agent.")
+    input: str | None = Field(default=None, description="Parameter to provide input to the agent.")
     files: list[io.BytesIO | bytes] = Field(default=None, description="Parameter to provide files to the agent.")
 
     user_id: str = Field(default=None, description="Parameter to provide user ID.")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `input` field in `AgentInputSchema` now defaults to `None`, making it optional.
> 
>   - **Behavior**:
>     - `input` field in `AgentInputSchema` now defaults to `None`, making it optional.
>   - **Files**:
>     - Change made in `base.py` within `AgentInputSchema` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 7f7acba523211963e00c3ce1b7673d866e52a1e8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->