### PR TITLE
feat: add single metric for llm predefined

### DIFF
--- a/tests/integration/evaluations/metrics/test_answer_correctness.py
+++ b/tests/integration/evaluations/metrics/test_answer_correctness.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
-from dynamiq.evaluations.metrics import AnswerCorrectnessEvaluator
+
+from dynamiq.evaluations.metrics.answer_correctness import AnswerCorrectnessEvaluator
 
 
 def test_answer_correctness_evaluator(openai_node):
@@ -24,15 +25,14 @@ def test_answer_correctness_evaluator(openai_node):
         ),
     ]
 
-    # Initialize evaluator with the provided openai_node
     evaluator = AnswerCorrectnessEvaluator(llm=openai_node)
 
-    # Mock the LLMEvaluator's run method for statement extraction.
-    # The first call returns extracted statements from the answers,
-    # The second call returns extracted statements from the ground truth answers.
+    # Mock extraction: each question calls extract_statements twice:
+    # For question 1: first call for the answer, second call for the ground truth.
+    # For question 2: similarly.
     evaluator._statement_extractor.run = MagicMock(
         side_effect=[
-            # Extraction for answers (for two questions)
+            # Q1: extraction for answer
             {
                 "results": [
                     {
@@ -40,11 +40,10 @@ def test_answer_correctness_evaluator(openai_node):
                             "The sun is powered by nuclear fission.",
                             "Its primary function is to provide light to the solar system.",
                         ]
-                    },
-                    {"statements": ["The boiling point of water is 100 degrees Celsius at sea level."]},
+                    }
                 ]
             },
-            # Extraction for ground truth answers (for two questions)
+            # Q1: extraction for ground truth answer
             {
                 "results": [
                     {
@@ -53,41 +52,58 @@ def test_answer_correctness_evaluator(openai_node):
                             "Fusion releases energy.",
                             "The sun provides heat and light.",
                         ]
-                    },
+                    }
+                ]
+            },
+            # Q2: extraction for answer
+            {"results": [{"statements": ["The boiling point of water is 100 degrees Celsius at sea level."]}]},
+            # Q2: extraction for ground truth answer
+            {
+                "results": [
                     {
                         "statements": [
                             "The boiling point of water is 100 degrees Celsius at sea level.",
                             "Boiling point can change with altitude.",
                         ]
-                    },
+                    }
                 ]
             },
         ]
     )
 
-    # For each candidate statement, the classification evaluator is called.
-    # In our new implementation each call returns a dict with "results" list containing 'match'
-    # and 'reasoning' keys.
-    # For question 1, there are 2 answer statements and 3 ground truth statements.
-    # For question 2, there is 1 answer statement and 2 ground truth statements.
+    # Mock classification: for each candidate statement, the classifier's run method is called.
+    # For Question 1:
+    #   - Two calls for answer statements:
+    #         Call 1 for "The sun is powered by nuclear fission." returns match: False.
+    #         Call 2 for "Its primary function is to provide light to the solar system." returns match: True.
+    #   - Three calls for ground truth statements:
+    #         Call 1 for "The sun is powered by nuclear fusion." returns match: False.
+    #         Call 2 for "Fusion releases energy." returns match: False.
+    #         Call 3 for "The sun provides heat and light." returns match: True.
+    #
+    # For Question 2:
+    #   - One call for answer statement returns match: True.
+    #   - Two calls for ground truth statements:
+    #         Call 1 for "The boiling point of water is 100 degrees Celsius at sea level." returns match: True.
+    #         Call 2 for "Boiling point can change with altitude." returns match: False.
     evaluator._statement_classifier.run = MagicMock(
         side_effect=[
             # Q1, answer statement call 1:
             {"results": [{"match": False, "reasoning": "Mismatch: expected fusion but found fission."}]},
             # Q1, answer statement call 2:
-            {"results": [{"match": True, "reasoning": "The statement supports the core fact of providing light."}]},
+            {"results": [{"match": True, "reasoning": "Supported: provides light."}]},
             # Q1, ground truth statement call 1:
-            {"results": [{"match": False, "reasoning": "Mismatch: the answer does not mention nuclear fusion."}]},
+            {"results": [{"match": False, "reasoning": "Mismatch: answer omits fusion."}]},
             # Q1, ground truth statement call 2:
-            {"results": [{"match": False, "reasoning": "The answer does not mention energy release."}]},
+            {"results": [{"match": False, "reasoning": "Answer does not mention energy release."}]},
             # Q1, ground truth statement call 3:
-            {"results": [{"match": True, "reasoning": "Matches: the answer supports the provision of light."}]},
+            {"results": [{"match": True, "reasoning": "Matches: answer supports the provision of light."}]},
             # Q2, answer statement call:
-            {"results": [{"match": True, "reasoning": "The statement matches the core fact."}]},
+            {"results": [{"match": True, "reasoning": "Correct: statement matches."}]},
             # Q2, ground truth statement call 1:
-            {"results": [{"match": True, "reasoning": "Matches: the statement is exactly present in the answer."}]},
+            {"results": [{"match": True, "reasoning": "Exact match."}]},
             # Q2, ground truth statement call 2:
-            {"results": [{"match": False, "reasoning": "This detail is not mentioned in the answer."}]},
+            {"results": [{"match": False, "reasoning": "Detail not mentioned in answer."}]},
         ]
     )
 
