### PR TITLE
feat: add base url for OpenAI connection

### DIFF
--- a/dynamiq/connections/connections.py
+++ b/dynamiq/connections/connections.py
@@ -212,13 +212,6 @@ class OpenAI(BaseApiKeyConnection):
     def conn_params(self) -> dict:
         """
         Returns the parameters required for connection.
-
-        Returns:
-            dict: A dictionary containing
-
-                -the API key with the key 'api_key'.
-
-                -the base url with the key 'api_base'.
         """
         return {
             "api_base": self.url,

--- a/dynamiq/connections/connections.py
+++ b/dynamiq/connections/connections.py
@@ -187,8 +187,10 @@ class OpenAI(BaseApiKeyConnection):
 
     Attributes:
         api_key (str): The API key for the OpenAI service, fetched from the environment variable 'OPENAI_API_KEY'.
+        url (str): The endpoint url for the OpenAI service, fetched from the environment variable 'OPENAI_URL'.
     """
     api_key: str = Field(default_factory=partial(get_env_var, "OPENAI_API_KEY"))
+    url: str = Field(default_factory=partial(get_env_var, "OPENAI_URL", "https://api.openai.com/v1"))
 
     def connect(self) -> "OpenAIClient":
         """
@@ -201,9 +203,27 @@ class OpenAI(BaseApiKeyConnection):
         """
         # Import in runtime to save memory
         from openai import OpenAI as OpenAIClient
-        openai_client = OpenAIClient(api_key=self.api_key)
+
+        openai_client = OpenAIClient(api_key=self.api_key, base_url=self.url)
         logger.debug("Connected to OpenAI")
         return openai_client
+
+    @property
+    def conn_params(self) -> dict:
+        """
+        Returns the parameters required for connection.
+
+        Returns:
+            dict: A dictionary containing
+
+                -the API key with the key 'api_key'.
+
+                -the base url with the key 'api_base'.
+        """
+        return {
+            "api_base": self.url,
+            "api_key": self.api_key,
+        }
 
 
 class Anthropic(BaseApiKeyConnection):

--- a/tests/integration/flows/test_flow.py
+++ b/tests/integration/flows/test_flow.py
@@ -123,6 +123,7 @@ def test_workflow_with_depend_nodes_with_tracing(
             client=ANY,
             response_format=None,
             drop_params=True,
+            api_base="https://api.openai.com/v1",
         ),
         mock.call(
             tools=None,
@@ -277,6 +278,7 @@ def test_workflow_with_depend_nodes_and_depend_fail(
             top_p=None,
             response_format=None,
             drop_params=True,
+            api_base="https://api.openai.com/v1",
         )
     ]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add configurable base URL for OpenAI connection in `connections.py` and update tests in `test_flow.py`.
> 
>   - **Behavior**:
>     - Add `url` attribute to `OpenAI` in `connections.py`, defaulting to `https://api.openai.com/v1`.
>     - Modify `connect()` in `OpenAI` to use `base_url` parameter.
>     - Add `conn_params` property to return connection parameters including `api_base`.
>   - **Tests**:
>     - Update `test_flow.py` to check `api_base` parameter in `mock_llm_executor` calls.
>     - Ensure tests verify the correct URL is used in OpenAI connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 2cb9b9f508cc1fae629563b5d0e306cf54ac3ff8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->