### PR TITLE
feat: add HTML converter node

### DIFF
--- a/dynamiq/components/converters/html.py
+++ b/dynamiq/components/converters/html.py
@@ -1,0 +1,431 @@
+import copy
+import html as html_module
+import html.parser
+import re
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Literal
+
+from lxml import etree  # nosec
+from lxml import html as lxml_html  # nosec
+
+from dynamiq.components.converters.base import BaseConverter
+from dynamiq.components.converters.utils import get_filename_for_bytesio
+from dynamiq.types import Document, DocumentCreationMode
+
+
+class HTMLConverter(BaseConverter):
+    """
+    A component for converting HTML files to Documents using lxml.
+
+    Initializes the object with the configuration for converting documents using
+    lxml HTML parser.
+
+    Args:
+        document_creation_mode (Literal["one-doc-per-file"], optional):
+            Determines how to create Documents from the HTML content. Currently only supports:
+            - `"one-doc-per-file"`: Creates one Document per file.
+                All content is converted to markdown format.
+            Defaults to `"one-doc-per-file"`.
+
+    Usage example:
+        ```python
+        from dynamiq.components.converters.html import HTMLConverter
+
+        converter = HTMLConverter()
+        documents = converter.run(paths=["a/file/path.html", "a/directory/path"])["documents"]
+        ```
+    """
+
+    document_creation_mode: Literal[DocumentCreationMode.ONE_DOC_PER_FILE] = DocumentCreationMode.ONE_DOC_PER_FILE
+
+    def _process_file(self, file: Path | BytesIO, metadata: dict[str, Any]) -> list[Any]:
+        """
+        Process a file and return a list of Documents.
+
+        Args:
+            file: Path to a file or BytesIO object
+            metadata: Metadata to attach to the documents
+
+        Returns:
+            List of Documents
+        """
+        # Get the file path or name for BytesIO
+        if isinstance(file, BytesIO):
+            filepath = get_filename_for_bytesio(file, metadata)
+        else:
+            filepath = str(file)
+
+        # Read the file content
+        if isinstance(file, BytesIO):
+            file.seek(0)
+            html_content = file.read().decode("utf-8")
+        else:
+            with open(file, encoding="utf-8") as f:
+                html_content = f.read()
+
+        # Parse the HTML content
+        elements = self._parse_html_content(html_content)
+
+        # Create documents from the HTML elements
+        return self._create_documents(
+            filepath=filepath,
+            elements=elements,
+            document_creation_mode=self.document_creation_mode,
+            metadata=metadata,
+        )
+
+    def _parse_html_content(self, html_content: str) -> lxml_html.HtmlElement:
+        """
+        Parse HTML content using lxml.
+
+        Args:
+            html_content: HTML content to parse
+
+        Returns:
+            lxml HTML element
+        """
+        try:
+            return lxml_html.fromstring(html_content)
+        except etree.ParserError:
+            # Handle malformed HTML by cleaning it first
+            html_content = self._clean_html(html_content)
+            return lxml_html.fromstring(html_content)
+
+    @staticmethod
+    def _clean_html(html_content: str) -> str:
+        """
+        Clean malformed HTML.
+
+        Args:
+            html_content: HTML content to clean
+
+        Returns:
+            Cleaned HTML content
+        """
+        parser = html.parser.HTMLParser()
+        try:
+            return parser.unescape(html_content)
+        except AttributeError:
+            # For Python 3.9+, HTMLParser.unescape is deprecated
+            return html_module.unescape(html_content)
+
+    def _create_documents(
+        self,
+        filepath: str,
+        elements: lxml_html.HtmlElement,
+        document_creation_mode: DocumentCreationMode,
+        metadata: dict[str, Any],
+        **kwargs,
+    ) -> list[Document]:
+        """
+        Create Documents from the HTML elements.
+        """
+        if document_creation_mode != DocumentCreationMode.ONE_DOC_PER_FILE:
+            raise ValueError("HTMLConverter only supports one-doc-per-file mode")
+
+        markdown_content = self._convert_to_markdown(elements)
+
+        # Clean up excessive newlines
+        markdown_content = re.sub(r"\n{4,}", "\n\n", markdown_content)
+        markdown_content = markdown_content.strip()
+
+        metadata = copy.deepcopy(metadata)
+        metadata["file_path"] = filepath
+
+        return [Document(content=markdown_content, metadata=metadata)]
+
+    def _convert_to_markdown(self, element: lxml_html.HtmlElement) -> str:
+        """
+        Convert HTML element to Markdown.
+
+        Args:
+            element: lxml HTML element
+
+        Returns:
+            Markdown string
+        """
+        markdown = MarkdownConverter()
+        return markdown.convert_element(element)
+
+
+class MarkdownConverter:
+    """Helper class to convert HTML elements to Markdown format"""
+
+    def __init__(self):
+        self.tag_handlers = {
+            "h1": self.handle_heading,
+            "h2": self.handle_heading,
+            "h3": self.handle_heading,
+            "h4": self.handle_heading,
+            "h5": self.handle_heading,
+            "h6": self.handle_heading,
+            "p": self.handle_paragraph,
+            "a": self.handle_link,
+            "img": self.handle_image,
+            "strong": self.handle_strong,
+            "b": self.handle_strong,
+            "em": self.handle_emphasis,
+            "i": self.handle_emphasis,
+            "code": self.handle_code,
+            "pre": self.handle_preformatted,
+            "ul": self.handle_unordered_list,
+            "ol": self.handle_ordered_list,
+            "li": self.handle_list_item,
+            "br": self.handle_linebreak,
+            "hr": self.handle_horizontal_rule,
+            "table": self.handle_table,
+            "tr": self.handle_table_row,
+            "th": self.handle_table_cell,
+            "td": self.handle_table_cell,
+            "blockquote": self.handle_blockquote,
+            "div": self.handle_block,
+            "span": self.handle_inline,
+        }
+
+        self.list_state = []
+        self.in_table = False
+        self.table_headers = []
+        self.table_rows = []
+        self.current_row = []
+
+    def convert_element(self, element: lxml_html.HtmlElement | str, parent_tag=None) -> str:
+        """Convert an HTML element to Markdown recursively"""
+        if element is None:
+            return ""
+
+        if isinstance(element, str) or element.tag == "text":
+            text = element if isinstance(element, str) else element.text_content().strip()
+            if text and parent_tag not in ["pre", "code"]:
+                text = " ".join(text.split())
+            return text
+
+        tag = element.tag
+
+        if tag is etree.Comment or tag in ["script", "style"]:
+            return ""
+
+        if tag == "html" or tag == "body" or tag == "document":
+            return self.handle_document(element)
+
+        if tag in self.tag_handlers:
+            return self.tag_handlers[tag](element)
+
+        return self.process_children(element)
+
+    def process_children(self, element: lxml_html.HtmlElement, add_linebreaks=False) -> str:
+        """Process all children of an element and join their markdown"""
+        result = []
+
+        if element.text and element.text.strip():
+            result.append(element.text)
+
+        for child in element:
+            child_md = self.convert_element(child)
+            if child_md:
+                result.append(child_md)
+            if child.tail and child.tail.strip():
+                result.append(child.tail)
+
+        separator = "\n" if add_linebreaks else ""
+        return separator.join([r for r in result if r and r.strip()])
+
+    def handle_document(self, element: lxml_html.HtmlElement) -> str:
+        """Handle document element (html or body)"""
+        return self.process_children(element, True)
+
+    def handle_heading(self, element: lxml_html.HtmlElement) -> str:
+        """Handle heading elements (h1-h6)"""
+        level = int(element.tag[1])
+        content = element.text_content().strip()
+        return f"\n\n{'#' * level} {content}\n\n"
+
+    def handle_paragraph(self, element: lxml_html.HtmlElement) -> str:
+        """Handle paragraph elements"""
+        content = element.text or ""
+
+        for child in element:
+            if child.tag in self.tag_handlers:
+                content += self.tag_handlers[child.tag](child)
+            else:
+                content += self.process_children(child)
+
+            if child.tail:
+                content += child.tail
+
+        if not content.strip():
+            return ""
+
+        return f"\n\n{content}\n\n"
+
+    def handle_link(self, element: lxml_html.HtmlElement) -> str:
+        """Handle anchor elements"""
+        href = element.get("href", "")
+        content = element.text_content() or href
+
+        if href.startswith("#"):
+            anchor = href[1:]
+            return f"[{content}](#{anchor})"
+
+        return f"[{content}]({href})"
+
+    def handle_image(self, element: lxml_html.HtmlElement) -> str:
+        """Handle image elements"""
+        src = element.get("src", "")
+        alt = element.get("alt", "")
+        title = element.get("title", "")
+        if title:
+            return f'![{alt}]({src} "{title}")'
+        return f"![{alt}]({src})"
+
+    def handle_strong(self, element: lxml_html.HtmlElement) -> str:
+        """Handle strong/bold elements"""
+        content = element.text_content().strip()
+        return f"**{content}**"
+
+    def handle_emphasis(self, element: lxml_html.HtmlElement) -> str:
+        """Handle emphasis/italic elements"""
+        content = element.text_content().strip()
+        return f"*{content}*"
+
+    def handle_code(self, element: lxml_html.HtmlElement) -> str:
+        """Handle inline code elements"""
+        if element.getparent() is not None and element.getparent().tag == "pre":
+            return element.text_content()
+
+        content = element.text_content()
+        return f"`{content}`"
+
+    def handle_preformatted(self, element: lxml_html.HtmlElement) -> str:
+        """Handle preformatted code blocks"""
+        code_element = element.find("code")
+        if code_element is not None:
+            content = code_element.text_content()
+            language = ""
+            for cls in code_element.get("class", "").split():
+                if cls.startswith("language-"):
+                    language = cls[9:]
+                    break
+            return f"\n```{language}\n{content}\n```\n"
+
+        content = element.text_content()
+        return f"\n```\n{content}\n```\n"
+
+    def handle_unordered_list(self, element: lxml_html.HtmlElement) -> str:
+        """Handle unordered list elements"""
+        self.list_state.append({"type": "ul", "index": 0})
+        content = self.process_children(element, True)
+        self.list_state.pop()
+        return f"\n{content}\n"
+
+    def handle_ordered_list(self, element: lxml_html.HtmlElement) -> str:
+        """Handle ordered list elements"""
+        start = element.get("start", "1")
+        try:
+            start = int(start)
+        except ValueError:
+            start = 1
+
+        self.list_state.append({"type": "ol", "index": start - 1})
+        content = self.process_children(element, True)
+        self.list_state.pop()
+        return f"\n{content}\n"
+
+    def handle_list_item(self, element: lxml_html.HtmlElement) -> str:
+        """Handle list item elements"""
+        if self.list_state and self.list_state[-1]["type"] == "ol":
+            self.list_state[-1]["index"] += 1
+
+        indent = "  " * (len(self.list_state) - 1)
+        if self.list_state and self.list_state[-1]["type"] == "ul":
+            bullet = "*"
+        else:
+            bullet = f"{self.list_state[-1]['index']}."
+
+        content = element.text or ""
+
+        for child in element:
+            if child.tag in self.tag_handlers:
+                content += self.tag_handlers[child.tag](child)
+            else:
+                content += self.process_children(child)
+
+            if child.tail:
+                content += child.tail
+
+        return f"{indent}{bullet} {content}"
+
+    def handle_linebreak(self, element: lxml_html.HtmlElement) -> str:
+        """Handle line break elements"""
+        return "\n"
+
+    def handle_horizontal_rule(self, element: lxml_html.HtmlElement) -> str:
+        """Handle horizontal rule elements"""
+        return "\n\n---\n\n"
+
+    def handle_table(self, element: lxml_html.HtmlElement) -> str:
+        """Handle table elements"""
+        self.in_table = True
+        self.table_headers = []
+        self.table_rows = []
+
+        self.process_children(element)
+
+        if not self.table_headers and self.table_rows:
+            self.table_headers = self.table_rows[0]
+            self.table_rows = self.table_rows[1:]
+
+        if not self.table_headers:
+            self.in_table = False
+            return ""
+
+        result = []
+        result.append("| " + " | ".join(self.table_headers) + " |")
+        result.append("| " + " | ".join(["---"] * len(self.table_headers)) + " |")
+
+        for row in self.table_rows:
+            padded_row = row + [""] * (len(self.table_headers) - len(row))
+            result.append("| " + " | ".join(padded_row) + " |")
+
+        self.in_table = False
+        return "\n\n" + "\n".join(result) + "\n\n"
+
+    def handle_table_row(self, element: lxml_html.HtmlElement) -> str:
+        """Handle table row elements"""
+        if not self.in_table:
+            return ""
+
+        self.current_row = []
+        self.process_children(element)
+
+        if element.findall("th"):
+            self.table_headers = self.current_row
+        else:
+            self.table_rows.append(self.current_row)
+
+        return ""
+
+    def handle_table_cell(self, element: lxml_html.HtmlElement) -> str:
+        """Handle table cell elements"""
+        if not self.in_table:
+            return ""
+
+        content = element.text_content()
+        self.current_row.append(content.strip())
+        return ""
+
+    def handle_blockquote(self, element: lxml_html.HtmlElement) -> str:
+        """Handle blockquote elements"""
+        content = element.text_content()
+        lines = content.split("\n")
+        quoted_lines = [f"> {line}" if line.strip() else ">" for line in lines]
+        return "\n\n" + "\n".join(quoted_lines) + "\n\n"
+
+    def handle_block(self, element: lxml_html.HtmlElement) -> str:
+        """Handle block-level elements like div"""
+        content = self.process_children(element)
+        return f"\n\n{content}\n\n"
+
+    def handle_inline(self, element: lxml_html.HtmlElement) -> str:
+        """Handle inline elements like span"""
+        return self.process_children(element)

