### PR TITLE
chore: upd mistral tests

### DIFF
--- a/examples/components/llm/llms/mistral_with_messages.py
+++ b/examples/components/llm/llms/mistral_with_messages.py
@@ -17,7 +17,7 @@ prompt_with_assistant_last = Prompt(
     messages=[
         Message(role="system", content="Be friendly"),
         Message(role="user", content="Hello"),
-        Message(role="assistant", content="Can I help you?", prefix=True),
+        Message(role="assistant", content="Can I help you?"),
     ]
 )
 

--- a/tests/integration/nodes/llms/test_mistral.py
+++ b/tests/integration/nodes/llms/test_mistral.py
@@ -7,15 +7,16 @@ from dynamiq import Workflow, connections
 from dynamiq.callbacks import TracingCallbackHandler
 from dynamiq.flows import Flow
 from dynamiq.nodes.llms import Mistral
-from dynamiq.prompts import Message, Prompt
+from dynamiq.prompts import Message, MessageRole, Prompt
 from dynamiq.runnables import RunnableConfig, RunnableResult, RunnableStatus
 
 
 def get_mistral_workflow(
     model: str,
     connection: connections.Mistral,
+    prompt: Prompt,
 ):
-    wf_mistral = Workflow(
+    return Workflow(
         id=str(uuid.uuid4()),
         flow=Flow(
             nodes=[
@@ -23,36 +24,30 @@ def get_mistral_workflow(
                     name="Mistral",
                     model=model,
                     connection=connection,
-                    prompt=Prompt(
-                        messages=[
-                            Message(
-                                role="user",
-                                content="What is LLM?",
-                            ),
-                        ],
-                    ),
+                    prompt=prompt,
                     temperature=0.1,
                 ),
             ],
         ),
     )
 
-    return wf_mistral
-
 
 @pytest.mark.parametrize(
     ("model", "expected_model"),
-    [("mistral/mistral-tiny", "mistral/mistral-tiny"), ("mistral-tiny", "mistral/mistral-tiny")],
+    [
+        ("mistral/mistral-tiny", "mistral/mistral-tiny"),
+        ("mistral-tiny", "mistral/mistral-tiny"),
+    ],
 )
 def test_workflow_with_mistral_llm(mock_llm_response_text, mock_llm_executor, model, expected_model):
-    model = model
+    prompt = Prompt(messages=[Message(role="user", content="What is LLM?")])
     connection = connections.Mistral(
         id=str(uuid.uuid4()),
         api_key="api_key",
     )
-    wf_mistral_ai = get_mistral_workflow(model=model, connection=connection)
+    wf = get_mistral_workflow(model=model, connection=connection, prompt=prompt)
 
-    response = wf_mistral_ai.run(
+    response = wf.run(
         input_data={},
         config=RunnableConfig(callbacks=[TracingCallbackHandler()]),
     )
@@ -62,18 +57,18 @@ def test_workflow_with_mistral_llm(mock_llm_response_text, mock_llm_executor, mo
         input={},
         output={"content": mock_llm_response_text},
     ).to_dict()
-    expected_output = {wf_mistral_ai.flow.nodes[0].id: expected_result}
+    expected_output = {wf.flow.nodes[0].id: expected_result}
+
     assert response == RunnableResult(
         status=RunnableStatus.SUCCESS,
         input={},
         output=expected_output,
     )
-    assert response.output == expected_output
     mock_llm_executor.assert_called_once_with(
         tools=None,
         tool_choice=None,
         model=expected_model,
-        messages=wf_mistral_ai.flow.nodes[0].prompt.format_messages(),
+        messages=prompt.format_messages(),
         stream=False,
         temperature=0.1,
         max_tokens=1000,
@@ -86,3 +81,35 @@ def test_workflow_with_mistral_llm(mock_llm_response_text, mock_llm_executor, mo
         response_format=None,
         drop_params=True,
     )
+
+
+def test_workflow_prefix_added_when_last_assistant(
+    mock_llm_executor,
+):
+    prompt = Prompt(
+        messages=[
+            Message(role=MessageRole.SYSTEM, content="Initialize system"),
+            Message(role=MessageRole.USER, content="Hello!"),
+            Message(role=MessageRole.ASSISTANT, content="How can I help?"),
+        ]
+    )
+    connection = connections.Mistral(
+        id=str(uuid.uuid4()),
+        api_key="api_key",
+    )
+    wf = get_mistral_workflow(
+        model="mistral/mistral-test",
+        connection=connection,
+        prompt=prompt,
+    )
+
+    wf.run(input_data={}, config=RunnableConfig(callbacks=[]))
+
+    called_kwargs = mock_llm_executor.call_args.kwargs
+    sent_messages = called_kwargs["messages"]
+
+    last = sent_messages[-1]
+    assert last["role"] == MessageRole.ASSISTANT.value
+    assert last.get("prefix") is True
+
+    assert all("prefix" not in m for m in sent_messages[:-1])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated Mistral tests to ensure `prefix` is added to the last assistant message and refactored prompt handling.
> 
>   - **Behavior**:
>     - Removed `prefix=True` from `Message` in `mistral_with_messages.py`.
>     - Added test `test_workflow_prefix_added_when_last_assistant` in `test_mistral.py` to ensure `prefix` is added when the last message is from the assistant.
>   - **Tests**:
>     - Refactored `get_mistral_workflow()` in `test_mistral.py` to accept `prompt` as a parameter.
>     - Updated `test_workflow_with_mistral_llm` to use the refactored `get_mistral_workflow()`.
>     - Added parameterization to `test_workflow_with_mistral_llm` for different model inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for ada321785a3d04d1e66d971eebfb33e9ddcf48a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->