@@ -102,29 +118,29 @@ def test_answer_correctness_evaluator(openai_node):
     #   Answer candidate classifications:
     #      - "The sun is powered by nuclear fission." => match: False
     #      - "Its primary function is to provide light to the solar system." => match: True
-    #     => TP (supported) = 1, FP = 1, Precision = 1/(1+1) = 0.5.
+    #     => TP = 1, FP = 1, so Precision = 1/(1+1) = 0.50.
     #
     #   Ground truth candidate classifications (compared against answer text):
     #      - "The sun is powered by nuclear fusion." => match: False
     #      - "Fusion releases energy." => match: False
     #      - "The sun provides heat and light." => match: True
-    #     => TP (present) = 1, FN = 2, Recall = 1/(1+2) ≈ 0.33.
+    #     => TP (present) = 1, FN = 2, so Recall = 1/(1+2) ≈ 0.33.
     #
-    #   F1 Score = 2*(0.5*0.33)/(0.5+0.33) ≈ 0.4.
+    #   F1 Score = 2 * (0.5 * 0.33) / (0.5 + 0.33) ≈ 0.40.
     #
     # For Question 2:
-    #   Answer candidate: "The boiling point of water is 100 degrees Celsius at sea level."
-    #      => match: True, so TP = 1, FP = 0, Precision = 1.0.
+    #   Answer candidate:
+    #      - "The boiling point of water is 100 degrees Celsius at sea level." => match: True
+    #     => TP = 1, FP = 0, so Precision = 1.0.
     #
-    #   Ground truth candidates:
+    #   Ground truth candidate classifications:
     #      - "The boiling point of water is 100 degrees Celsius at sea level." => match: True
     #      - "Boiling point can change with altitude." => match: False
-    #     => TP (present) = 1, FN = 1, Recall = 1/(1+1) = 0.5.
+    #     => TP = 1, FN = 1, so Recall = 1/(1+1) = 0.50.
     #
-    #   F1 Score = 2*(1*0.5)/(1+0.5) = 0.67 (approximately).
-    #
-    # Therefore, expected final scores are approximately [0.4, 0.67].
-    expected_scores = [0.4, 0.67]
+    #   F1 Score = 2 * (1.0 * 0.50) / (1.0 + 0.50) ≈ 0.67.
+    expected_scores = [0.40, 0.67]
 
-    for computed, expected in zip([result.score for result in correctness_scores.results], expected_scores):
+    computed_scores = [result.score for result in correctness_scores.results]
+    for computed, expected in zip(computed_scores, expected_scores):
         assert abs(computed - expected) < 0.01, f"Expected {expected}, got {computed}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce `run_single` method for single sample evaluation across multiple metrics, refactoring existing methods for consistency and updating tests accordingly.
> 
>   - **Behavior**:
>     - Add `run_single()` method to `AnswerCorrectnessEvaluator`, `ContextPrecisionEvaluator`, `ContextRecallEvaluator`, `FactualCorrectnessEvaluator`, and `FaithfulnessEvaluator` for single sample evaluation.
>     - Refactor `run()` methods in these evaluators to use `run_single()` for each sample.
>   - **Models**:
>     - Add `AnswerCorrectnessRunSingleInput` to `answer_correctness.py`.
>     - Add `FaithfulnessRunSingleInput` to `faithfulness.py`.
>   - **Tests**:
>     - Update `test_answer_correctness_evaluator` in `test_answer_correctness.py` to reflect changes in evaluation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for d81435e597e30471d104de151cc16f64c6db17b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->