### PR TITLE
fix: messages order

### DIFF
--- a/dynamiq/memory/memory.py
+++ b/dynamiq/memory/memory.py
@@ -321,38 +321,48 @@ class Memory(BaseModel):
 
     def _extract_valid_conversation(self, messages: list[Message], limit: int) -> list[Message]:
         """
-        Extracts a valid conversation from a list of messages.
+        Extracts a valid conversation from a list of messages, ensuring it starts with a user message.
 
         Ensures:
-        1. Messages are sorted by timestamp
-        2. For messages with identical timestamps, user messages come before assistant messages
-        3. The first message is from a user
-        4. We respect the limit but prioritize keeping full conversation flows
+        1. Messages are sorted chronologically (timestamp, with USER priority for ties).
+        2. The final list respects the message limit (most recent messages).
+        3. The returned list *always* starts with a USER message, unless empty.
 
         Args:
-            messages: List of messages to process
-            limit: Maximum number of messages to include in the result
+            messages: List of messages to process.
+            limit: Maximum number of messages to include in the result.
 
         Returns:
-            List of messages forming a valid conversation
+            List of messages forming a valid conversation, starting with USER, or an empty list.
         """
         if not messages:
             return []
 
         def message_sort_key(msg):
-            timestamp = msg.metadata.get("timestamp", 0)
+            timestamp = msg.metadata.get("timestamp", float("inf"))
             role_priority = 0 if msg.role == MessageRole.USER else 0.1
             return (timestamp, role_priority)
 
         sorted_messages = sorted(messages, key=message_sort_key)
 
         if limit and len(sorted_messages) > limit:
-            sorted_messages = sorted_messages[-limit:]
+            limited_messages = sorted_messages[-limit:]
+        else:
+            limited_messages = sorted_messages
 
-        if sorted_messages and sorted_messages[0].role != MessageRole.USER:
-            first_user_idx = next((i for i, msg in enumerate(sorted_messages) if msg.role == MessageRole.USER), None)
+        if not limited_messages:
+            return []
+
+        if limited_messages[0].role == MessageRole.USER:
+            return limited_messages
+        else:
+            first_user_idx = next((i for i, msg in enumerate(limited_messages) if msg.role == MessageRole.USER), None)
 
             if first_user_idx is not None:
-                sorted_messages = sorted_messages[first_user_idx:]
-
-        return sorted_messages
+                return limited_messages[first_user_idx:]
+            else:
+                logger.warning(
+                    f"Memory._extract_valid_conversation: No USER message found within the "
+                    f"last {len(limited_messages)} messages. Returning empty history."
+                )
+                return []


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes message order in `_extract_valid_conversation` to ensure conversations start with a USER message and respect limits in `memory.py`.
> 
>   - **Behavior**:
>     - `_extract_valid_conversation` in `memory.py` now ensures the conversation starts with a USER message or returns an empty list if none is found.
>     - Messages are sorted by timestamp with USER messages prioritized in case of ties.
>     - The method respects the message limit, returning the most recent messages.
>   - **Logging**:
>     - Adds a warning log if no USER message is found within the limited messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 3406ee3d99c76d9741052e275dee832d5bbf1853. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->