--- a/dynamiq/components/converters/html.py
+++ b/dynamiq/components/converters/html.py
@@ -52,7 +52,7 @@ class HTMLConverter(BaseConverter):
         """
         # Get the file path or name for BytesIO
         if isinstance(file, BytesIO):
-            filepath = get_filename_for_bytesio(file, metadata)
+            filepath = get_filename_for_bytesio(file)
         else:
             filepath = str(file)
 

--- a/dynamiq/nodes/converters/__init__.py
+++ b/dynamiq/nodes/converters/__init__.py
@@ -1,4 +1,5 @@
 from .csv import CSVConverter
+from .html import HTMLConverter
 from .llm_text_extractor import LLMImageConverter, LLMPDFConverter
 from .pptx import PPTXFileConverter
 from .pypdf import PyPDFConverter

--- a/dynamiq/nodes/converters/html.py
+++ b/dynamiq/nodes/converters/html.py
@@ -1,0 +1,107 @@
+from io import BytesIO
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from dynamiq.components.converters.html import HTMLConverter as HTMLConverterComponent
+from dynamiq.connections.managers import ConnectionManager
+from dynamiq.nodes.node import Node, NodeGroup, ensure_config
+from dynamiq.runnables import RunnableConfig
+from dynamiq.types import DocumentCreationMode
+from dynamiq.utils.logger import logger
+
+
+class HTMLConverterInputSchema(BaseModel):
+    file_paths: list[str] = Field(default=None, description="Parameter to provide path to files.")
+    files: list[BytesIO] = Field(default=None, description="Parameter to provide files.")
+    metadata: dict | list = Field(default=None, description="Parameter to provide metadata.")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @model_validator(mode="after")
+    def validate_file_source(self):
+        """Validate that either `file_paths` or `files` is specified"""
+        if not self.file_paths and not self.files:
+            raise ValueError("Either `file_paths` or `files` must be provided.")
+        return self
+
+
+class HTMLConverter(Node):
+    """
+    A component for converting HTML files to Documents using the HTML converter.
+
+    Args:
+        document_creation_mode (Literal["one-doc-per-file"], optional):
+            Determines how to create Documents from the HTML content. Currently only supports:
+            - "one-doc-per-file": Creates one Document per file.
+                All content is converted to markdown format.
+            Defaults to "one-doc-per-file".
+    """
+
+    group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
+    name: str = "HTML File Converter"
+    document_creation_mode: DocumentCreationMode = DocumentCreationMode.ONE_DOC_PER_FILE
+    file_converter: HTMLConverterComponent | None = None
+    input_schema: ClassVar[type[HTMLConverterInputSchema]] = HTMLConverterInputSchema
+
+    @property
+    def to_dict_exclude_params(self):
+        return super().to_dict_exclude_params | {"file_converter": True}
+
+    def init_components(self, connection_manager: ConnectionManager | None = None):
+        """
+        Initialize the components of the HTMLConverter.
+
+        Args:
+            connection_manager (ConnectionManager, optional): The connection manager to use.
+                Defaults to a new ConnectionManager instance.
+        """
+        connection_manager = connection_manager or ConnectionManager()
+        super().init_components(connection_manager)
+        if self.file_converter is None:
+            self.file_converter = HTMLConverterComponent(
+                document_creation_mode=self.document_creation_mode,
+            )
+
+    def execute(
+        self, input_data: HTMLConverterInputSchema, config: RunnableConfig | None = None, **kwargs
+    ) -> dict[str, list[Any]]:
+        """
+        Execute the HTMLConverter to convert files to Documents.
+
+        Args:
+            input_data (HTMLConverterInputSchema): An instance containing 'file_paths', 'files', and/or 'metadata'.
+            config (RunnableConfig): Optional configuration for the execution.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            Dict with 'documents' key containing a list of converted Documents.
+
+        Raises:
+            KeyError: If required keys are missing in input_data.
+
+        Example:
+            input_data = {
+                "file_paths": ["/path/to/file1.html"],
+                "files": [BytesIO(b"file content")],
+                "metadata": {"source": "user_upload"}
+            }
+        """
+        config = ensure_config(config)
+        self.run_on_node_execute_run(config.callbacks, **kwargs)
+
+        file_paths = input_data.file_paths
+        files = input_data.files
+        metadata = input_data.metadata
+
+        output = self.file_converter.run(file_paths=file_paths, files=files, metadata=metadata)
+        documents = output["documents"]
+
+        count_file_paths = len(file_paths) if file_paths else 0
+        count_files = len(files) if files else 0
+
+        logger.debug(
+            f"Converted {count_file_paths} file paths and {count_files} file objects " f"to {len(documents)} Documents."
+        )
+
+        return {"documents": documents}

--- a/dynamiq/nodes/converters/html.py
+++ b/dynamiq/nodes/converters/html.py
@@ -7,7 +7,6 @@ from dynamiq.components.converters.html import HTMLConverter as HTMLConverterCom
 from dynamiq.connections.managers import ConnectionManager
 from dynamiq.nodes.node import Node, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
-from dynamiq.types import DocumentCreationMode
 from dynamiq.utils.logger import logger
 
 
@@ -29,18 +28,10 @@ class HTMLConverterInputSchema(BaseModel):
 class HTMLConverter(Node):
     """
     A component for converting HTML files to Documents using the HTML converter.
