### PR TITLE
fix: stop words

### DIFF
--- a/dynamiq/nodes/agents/react.py
+++ b/dynamiq/nodes/agents/react.py
@@ -331,7 +331,7 @@ class ReActAgent(Agent):
         stop_sequences = []
 
         if self.inference_mode == InferenceMode.XML:
-            stop_sequences.extend(["</action_input>", "</output>", "<observation>"])
+            stop_sequences.extend(["<observation>"])
         elif self.inference_mode == InferenceMode.DEFAULT:
             stop_sequences.extend(["Observation: "])
         self.llm.stop = stop_sequences


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes stop sequences in `_run_agent()` for `InferenceMode.XML` in `react.py`, using only `<observation>`.
> 
>   - **Behavior**:
>     - In `react.py`, `_run_agent()` function now only uses `<observation>` as a stop sequence for `InferenceMode.XML`, removing `</action_input>` and `</output>`.
>   - **Misc**:
>     - No other changes or additions were made in this pull request.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 773c27d7ad4cb815fbfb83577a6f8aa63075b50f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->