### PR TITLE
feat: integrate Milvus hybrid search

### DIFF
--- a/dynamiq/nodes/retrievers/milvus.py
+++ b/dynamiq/nodes/retrievers/milvus.py
@@ -95,13 +95,19 @@ class MilvusDocumentRetriever(Retriever, MilvusVectorStoreParams):
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query_embedding = input_data.embedding
+        query = input_data.query
         content_key = input_data.content_key
         embedding_key = input_data.embedding_key
         filters = input_data.filters or self.filters
         top_k = input_data.top_k or self.top_k
 
         output = self.document_retriever.run(
-            query_embedding, filters=filters, top_k=top_k, content_key=content_key, embedding_key=embedding_key
+            query_embedding,
+            query=query,
+            filters=filters,
+            top_k=top_k,
+            content_key=content_key,
+            embedding_key=embedding_key,
         )
 
         return {

--- a/dynamiq/storages/vector/milvus/milvus.py
+++ b/dynamiq/storages/vector/milvus/milvus.py
@@ -210,14 +210,14 @@ class MilvusVectorStore:
 
         return self._get_result_to_documents(result, content_key=content_key, embedding_key=embedding_key)
 
-    def search_embeddings(
+    def _embedding_retrieval(
         self,
         query_embeddings: list[list[float]],
         top_k: int,
         filters: dict[str, Any] | None = None,
         content_key: str | None = None,
         embedding_key: str | None = None,
-        return_embedding: bool = False,
+        return_embeddings: bool = False,
     ) -> list[Document]:
         """
         Perform vector search on the stored documents using query embeddings.
@@ -228,7 +228,7 @@ class MilvusVectorStore:
             filters (dict[str, Any] | None): A dictionary of filters to apply to the search. Defaults to None.
             content_key (Optional[str]): The field used to store content in the storage.
             embedding_key (Optional[str]): The field used to store vector in the storage.
-            return_embedding (bool): Whether to return the embeddings of the retrieved documents.
+            return_embeddings (bool): Whether to return the embeddings of the retrieved documents.
 
         Returns:
             List[Document]: A list of Document objects containing the retrieved documents.
@@ -248,7 +248,7 @@ class MilvusVectorStore:
         )
 
         return self._convert_query_result_to_documents(
-            results[0], content_key=content_key, embedding_key=embedding_key, return_embedding=return_embedding
+            results[0], content_key=content_key, embedding_key=embedding_key, return_embeddings=return_embeddings
         )
 
     def _convert_query_result_to_documents(
@@ -256,7 +256,7 @@ class MilvusVectorStore:
         result: list[dict[str, Any]],
         content_key: str | None = None,
         embedding_key: str | None = None,
-        return_embedding: bool = False,
+        return_embeddings: bool = False,
     ) -> list[Document]:
         """
         Convert Milvus search results to Document objects.
@@ -265,7 +265,7 @@ class MilvusVectorStore:
             result (List[Dict[str, Any]]): The result from a Milvus search operation.
             content_key (Optional[str]): The field used to store content in the storage.
             embedding_key (Optional[str]): The field used to store vector in the storage.
-            return_embedding (bool): Whether to return the embeddings of the retrieved documents.
+            return_embeddings (bool): Whether to return the embeddings of the retrieved documents.
 
         Returns:
             List[Document]: A list of Document instances created from the Milvus search result.
@@ -285,7 +285,7 @@ class MilvusVectorStore:
                 metadata=metadata,
                 score=hit.get("distance", None),
             )
-            if return_embedding:
+            if return_embeddings:
                 doc.embedding = embedding
 
             documents.append(doc)
@@ -356,7 +356,7 @@ class MilvusVectorStore:
 
         return documents
 
-    def search_hybrid(
+    def _hybrid_retrieval(
         self,
         query: str,
         query_embeddings: list[list[float]],
@@ -365,7 +365,7 @@ class MilvusVectorStore:
         top_k_sparse: int | None = None,
         content_key: str | None = None,
         embedding_key: str | None = None,
-        return_embedding: bool = False,
+        return_embeddings: bool = False,
         drop_ratio_build: float = 0.0,
     ) -> list[Document]:
         """
@@ -381,7 +381,7 @@ class MilvusVectorStore:
                 If None, defaults to `top_k`.
             content_key (Optional[str]): The field used to store content in the storage.
             embedding_key (Optional[str]): The field used to store vector in the storage.
-            return_embedding (bool): Whether to return the embeddings of the retrieved documents.
+            return_embeddings (bool): Whether to return the embeddings of the retrieved documents.
             drop_ratio_build (float): The ratio of small vector values to be dropped during indexing during text search.
 
         Returns:
@@ -416,5 +416,5 @@ class MilvusVectorStore:
         )
 
         return self._convert_query_result_to_documents(
-            results[0], content_key=content_key, embedding_key=embedding_key, return_embedding=return_embedding
+            results[0], content_key=content_key, embedding_key=embedding_key, return_embeddings=return_embeddings
         )

--- a/dynamiq/storages/vector/milvus/milvus.py
+++ b/dynamiq/storages/vector/milvus/milvus.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Optional
 
-from pymilvus import DataType
+from pymilvus import AnnSearchRequest, DataType, Function, FunctionType, RRFRanker
 
 from dynamiq.connections import Milvus
 from dynamiq.storages.vector.base import BaseWriterVectorStoreParams
@@ -48,19 +48,28 @@ class MilvusVectorStore:
         self.embedding_key = embedding_key
         self.dimension = dimension
         self.create_if_not_exist = create_if_not_exist
-        self.schema = self.client.create_schema(
-            auto_id=False,
-            enable_dynamic_field=True,
-        )
+        self.schema = self.client.create_schema(auto_id=False, enable_dynamic_field=True)
         self.schema.add_field(field_name="id", datatype=DataType.VARCHAR, is_primary=True, max_length=65_535)
-        self.schema.add_field(field_name=self.content_key, datatype=DataType.VARCHAR, max_length=65_535)
+        self.schema.add_field(
+            field_name=self.content_key, datatype=DataType.VARCHAR, max_length=65_535, enable_analyzer=True
+        )
         self.schema.add_field(field_name=self.embedding_key, datatype=DataType.FLOAT_VECTOR, dim=self.dimension)
+        self.schema.add_field(field_name="sparse", datatype=DataType.SPARSE_FLOAT_VECTOR)
+
+        bm25_function = Function(
+            name="text_bm25_emb",
+            input_field_names=[self.content_key],
+            output_field_names=["sparse"],
+            function_type=FunctionType.BM25,
+        )
+        self.schema.add_function(bm25_function)
 
         self.index_params = self.client.prepare_index_params()
         self.index_params.add_index(field_name="id")
         self.index_params.add_index(
             field_name=self.embedding_key, index_type=self.index_type, metric_type=self.metric_type
         )
+        self.index_params.add_index(field_name="sparse", index_type="SPARSE_INVERTED_INDEX", metric_type="BM25")
 
         if not self.client.has_collection(self.index_name):
             if self.create_if_not_exist:
@@ -208,6 +217,7 @@ class MilvusVectorStore:
         filters: dict[str, Any] | None = None,
         content_key: str | None = None,
         embedding_key: str | None = None,
+        return_embedding: bool = False,
     ) -> list[Document]:
         """
         Perform vector search on the stored documents using query embeddings.
@@ -218,6 +228,7 @@ class MilvusVectorStore:
             filters (dict[str, Any] | None): A dictionary of filters to apply to the search. Defaults to None.
             content_key (Optional[str]): The field used to store content in the storage.
             embedding_key (Optional[str]): The field used to store vector in the storage.
+            return_embedding (bool): Whether to return the embeddings of the retrieved documents.
 
         Returns:
             List[Document]: A list of Document objects containing the retrieved documents.
@@ -232,14 +243,20 @@ class MilvusVectorStore:
             limit=top_k,
             filter=filter_expression,
             output_fields=["*"],
+            anns_field=embedding_key or self.embedding_key,
             search_params=search_params,
         )
 
-        return self._convert_query_result_to_documents(results[0], content_key=content_key, embedding_key=embedding_key)
+        return self._convert_query_result_to_documents(
+            results[0], content_key=content_key, embedding_key=embedding_key, return_embedding=return_embedding
+        )
 
-    # @staticmethod
     def _convert_query_result_to_documents(
-        self, result: list[dict[str, Any]], content_key: str | None = None, embedding_key: str | None = None
+        self,
+        result: list[dict[str, Any]],
+        content_key: str | None = None,
+        embedding_key: str | None = None,
+        return_embedding: bool = False,
     ) -> list[Document]:
         """
         Convert Milvus search results to Document objects.
@@ -248,6 +265,7 @@ class MilvusVectorStore:
             result (List[Dict[str, Any]]): The result from a Milvus search operation.
             content_key (Optional[str]): The field used to store content in the storage.
             embedding_key (Optional[str]): The field used to store vector in the storage.
+            return_embedding (bool): Whether to return the embeddings of the retrieved documents.
 
         Returns:
             List[Document]: A list of Document instances created from the Milvus search result.
@@ -265,9 +283,11 @@ class MilvusVectorStore:
                 id=str(hit.get("id", "")),
                 content=content,
                 metadata=metadata,
-                embedding=embedding,
                 score=hit.get("distance", None),
             )
+            if return_embedding:
+                doc.embedding = embedding
+
             documents.append(doc)
 
         return documents
@@ -301,7 +321,6 @@ class MilvusVectorStore:
         )
         return self._get_result_to_documents(result, content_key=content_key, embedding_key=embedding_key)
 
-    # @staticmethod
     def _get_result_to_documents(
         self, result: list[dict[str, Any]], content_key: str | None = None, embedding_key: str | None = None
     ) -> list[Document]:
@@ -336,3 +355,66 @@ class MilvusVectorStore:
                 logger.error(f"Error creating Document: {e}, data: {document_dict}")
 
         return documents
+
+    def search_hybrid(
+        self,
+        query: str,
+        query_embeddings: list[list[float]],
+        top_k: int,
+        top_k_dense: int | None = None,
+        top_k_sparse: int | None = None,
+        content_key: str | None = None,
+        embedding_key: str | None = None,
+        return_embedding: bool = False,
+        drop_ratio_build: float = 0.0,
+    ) -> list[Document]:
+        """
+        Perform a hybrid search using both dense (vector-based) and sparse (text-based) retrieval techniques.
+
+        Args:
+            query (str): The textual query used for sparse search (BM25).
+            query_embeddings (list[list[float]]): A list of embeddings representing the query for dense search.
+            top_k (int): The maximum number of documents to retrieve with hybrid search.
+            top_k_dense (int | None, optional): The number of top results to retrieve from the dense search.
+                If None, defaults to `top_k`.
+            top_k_sparse (int | None, optional): The number of top results to retrieve from the sparse search.
+                If None, defaults to `top_k`.
+            content_key (Optional[str]): The field used to store content in the storage.
+            embedding_key (Optional[str]): The field used to store vector in the storage.
+            return_embedding (bool): Whether to return the embeddings of the retrieved documents.
+            drop_ratio_build (float): The ratio of small vector values to be dropped during indexing during text search.
+
+        Returns:
+            List[Document]: A list of Document objects containing the retrieved documents.
+        """
+
+        search_param_1 = {
+            "data": query_embeddings,
+            "anns_field": embedding_key or self.embedding_key,
+            "param": {
+                "metric_type": self.metric_type,
+            },
+            "limit": top_k_dense or top_k,
+        }
+        request_1 = AnnSearchRequest(**search_param_1)
+
+        search_param_2 = {
+            "data": [query],
+            "anns_field": "sparse",
+            "param": {"metric_type": "BM25", "params": {"drop_ratio_build": drop_ratio_build}},
+            "limit": top_k_sparse or top_k,
+        }
+        request_2 = AnnSearchRequest(**search_param_2)
+
+        ranker = RRFRanker()
+        results = self.client.hybrid_search(
+            collection_name=self.index_name,
+            output_fields=["*"],
+            reqs=[request_1, request_2],
+            ranker=ranker,
+            limit=top_k,
+        )
+
+        return self._convert_query_result_to_documents(
+            results[0], content_key=content_key, embedding_key=embedding_key, return_embedding=return_embedding
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -528,6 +528,10 @@ files = [
     {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a37b8f0391212d29b3a91a799c8e4a2855e0576911cdfb2515487e30e322253d"},
     {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:e84799f09591700a4154154cab9787452925578841a94321d5ee8fb9a9a328f0"},
     {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f66b5337fa213f1da0d9000bc8dc0cb5b896b726eefd9c6046f699b169c41b9e"},
+    {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5dab0844f2cf82be357a0eb11a9087f70c5430b2c241493fc122bb6f2bb0917c"},
+    {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e4fe605b917c70283db7dfe5ada75e04561479075761a0b3866c081d035b01c1"},
+    {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:1e9a65b5736232e7a7f91ff3d02277f11d339bf34099a56cdab6a8b3410a02b2"},
+    {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:58d4b711689366d4a03ac7957ab8c28890415e267f9b6589969e74b6e42225ec"},
     {file = "Brotli-1.1.0-cp310-cp310-win32.whl", hash = "sha256:be36e3d172dc816333f33520154d708a2657ea63762ec16b62ece02ab5e4daf2"},
     {file = "Brotli-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:0c6244521dda65ea562d5a69b9a26120769b7a9fb3db2fe9545935ed6735b128"},
     {file = "Brotli-1.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a3daabb76a78f829cafc365531c972016e4aa8d5b4bf60660ad8ecee19df7ccc"},
@@ -540,8 +544,14 @@ files = [
     {file = "Brotli-1.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:19c116e796420b0cee3da1ccec3b764ed2952ccfcc298b55a10e5610ad7885f9"},
     {file = "Brotli-1.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:510b5b1bfbe20e1a7b3baf5fed9e9451873559a976c1a78eebaa3b86c57b4265"},
     {file = "Brotli-1.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a1fd8a29719ccce974d523580987b7f8229aeace506952fa9ce1d53a033873c8"},
+    {file = "Brotli-1.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c247dd99d39e0338a604f8c2b3bc7061d5c2e9e2ac7ba9cc1be5a69cb6cd832f"},
+    {file = "Brotli-1.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1b2c248cd517c222d89e74669a4adfa5577e06ab68771a529060cf5a156e9757"},
+    {file = "Brotli-1.1.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:2a24c50840d89ded6c9a8fdc7b6ed3692ed4e86f1c4a4a938e1e92def92933e0"},
+    {file = "Brotli-1.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f31859074d57b4639318523d6ffdca586ace54271a73ad23ad021acd807eb14b"},
     {file = "Brotli-1.1.0-cp311-cp311-win32.whl", hash = "sha256:39da8adedf6942d76dc3e46653e52df937a3c4d6d18fdc94a7c29d263b1f5b50"},
     {file = "Brotli-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:aac0411d20e345dc0920bdec5548e438e999ff68d77564d5e9463a7ca9d3e7b1"},
+    {file = "Brotli-1.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:32d95b80260d79926f5fab3c41701dbb818fde1c9da590e77e571eefd14abe28"},
+    {file = "Brotli-1.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b760c65308ff1e462f65d69c12e4ae085cff3b332d894637f6273a12a482d09f"},
     {file = "Brotli-1.1.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:316cc9b17edf613ac76b1f1f305d2a748f1b976b033b049a6ecdfd5612c70409"},
     {file = "Brotli-1.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:caf9ee9a5775f3111642d33b86237b05808dafcd6268faa492250e9b78046eb2"},
     {file = "Brotli-1.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70051525001750221daa10907c77830bc889cb6d865cc0b813d9db7fefc21451"},
@@ -552,8 +562,24 @@ files = [
     {file = "Brotli-1.1.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:4093c631e96fdd49e0377a9c167bfd75b6d0bad2ace734c6eb20b348bc3ea180"},
     {file = "Brotli-1.1.0-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:7e4c4629ddad63006efa0ef968c8e4751c5868ff0b1c5c40f76524e894c50248"},
     {file = "Brotli-1.1.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:861bf317735688269936f755fa136a99d1ed526883859f86e41a5d43c61d8966"},
+    {file = "Brotli-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:87a3044c3a35055527ac75e419dfa9f4f3667a1e887ee80360589eb8c90aabb9"},
+    {file = "Brotli-1.1.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c5529b34c1c9d937168297f2c1fde7ebe9ebdd5e121297ff9c043bdb2ae3d6fb"},
+    {file = "Brotli-1.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ca63e1890ede90b2e4454f9a65135a4d387a4585ff8282bb72964fab893f2111"},
+    {file = "Brotli-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e79e6520141d792237c70bcd7a3b122d00f2613769ae0cb61c52e89fd3443839"},
     {file = "Brotli-1.1.0-cp312-cp312-win32.whl", hash = "sha256:5f4d5ea15c9382135076d2fb28dde923352fe02951e66935a9efaac8f10e81b0"},
     {file = "Brotli-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:906bc3a79de8c4ae5b86d3d75a8b77e44404b0f4261714306e3ad248d8ab0951"},
+    {file = "Brotli-1.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8bf32b98b75c13ec7cf774164172683d6e7891088f6316e54425fde1efc276d5"},
+    {file = "Brotli-1.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7bc37c4d6b87fb1017ea28c9508b36bbcb0c3d18b4260fcdf08b200c74a6aee8"},
+    {file = "Brotli-1.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c0ef38c7a7014ffac184db9e04debe495d317cc9c6fb10071f7fefd93100a4f"},
+    {file = "Brotli-1.1.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91d7cc2a76b5567591d12c01f019dd7afce6ba8cba6571187e21e2fc418ae648"},
+    {file = "Brotli-1.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a93dde851926f4f2678e704fadeb39e16c35d8baebd5252c9fd94ce8ce68c4a0"},
+    {file = "Brotli-1.1.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f0db75f47be8b8abc8d9e31bc7aad0547ca26f24a54e6fd10231d623f183d089"},
+    {file = "Brotli-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6967ced6730aed543b8673008b5a391c3b1076d834ca438bbd70635c73775368"},
+    {file = "Brotli-1.1.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7eedaa5d036d9336c95915035fb57422054014ebdeb6f3b42eac809928e40d0c"},
+    {file = "Brotli-1.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d487f5432bf35b60ed625d7e1b448e2dc855422e87469e3f450aa5552b0eb284"},
+    {file = "Brotli-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:832436e59afb93e1836081a20f324cb185836c617659b07b129141a8426973c7"},
+    {file = "Brotli-1.1.0-cp313-cp313-win32.whl", hash = "sha256:43395e90523f9c23a3d5bdf004733246fba087f2948f87ab28015f12359ca6a0"},
+    {file = "Brotli-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:9011560a466d2eb3f5a6e4929cf4a09be405c64154e12df0dd72713f6500e32b"},
     {file = "Brotli-1.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a090ca607cbb6a34b0391776f0cb48062081f5f60ddcce5d11838e67a01928d1"},
     {file = "Brotli-1.1.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2de9d02f5bda03d27ede52e8cfe7b865b066fa49258cbab568720aa5be80a47d"},
     {file = "Brotli-1.1.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2333e30a5e00fe0fe55903c8832e08ee9c3b1382aacf4db26664a16528d51b4b"},
@@ -563,6 +589,10 @@ files = [
     {file = "Brotli-1.1.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:fd5f17ff8f14003595ab414e45fce13d073e0762394f957182e69035c9f3d7c2"},
     {file = "Brotli-1.1.0-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:069a121ac97412d1fe506da790b3e69f52254b9df4eb665cd42460c837193354"},
     {file = "Brotli-1.1.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e93dfc1a1165e385cc8239fab7c036fb2cd8093728cbd85097b284d7b99249a2"},
+    {file = "Brotli-1.1.0-cp36-cp36m-musllinux_1_2_aarch64.whl", hash = "sha256:aea440a510e14e818e67bfc4027880e2fb500c2ccb20ab21c7a7c8b5b4703d75"},
+    {file = "Brotli-1.1.0-cp36-cp36m-musllinux_1_2_i686.whl", hash = "sha256:6974f52a02321b36847cd19d1b8e381bf39939c21efd6ee2fc13a28b0d99348c"},
+    {file = "Brotli-1.1.0-cp36-cp36m-musllinux_1_2_ppc64le.whl", hash = "sha256:a7e53012d2853a07a4a79c00643832161a910674a893d296c9f1259859a289d2"},
+    {file = "Brotli-1.1.0-cp36-cp36m-musllinux_1_2_x86_64.whl", hash = "sha256:d7702622a8b40c49bffb46e1e3ba2e81268d5c04a34f460978c6b5517a34dd52"},
     {file = "Brotli-1.1.0-cp36-cp36m-win32.whl", hash = "sha256:a599669fd7c47233438a56936988a2478685e74854088ef5293802123b5b2460"},
     {file = "Brotli-1.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:d143fd47fad1db3d7c27a1b1d66162e855b5d50a89666af46e1679c496e8e579"},
     {file = "Brotli-1.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:11d00ed0a83fa22d29bc6b64ef636c4552ebafcef57154b4ddd132f5638fbd1c"},
@@ -574,6 +604,10 @@ files = [
     {file = "Brotli-1.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:919e32f147ae93a09fe064d77d5ebf4e35502a8df75c29fb05788528e330fe74"},
     {file = "Brotli-1.1.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:23032ae55523cc7bccb4f6a0bf368cd25ad9bcdcc1990b64a647e7bbcce9cb5b"},
     {file = "Brotli-1.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:224e57f6eac61cc449f498cc5f0e1725ba2071a3d4f48d5d9dffba42db196438"},
+    {file = "Brotli-1.1.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:cb1dac1770878ade83f2ccdf7d25e494f05c9165f5246b46a621cc849341dc01"},
+    {file = "Brotli-1.1.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:3ee8a80d67a4334482d9712b8e83ca6b1d9bc7e351931252ebef5d8f7335a547"},
+    {file = "Brotli-1.1.0-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:5e55da2c8724191e5b557f8e18943b1b4839b8efc3ef60d65985bcf6f587dd38"},
+    {file = "Brotli-1.1.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:d342778ef319e1026af243ed0a07c97acf3bad33b9f29e7ae6a1f68fd083e90c"},
     {file = "Brotli-1.1.0-cp37-cp37m-win32.whl", hash = "sha256:587ca6d3cef6e4e868102672d3bd9dc9698c309ba56d41c2b9c85bbb903cdb95"},
     {file = "Brotli-1.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2954c1c23f81c2eaf0b0717d9380bd348578a94161a65b3a2afc62c86467dd68"},
     {file = "Brotli-1.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:efa8b278894b14d6da122a72fefcebc28445f2d3f880ac59d46c90f4c13be9a3"},
@@ -586,6 +620,10 @@ files = [
     {file = "Brotli-1.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ab4fbee0b2d9098c74f3057b2bc055a8bd92ccf02f65944a241b4349229185a"},
     {file = "Brotli-1.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:141bd4d93984070e097521ed07e2575b46f817d08f9fa42b16b9b5f27b5ac088"},
     {file = "Brotli-1.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fce1473f3ccc4187f75b4690cfc922628aed4d3dd013d047f95a9b3919a86596"},
+    {file = "Brotli-1.1.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d2b35ca2c7f81d173d2fadc2f4f31e88cc5f7a39ae5b6db5513cf3383b0e0ec7"},
+    {file = "Brotli-1.1.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:af6fa6817889314555aede9a919612b23739395ce767fe7fcbea9a80bf140fe5"},
+    {file = "Brotli-1.1.0-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:2feb1d960f760a575dbc5ab3b1c00504b24caaf6986e2dc2b01c09c87866a943"},
+    {file = "Brotli-1.1.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:4410f84b33374409552ac9b6903507cdb31cd30d2501fc5ca13d18f73548444a"},
     {file = "Brotli-1.1.0-cp38-cp38-win32.whl", hash = "sha256:db85ecf4e609a48f4b29055f1e144231b90edc90af7481aa731ba2d059226b1b"},
     {file = "Brotli-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:3d7954194c36e304e1523f55d7042c59dc53ec20dd4e9ea9d151f1b62b4415c0"},
     {file = "Brotli-1.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5fb2ce4b8045c78ebbc7b8f3c15062e435d47e7393cc57c25115cfd49883747a"},
@@ -598,6 +636,10 @@ files = [
     {file = "Brotli-1.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:949f3b7c29912693cee0afcf09acd6ebc04c57af949d9bf77d6101ebb61e388c"},
     {file = "Brotli-1.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:89f4988c7203739d48c6f806f1e87a1d96e0806d44f0fba61dba81392c9e474d"},
     {file = "Brotli-1.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:de6551e370ef19f8de1807d0a9aa2cdfdce2e85ce88b122fe9f6b2b076837e59"},
+    {file = "Brotli-1.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0737ddb3068957cf1b054899b0883830bb1fec522ec76b1098f9b6e0f02d9419"},
+    {file = "Brotli-1.1.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:4f3607b129417e111e30637af1b56f24f7a49e64763253bbc275c75fa887d4b2"},
+    {file = "Brotli-1.1.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:6c6e0c425f22c1c719c42670d561ad682f7bfeeef918edea971a79ac5252437f"},
+    {file = "Brotli-1.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:494994f807ba0b92092a163a0a283961369a65f6cbe01e8891132b7a320e61eb"},
     {file = "Brotli-1.1.0-cp39-cp39-win32.whl", hash = "sha256:f0d8a7a6b5983c2496e364b969f0e526647a06b075d034f3297dc66f3b360c64"},
     {file = "Brotli-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:cdad5b9014d83ca68c25d2e9444e28e967ef16e80f6b436918c700c117a85467"},
     {file = "Brotli-1.1.0.tar.gz", hash = "sha256:81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724"},
@@ -1294,27 +1336,6 @@ elastic-transport = ">=8,<9"
 [package.extras]
 async = ["aiohttp (>=3,<4)"]
 requests = ["requests (>=2.4.0,<3.0.0)"]
-
-[[package]]
-name = "environs"
-version = "9.5.0"
-description = "simplified environment variable parsing"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "environs-9.5.0-py2.py3-none-any.whl", hash = "sha256:1e549569a3de49c05f856f40bce86979e7d5ffbbc4398e7f338574c220189124"},
-    {file = "environs-9.5.0.tar.gz", hash = "sha256:a76307b36fbe856bdca7ee9161e6c466fd7fcffc297109a118c59b54e27e30c9"},
-]
-
-[package.dependencies]
-marshmallow = ">=3.0.0"
-python-dotenv = "*"
-
-[package.extras]
-dev = ["dj-database-url", "dj-email-url", "django-cache-url", "flake8 (==4.0.1)", "flake8-bugbear (==21.9.2)", "mypy (==0.910)", "pre-commit (>=2.4,<3.0)", "pytest", "tox"]
-django = ["dj-database-url", "dj-email-url", "django-cache-url"]
-lint = ["flake8 (==4.0.1)", "flake8-bugbear (==21.9.2)", "mypy (==0.910)", "pre-commit (>=2.4,<3.0)"]
-tests = ["dj-database-url", "dj-email-url", "django-cache-url", "pytest"]
 
 [[package]]
 name = "exceptiongroup"
@@ -4799,28 +4820,28 @@ extra = ["pygments (>=2.12)"]
 
 [[package]]
 name = "pymilvus"
-version = "2.4.9"
+version = "2.5.6"
 description = "Python Sdk for Milvus"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pymilvus-2.4.9-py3-none-any.whl", hash = "sha256:45313607d2c164064bdc44e0f933cb6d6afa92e9efcc7f357c5240c57db58fbe"},
-    {file = "pymilvus-2.4.9.tar.gz", hash = "sha256:0937663700007c23a84cfc0656160b301f6ff9247aaec4c96d599a6b43572136"},
+    {file = "pymilvus-2.5.6-py3-none-any.whl", hash = "sha256:19796f328278974f04632a1531e602070614f6ab0865cc97e27755f622e50a6d"},
+    {file = "pymilvus-2.5.6.tar.gz", hash = "sha256:2bea0b03ed9ac3daadb1b2df8e38aa5c8f4aabd00b23a4999abb4adaebf54f59"},
 ]
 
 [package.dependencies]
-environs = "<=9.5.0"
-grpcio = ">=1.49.1"
-milvus-lite = {version = ">=2.4.0,<2.5.0", markers = "sys_platform != \"win32\""}
+grpcio = ">=1.49.1,<=1.67.1"
+milvus-lite = {version = ">=2.4.0", markers = "sys_platform != \"win32\""}
 pandas = ">=1.2.4"
 protobuf = ">=3.20.0"
+python-dotenv = ">=1.0.1,<2.0.0"
 setuptools = ">69"
 ujson = ">=2.0.0"
 
 [package.extras]
 bulk-writer = ["azure-storage-blob", "minio (>=7.0.0)", "pyarrow (>=12.0.0)", "requests"]
 dev = ["black", "grpcio (==1.62.2)", "grpcio-testing (==1.62.2)", "grpcio-tools (==1.62.2)", "pytest (>=5.3.4)", "pytest-cov (>=2.8.1)", "pytest-timeout (>=1.3.4)", "ruff (>0.4.0)"]
-model = ["milvus-model (>=0.1.0)"]
+model = ["pymilvus.model (>=0.3.0)"]
 
 [[package]]
 name = "pyopenssl"
@@ -5818,6 +5839,11 @@ files = [
     {file = "scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f60021ec1574e56632be2a36b946f8143bf4e5e6af4a06d85281adc22938e0dd"},
     {file = "scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:394397841449853c2290a32050382edaec3da89e35b3e03d6cc966aebc6a8ae6"},
     {file = "scikit_learn-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:57cc1786cfd6bd118220a92ede80270132aa353647684efa385a74244a41e3b1"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9a702e2de732bbb20d3bad29ebd77fc05a6b427dc49964300340e4c9328b3f5"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:b0768ad641981f5d3a198430a1d31c3e044ed2e8a6f22166b4d546a5116d7908"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:178ddd0a5cb0044464fc1bfc4cca5b1833bfc7bb022d70b05db8530da4bb3dd3"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7284ade780084d94505632241bf78c44ab3b6f1e8ccab3d2af58e0e950f9c12"},
+    {file = "scikit_learn-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:b7b0f9a0b1040830d38c39b91b3a44e1b643f4b36e36567b80b7c6bd2202a27f"},
     {file = "scikit_learn-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:757c7d514ddb00ae249832fe87100d9c73c6ea91423802872d9e74970a0e40b9"},
     {file = "scikit_learn-1.5.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:52788f48b5d8bca5c0736c175fa6bdaab2ef00a8f536cda698db61bd89c551c1"},
     {file = "scikit_learn-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:643964678f4b5fbdc95cbf8aec638acc7aa70f5f79ee2cdad1eec3df4ba6ead8"},
@@ -7729,4 +7755,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "5425284dba5974da6c838138254b470b4aed06eff62e7a13a040ab2c568405fe"
+content-hash = "c2b70582022057f49594288e52c2780101df1629b8902b33d09c45ff01dd6e1d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7670,4 +7670,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "715eee9a33948afbfa936e6321b7fef928fd9a0a284f4ff8a0f1ca631d240049"
+content-hash = "95d850fdda8d977f3bedc392f333daa2d6209aca73a823f188670fc7df6144b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ black = "~24.8.0"
 pypdf = "~4.3.1"
 python-pptx = "1.0.2"
 qdrant-client = "~1.11.3"
-pymilvus = "~2.4.3"
+pymilvus = ">=2.5"
 psycopg = { version = "~3.2.3", extras = ["binary"] }
 pgvector = "~0.3.6"
 mysql-connector-python = "~9.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ black = "~24.8.0"
 pypdf = "~4.3.1"
 python-pptx = "1.0.2"
 qdrant-client = "~1.11.3"
-pymilvus = ">=2.5"
+pymilvus = "~2.5.6"
 psycopg = { version = "~3.2.3", extras = ["binary"] }
 pgvector = "~0.3.6"
 mysql-connector-python = "~9.0.0"

--- a/tests/integration/nodes/retrievers/test_milvus_retriever_flow.py
+++ b/tests/integration/nodes/retrievers/test_milvus_retriever_flow.py
@@ -34,7 +34,7 @@ def mock_milvus_vector_store(mock_milvus_client, mock_milvus_connection):
 @pytest.fixture
 def mock_search_embeddings(mock_documents):
     with patch(
-        "dynamiq.storages.vector.milvus.milvus.MilvusVectorStore.search_embeddings",
+        "dynamiq.storages.vector.milvus.milvus.MilvusVectorStore._embedding_retrieval",
         return_value=mock_documents,
     ) as mock_search_embeddings:
         yield mock_search_embeddings
@@ -112,4 +112,5 @@ def test_milvus_retrieve_workflow(
         top_k=input_data["top_k"],
         content_key=None,
         embedding_key=None,
+        return_embeddings=False,
     )

--- a/tests/unit/components/retrievers/test_milvus_document_retriever.py
+++ b/tests/unit/components/retrievers/test_milvus_document_retriever.py
@@ -31,7 +31,7 @@ class TestMilvusDocumentRetriever:
             embedding_key=None,
             return_embeddings=True,
         )
-        print(result)
+
         expected_documents = [
             Document(id="1", content="Document 1", embedding=[0.1, 0.2, 0.3]),
             Document(id="2", content="Document 2", embedding=[0.4, 0.5, 0.6]),

--- a/tests/unit/components/retrievers/test_milvus_document_retriever.py
+++ b/tests/unit/components/retrievers/test_milvus_document_retriever.py
@@ -12,23 +12,53 @@ class TestMilvusDocumentRetriever:
             Document(id="2", content="Document 2", embedding=[0.4, 0.5, 0.6]),
         ]
         mock_vector_store = MagicMock(spec=MilvusVectorStore)
-        mock_vector_store.search_embeddings.return_value = mock_documents
+        mock_vector_store._embedding_retrieval.return_value = mock_documents
 
         retriever = MilvusDocumentRetriever(vector_store=mock_vector_store, filters={"field": "value"}, top_k=5)
 
         result = retriever.run(
             query_embedding=[0.1, 0.2, 0.3],
-            exclude_document_embeddings=True,
+            exclude_document_embeddings=False,
             top_k=2,
             filters={"new_field": "new_value"},
         )
 
-        mock_vector_store.search_embeddings.assert_called_once_with(
+        mock_vector_store._embedding_retrieval.assert_called_once_with(
             query_embeddings=[[0.1, 0.2, 0.3]],
             filters={"new_field": "new_value"},
             top_k=2,
             content_key=None,
             embedding_key=None,
+            return_embeddings=True,
+        )
+        print(result)
+        expected_documents = [
+            Document(id="1", content="Document 1", embedding=[0.1, 0.2, 0.3]),
+            Document(id="2", content="Document 2", embedding=[0.4, 0.5, 0.6]),
+        ]
+        assert result == {"documents": expected_documents}
+
+    def test_run_method_with_defaults(self):
+        mock_documents = [
+            Document(id="1", content="Document 1", embedding=None),
+            Document(id="2", content="Document 2", embedding=None),
+        ]
+        mock_filters = {"field": "value"}
+
+        mock_vector_store = MagicMock(spec=MilvusVectorStore)
+        mock_vector_store._embedding_retrieval.return_value = mock_documents
+
+        retriever = MilvusDocumentRetriever(vector_store=mock_vector_store, filters=mock_filters, top_k=5)
+
+        result = retriever.run(query_embedding=[0.1, 0.2, 0.3], exclude_document_embeddings=True)
+
+        mock_vector_store._embedding_retrieval.assert_called_once_with(
+            query_embeddings=[[0.1, 0.2, 0.3]],
+            filters=mock_filters,
+            top_k=5,
+            content_key=None,
+            embedding_key=None,
+            return_embeddings=False,
         )
 
         expected_documents = [
@@ -37,22 +67,26 @@ class TestMilvusDocumentRetriever:
         ]
         assert result == {"documents": expected_documents}
 
-    def test_run_method_with_defaults(self):
+    def test_run_hybrid_method(self):
         mock_documents = [
-            Document(id="1", content="Document 1", embedding=[0.1, 0.2, 0.3]),
-            Document(id="2", content="Document 2", embedding=[0.4, 0.5, 0.6]),
+            Document(id="1", content="Document 1", embedding=None),
+            Document(id="2", content="Document 2", embedding=None),
         ]
-        mock_filters = {"field": "value"}
 
         mock_vector_store = MagicMock(spec=MilvusVectorStore)
-        mock_vector_store.search_embeddings.return_value = mock_documents
+        mock_vector_store._hybrid_retrieval.return_value = mock_documents
 
-        retriever = MilvusDocumentRetriever(vector_store=mock_vector_store, filters=mock_filters, top_k=5)
+        retriever = MilvusDocumentRetriever(vector_store=mock_vector_store, top_k=5)
 
-        result = retriever.run(query_embedding=[0.1, 0.2, 0.3])
+        result = retriever.run(query="Document", query_embedding=[0.1, 0.2, 0.3], exclude_document_embeddings=True)
 
-        mock_vector_store.search_embeddings.assert_called_once_with(
-            query_embeddings=[[0.1, 0.2, 0.3]], filters=mock_filters, top_k=5, content_key=None, embedding_key=None
+        mock_vector_store._hybrid_retrieval.assert_called_once_with(
+            query="Document",
+            query_embeddings=[[0.1, 0.2, 0.3]],
+            top_k=5,
+            content_key=None,
+            embedding_key=None,
+            return_embeddings=False,
         )
 
         expected_documents = [

--- a/tests/unit/connections/test_connections.py
+++ b/tests/unit/connections/test_connections.py
@@ -88,7 +88,7 @@ def test_milvus_connect_host_without_token(mock_milvus_client_class):
     mock_milvus_client_instance = MagicMock()
     mock_milvus_client_class.return_value = mock_milvus_client_instance
 
-    milvus = MilvusConnection(deployment_type=MilvusDeploymentType.HOST, uri="http://localhost:19530")
+    milvus = MilvusConnection(deployment_type=MilvusDeploymentType.HOST, uri="http://localhost:19530", api_key=None)
     client = milvus.connect()
 
     mock_milvus_client_class.assert_called_once_with(uri="http://localhost:19530")

--- a/tests/unit/nodes/retrievers/test_milvus_retriever.py
+++ b/tests/unit/nodes/retrievers/test_milvus_retriever.py
@@ -74,6 +74,7 @@ def test_execute(milvus_document_retriever):
         top_k=input_data.top_k,
         content_key=None,
         embedding_key=None,
+        query=None,
     )
 
     assert result == {"documents": mock_output["documents"]}
@@ -102,6 +103,7 @@ def test_execute_with_default_filters_and_top_k(milvus_document_retriever):
         top_k=milvus_document_retriever.top_k,
         content_key=None,
         embedding_key=None,
+        query=None,
     )
 
     assert result == {"documents": mock_output["documents"]}

--- a/tests/unit/storages/vector/milvus/test_milvus_storage.py
+++ b/tests/unit/storages/vector/milvus/test_milvus_storage.py
@@ -148,3 +148,22 @@ def test_convert_query_result_to_documents(milvus_vector_store):
     assert documents[0].id == "1"
     assert documents[0].content == "Document 1"
     assert documents[0].score == 0.1
+
+
+def test_hybrid_search(milvus_vector_store, mock_milvus_client):
+    query = "example"
+    query_embeddings = [[0.1, 0.2]]
+    mock_milvus_client.hybrid_search.return_value = [
+        [
+            {
+                "id": "1",
+                "entity": {"content": "Document 1", "vector": [0.1, 0.2], "metadata": {"type": "test"}},
+                "distance": 0.1,
+            }
+        ]
+    ]
+    documents = milvus_vector_store.search_hybrid(query=query, query_embeddings=query_embeddings, top_k=3)
+    assert len(documents) == 1
+    assert documents[0].id == "1"
+    assert documents[0].content == "Document 1"
+    assert documents[0].score == 0.1

--- a/tests/unit/storages/vector/milvus/test_milvus_storage.py
+++ b/tests/unit/storages/vector/milvus/test_milvus_storage.py
@@ -103,7 +103,7 @@ def test_search_embeddings(milvus_vector_store, mock_milvus_client):
             }
         ]
     ]
-    documents = milvus_vector_store.search_embeddings(query_embeddings, top_k=1)
+    documents = milvus_vector_store._embedding_retrieval(query_embeddings, top_k=1)
     assert len(documents) == 1
     assert documents[0].id == "1"
     assert documents[0].content == "Document 1"
@@ -162,7 +162,7 @@ def test_hybrid_search(milvus_vector_store, mock_milvus_client):
             }
         ]
     ]
-    documents = milvus_vector_store.search_hybrid(query=query, query_embeddings=query_embeddings, top_k=3)
+    documents = milvus_vector_store._hybrid_retrieval(query=query, query_embeddings=query_embeddings, top_k=3)
     assert len(documents) == 1
     assert documents[0].id == "1"
     assert documents[0].content == "Document 1"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Integrates hybrid search in Milvus retriever, updates pymilvus, and enhances schema and tests.
> 
>   - **Hybrid Search Integration**:
>     - Adds `query` parameter to `run()` in `milvus.py` for hybrid search.
>     - Implements `_hybrid_retrieval()` in `milvus.py` for combined dense and sparse search.
>   - **Milvus Client Update**:
>     - Updates `pymilvus` version in `pyproject.toml` to `~2.5.6`.
>   - **Schema and Indexing**:
>     - Adds `sparse` field and BM25 function to schema in `milvus.py`.
>     - Adds sparse index with `SPARSE_INVERTED_INDEX` type in `milvus.py`.
>   - **Testing**:
>     - Updates tests in `test_milvus_retriever_flow.py` and `test_milvus_document_retriever.py` to mock `_embedding_retrieval` and `_hybrid_retrieval`.
>     - Adds tests for hybrid search in `test_milvus_storage.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for fc71a38d13862abfc8feb48e6f8f53031560483a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->