### PR TITLE
feat: unify delete file method

### DIFF
--- a/dynamiq/storages/vector/elasticsearch/elasticsearch.py
+++ b/dynamiq/storages/vector/elasticsearch/elasticsearch.py
@@ -411,9 +411,10 @@ class ElasticsearchVectorStore:
 
         self.client.delete_by_query(index=self.index_name, query=bool_query, refresh=True)
 
-    def delete_document_by_file_id(self, file_id: str):
+    def delete_documents_by_file_id(self, file_id: str) -> None:
         """
-        Delete documents from the Pinecone vector store by file ID.
+        Delete documents from the vector store based on the provided file ID.
+            file_id should be located in the metadata of the document.
 
         Args:
             file_id (str): The file ID to filter by.

--- a/dynamiq/storages/vector/pinecone/pinecone.py
+++ b/dynamiq/storages/vector/pinecone/pinecone.py
@@ -247,9 +247,9 @@ class PineconeVectorStore:
             filters = _normalize_filters(filters)
             self._index.delete(filter=filters, namespace=self.namespace)
 
-    def delete_documents_by_file_id(self, file_id: str):
+    def delete_documents_by_file_id(self, file_id: str) -> None:
         """
-        Delete documents from the Pinecone vector store by file ID.
+        Delete documents from the vector store based on the provided file ID.
             file_id should be located in the metadata of the document.
 
         Args:

--- a/tests/unit/storages/vector/elasticsearch/test_elasticsearch.py
+++ b/tests/unit/storages/vector/elasticsearch/test_elasticsearch.py
@@ -99,7 +99,7 @@ def test_delete_documents_by_file_id(es_vector_store, mock_es_client, mock_es_fi
     with patch(
         "dynamiq.storages.vector.elasticsearch.elasticsearch.create_file_id_filter", return_value=mock_es_filters
     ):
-        es_vector_store.delete_document_by_file_id(file_id)
+        es_vector_store.delete_documents_by_file_id(file_id)
     norm_filters = {"must": [{"match": {"company": "BMW"}}, {"range": {"year": {"gt": 2010}}}]}
 
     mock_es_client.delete_by_query.assert_called_once_with(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Unify `delete_documents_by_file_id` method across vector storage implementations to use `create_file_id_filter` for consistent metadata-based filtering.
> 
>   - **Behavior**:
>     - Unify `delete_documents_by_file_id` method in `elasticsearch.py`, `pgvector.py`, and `pinecone.py` to use `create_file_id_filter` for filtering by file ID in metadata.
>   - **Refactoring**:
>     - Rename `delete_document_by_file_id` to `delete_documents_by_file_id` in `elasticsearch.py` and `pinecone.py`.
>   - **Testing**:
>     - Update `test_delete_documents_by_file_id` in `test_elasticsearch.py` to reflect method name change and ensure correct filter application.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 3ff5fd4062496e238e33e6717007ce112c55fde3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->