### PR TITLE
fix: yaml load inline prompt from nested nodes

### DIFF
--- a/dynamiq/serializers/loaders/yaml.py
+++ b/dynamiq/serializers/loaders/yaml.py
@@ -349,7 +349,9 @@ class WorkflowYAMLLoader:
             elif isinstance(param_data, dict):
                 updated_param_data = {}
                 for param_name_inner, param_data_inner in param_data.items():
-                    if isinstance(param_data_inner, (dict, list)):
+                    if param_name_inner == "prompt":
+                        updated_param_data[param_name_inner] = param_data_inner
+                    elif isinstance(param_data_inner, (dict, list)):
                         param_id = None
                         updated_param_data[param_name_inner] = cls.get_updated_node_init_data_with_initialized_nodes(
                             {param_id: param_data_inner}, **kwargs


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes handling of 'prompt' data in nested nodes in `get_updated_node_init_data_with_initialized_nodes()` in `yaml.py`.
> 
>   - **Behavior**:
>     - Fixes handling of 'prompt' data in nested nodes in `get_updated_node_init_data_with_initialized_nodes()` in `yaml.py`.
>     - Ensures 'prompt' data is not processed recursively, preventing potential errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 63c09cecdc7febe8089921f43b7c2efb1c44a7e7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->