-
-    Args:
-        document_creation_mode (Literal["one-doc-per-file"], optional):
-            Determines how to create Documents from the HTML content. Currently only supports:
-            - "one-doc-per-file": Creates one Document per file.
-                All content is converted to markdown format.
-            Defaults to "one-doc-per-file".
     """
 
     group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
     name: str = "HTML File Converter"
-    document_creation_mode: DocumentCreationMode = DocumentCreationMode.ONE_DOC_PER_FILE
     file_converter: HTMLConverterComponent | None = None
     input_schema: ClassVar[type[HTMLConverterInputSchema]] = HTMLConverterInputSchema
 
@@ -59,9 +50,7 @@ class HTMLConverter(Node):
         connection_manager = connection_manager or ConnectionManager()
         super().init_components(connection_manager)
         if self.file_converter is None:
-            self.file_converter = HTMLConverterComponent(
-                document_creation_mode=self.document_creation_mode,
-            )
+            self.file_converter = HTMLConverterComponent()
 
     def execute(
         self, input_data: HTMLConverterInputSchema, config: RunnableConfig | None = None, **kwargs

--- a/examples/converters/html_converter.py
+++ b/examples/converters/html_converter.py
@@ -1,0 +1,63 @@
+import logging
+from io import BytesIO
+
+from dynamiq import Workflow
+from dynamiq.components.converters.unstructured import DocumentCreationMode
+from dynamiq.connections.managers import ConnectionManager
+from dynamiq.flows import Flow
+from dynamiq.nodes.converters import HTMLConverter
+from dynamiq.nodes.embedders import MistralDocumentEmbedder
+from dynamiq.nodes.node import InputTransformer, NodeDependency
+
+# Please use your own HTML file path
+HTML_FILE_PATH = "example.html"
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    cm = ConnectionManager()
+
+    # Create the HTML converter node
+    html_converter_node = HTMLConverter(document_creation_mode=DocumentCreationMode.ONE_DOC_PER_FILE)
+
+    # Create the embedder node that depends on the converter
+    mistral_text_embedder_node = MistralDocumentEmbedder(
+        name="MistralDocumentEmbedder",
+        depends=[
+            NodeDependency(html_converter_node),
+        ],
+        input_transformer=InputTransformer(
+            selector={
+                "documents": f"${[html_converter_node.id]}.output.documents",
+            },
+        ),
+    )
+
+    # Create the workflow with both nodes
+    wf = Workflow(
+        id="wf",
+        flow=Flow(
+            id="wf",
+            nodes=[html_converter_node, mistral_text_embedder_node],
+            connection_manager=cm,
+        ),
+    )
+
+    # Read and process the HTML file
+    with open(HTML_FILE_PATH, "rb") as upload_file:
+        file = BytesIO(upload_file.read())
+        file.name = upload_file.name
+
+    # Run the workflow
+    output = wf.run(
+        input_data={
+            "files": [file],
+        }
+    )
+    logger.info(f"Workflow result:{output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/converters/html_converter.py
+++ b/examples/converters/html_converter.py
@@ -30,7 +30,7 @@ def main():
         ],
         input_transformer=InputTransformer(
             selector={
-                "documents": f"${[html_converter_node.id]}.output.documents",
+                "documents": f"${html_converter_node.id}.output.documents",
             },
         ),
     )

--- a/examples/rag/dag_html_pinecone.yaml
+++ b/examples/rag/dag_html_pinecone.yaml
@@ -1,0 +1,163 @@
+connections:
+  openai-conn:  # id
+    type: dynamiq.connections.OpenAI
+    api_key: ${oc.env:OPENAI_API_KEY}
+
+  pinecone-conn:  # id
+    type: dynamiq.connections.Pinecone
+    api_key: ${oc.env:PINECONE_API_KEY}
+
+prompt_template: |
+  Please answer the following question based on the information found
+  within the sections enclosed by triplet quotes (\`\`\`).
+  Your response should be concise, well-written, and follow markdown formatting guidelines:
+
+  - Use bullet points for list items.
+  - Use **bold** text for emphasis where necessary.
+
+  **Question:** {{query}}
+
+  Thank you for your detailed attention to the request
+  **Context information**:
+  ```
+  {% for document in documents %}
+      ---
+      Document title: {{ document.metadata["title"] }}
+      Document information: {{ document.content }}
+      ---
+  {% endfor %}
+  ```
+
+  **User Question:** {{query}}
+  Answer:
+
+prompts:
+  openai-ai-prompt:
+    messages:
+      - role: user
+        content: ${prompt_template}
+
+
+nodes:
+  html-file-converter-1:
+    type: dynamiq.nodes.converters.HTMLConverter
+    name: HTML File Converter
+    document_creation_mode: one-doc-per-file
+
+  document-splitter-1:
+    type: dynamiq.nodes.splitters.DocumentSplitter
+    name: Document Splitter
+    split_by: passage
+    depends:
+      - node: html-file-converter-1
+    input_transformer:
+      path: null
+      selector:
+        "documents": "$.html-file-converter-1.output.documents"
+
+  document-embedder-node-1:
+    type: dynamiq.nodes.embedders.OpenAIDocumentEmbedder
+    name: OpenAI Document Embedder
+    connection: openai-conn
+    depends:
+      - node: document-splitter-1
+    input_transformer:
+      path: null
+      selector:
+        "documents": "$.document-splitter-1.output.documents"
+
+  document-writer-node-1:
+    type: dynamiq.nodes.writers.PineconeDocumentWriter
+    name: Pinecone Document Writer
+    connection: pinecone-conn
+    index_name: default
+    batch_size: 125
+    dimension: 1536
+    metric: cosine
+    index_type: serverless
+    cloud: ${oc.env:PINECONE_CLOUD}
+    region: ${oc.env:PINECONE_REGION}
+    pods: 1
+    depends:
+      - node: document-embedder-node-1
+    input_transformer:
+      path: null
+      selector:
+        "documents": "$.document-embedder-node-1.output.documents"
+
+
+  openai-text-embedder-1:
+    type: dynamiq.nodes.embedders.OpenAITextEmbedder
+    name: OpenAI Text Embedder
+    connection: openai-conn
+    model: text-embedding-3-small
+
+  document-retriever-node-1:
+    type: dynamiq.nodes.retrievers.PineconeDocumentRetriever
+    name: Pinecone Document Retriever
+    connection: pinecone-conn
+    index_name: default
+    depends:
+      - node: openai-text-embedder-1
+    input_transformer:
+      path: null
+      selector:
+        "embedding": "$.openai-text-embedder-1.output.embedding"
+    output_transformer:
+      path: null
+      selector:
+        "documents": "$.documents"
+
+  openai-1:  # id
+    type: dynamiq.nodes.llms.OpenAI
+    name: OpenAI-1
+    model: gpt-3.5-turbo
+    connection: openai-conn
+    prompt: openai-ai-prompt
+    error_handling:
+      timeout_seconds: 60
+      retry_interval_seconds: 1
+      max_retries: 0
+      backoff_rate: 1
+    depends:
+      - node: document-retriever-node-1
+    input_transformer:
+      path: null
+      selector:
+        "query": "$.query"
+        "documents": "$.document-retriever-node-1.output.documents"
+    output_transformer:
+      path: null
+      selector:
+        "answer": "$.content"
+    caching:
+      enabled: false
+    streaming:
+      enabled: false
+
+
+flows:
+  indexing-flow:  # id
+    name: RAG Document Indexing Flow with HTML
+    nodes:
+      - html-file-converter-1
+      - document-splitter-1
+      - document-embedder-node-1
+      - document-writer-node-1
+
+
+  retrieval-flow:  # id
+    name: RAG Document Retrieval Flow
+    nodes:
+      - openai-text-embedder-1
+      - document-retriever-node-1
+      - openai-1
+
+
+# Could specify multiple workflows in single yaml
+workflows:
+  indexing-workflow:  # id
+    flow: indexing-flow
+
+  retrieval-workflow:  # id
+    flow: retrieval-flow

--- a/examples/rag/dag_yaml.py
+++ b/examples/rag/dag_yaml.py
@@ -65,6 +65,7 @@ if __name__ == "__main__":
     data_folder_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
     with get_connection_manager() as cm:
         for yaml_file_name in (
+            "dag_html_pinecone.yaml",
             "dag_qdrant.yaml",
             "dag_chroma.yaml",
             "dag_pinecone.yaml",

--- a/tests/integration/nodes/converters/test_html.py
+++ b/tests/integration/nodes/converters/test_html.py
@@ -1,0 +1,135 @@
+from io import BytesIO
+
+from dynamiq import Workflow
+from dynamiq.flows import Flow
+from dynamiq.nodes.converters.html import HTMLConverter
+from dynamiq.runnables import RunnableStatus
+
+
+def test_workflow_with_html_converter():
+    wf_html = Workflow(
+        flow=Flow(nodes=[HTMLConverter()]),
+    )
+
+    # Create a simple HTML file content
+    html_content = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Test HTML Document</title>
+    </head>
+    <body>
+        <h1>Hello, World!</h1>
+        <p>This is a test paragraph for the HTML converter.</p>
+        <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+            <li>Item 3</li>
+        </ul>
+    </body>
+    </html>
+    """
+
+    file = BytesIO(html_content.encode("utf-8"))
+    file.name = "test.html"
+
+    input_data = {"files": [file]}
+    response = wf_html.run(input_data=input_data)
+
+    # Verify the response status
+    assert response.status == RunnableStatus.SUCCESS
+
+    # Verify that documents were created
+    node_id = wf_html.flow.nodes[0].id
+    assert "documents" in response.output[node_id]["output"]
+    assert len(response.output[node_id]["output"]["documents"]) == 1
+
+    # Get the actual document content
+    document = response.output[node_id]["output"]["documents"][0]
+
+    # Check for expected elements in the content
+    assert "Hello, World!" in document["content"]
+    assert "This is a test paragraph for the HTML converter" in document["content"]
+    assert "Item 1" in document["content"]
+    assert "Item 2" in document["content"]
+    assert "Item 3" in document["content"]
+    assert document["metadata"]["file_path"] == "test.html"
+
+
+def test_html_converter_with_complex_content():
+    wf_html = Workflow(
+        flow=Flow(nodes=[HTMLConverter()]),
+    )
+
+    # Create a more complex HTML file with various elements
+    html_content = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Complex HTML Document</title>
+    </head>
+    <body>
+        <h1>Complex HTML Test</h1>
+        <p>This is a <strong>bold text</strong> and <em>italic text</em> in a paragraph.</p>
+
+        <h2>Code Example</h2>
+        <pre><code>def hello_world():
+    print("Hello, World!")
+        </code></pre>
+
+        <h2>Table Example</h2>
+        <table>
+            <tr>
+                <th>Header 1</th>
+                <th>Header 2</th>
+            </tr>
+            <tr>
+                <td>Cell 1</td>
+                <td>Cell 2</td>
+            </tr>
+            <tr>
+                <td>Cell 3</td>
+                <td>Cell 4</td>
+            </tr>
+        </table>
+
+        <h2>Link Example</h2>
+        <p>Visit <a href="https://example.com">Example Website</a> for more information.</p>
+
+        <blockquote>
+            This is a blockquote with some text.
+        </blockquote>
+    </body>
+    </html>
+    """
+
+    file = BytesIO(html_content.encode("utf-8"))
+    file.name = "complex.html"
+
+    input_data = {"files": [file]}
+    response = wf_html.run(input_data=input_data)
+
+    # Verify the response status
+    assert response.status == RunnableStatus.SUCCESS
+
+    # Verify that documents were created
+    node_id = wf_html.flow.nodes[0].id
+    assert "documents" in response.output[node_id]["output"]
+    assert len(response.output[node_id]["output"]["documents"]) == 1
+
+    # Verify document content contains expected markdown elements
+    document = response.output[node_id]["output"]["documents"][0]
+    content = document["content"]
+
+    # Check for various markdown elements in the content
+    assert "Complex HTML Test" in content
+    assert "bold text" in content
+    assert "italic text" in content
+    assert "Code Example" in content
+    assert "def hello_world()" in content
+    assert "Table Example" in content
+    assert "Header 1" in content
+    assert "Header 2" in content
+    assert "Example Website" in content
+    assert "https://example.com" in content
+    assert "blockquote" in content

--- a/tests/integration_with_creds/test_rag_yaml.py
+++ b/tests/integration_with_creds/test_rag_yaml.py
@@ -18,7 +18,7 @@ def rag_data_path():
     return os.path.join(os.path.dirname(ROOT_PATH), "examples", "data")
 
 
-@pytest.mark.parametrize("rag_yaml_file_name", ["dag_pinecone.yaml"])
+@pytest.mark.parametrize("rag_yaml_file_name", ["dag_html_pinecone.yaml"])
 def test_indexing_flow(rag_examples_folder, rag_data_path, rag_yaml_file_name):
     with get_connection_manager() as cm:
         result, dumped_tracing = indexing_flow(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds an HTML converter node to convert HTML files to markdown documents, integrates it into workflows, and provides examples and tests.
> 
>   - **HTML Converter Implementation**:
>     - Adds `HTMLConverter` class in `dynamiq/components/converters/html.py` to convert HTML files to markdown documents.
>     - Implements `MarkdownConverter` class for HTML to markdown conversion.
>   - **Node Integration**:
>     - Adds `HTMLConverter` to `dynamiq/nodes/converters/__init__.py`.
>     - Implements `HTMLConverter` node in `dynamiq/nodes/converters/html.py` with input validation and execution logic.
>   - **Examples and Workflows**:
>     - Adds example usage in `examples/converters/html_converter.py`.
>     - Introduces `dag_html_pinecone.yaml` for RAG workflows using the HTML converter.
>   - **Testing**:
>     - Adds integration tests in `tests/integration/nodes/converters/test_html.py` for HTML conversion.
>     - Updates `tests/integration_with_creds/test_rag_yaml.py` to include `dag_html_pinecone.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 7115a4e441dd8535e1e2c8fa4a55037ebe559f94. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->