### PR TITLE
fix: add support for Milvus writer to define embedding size

### DIFF
--- a/dynamiq/nodes/writers/milvus.py
+++ b/dynamiq/nodes/writers/milvus.py
@@ -1,5 +1,3 @@
-from pydantic import model_validator
-
 from dynamiq.connections import Milvus
 from dynamiq.nodes.node import ensure_config
 from dynamiq.nodes.writers.base import Writer, WriterInputSchema
@@ -38,19 +36,6 @@ class MilvusDocumentWriter(Writer, MilvusWriterVectorStoreParams):
         if kwargs.get("vector_store") is None and kwargs.get("connection") is None:
             kwargs["connection"] = Milvus()
         super().__init__(**kwargs)
-
-    @model_validator(mode="after")
-    def check_required_params(self) -> "MilvusDocumentWriter":
-        """
-        Validate required parameters
-
-        Returns:
-            self: The updated instance.
-        """
-        if self.vector_store is None and self.create_if_not_exist and self.dimension <= 0:
-            raise ValueError("'dimension' must be a positive integer when creating a new collection")
-
-        return self
 
     @property
     def vector_store_cls(self):

--- a/dynamiq/storages/vector/milvus/milvus.py
+++ b/dynamiq/storages/vector/milvus/milvus.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from pymilvus import AnnSearchRequest, DataType, Function, FunctionType, RRFRanker
 
 from dynamiq.connections import Milvus
-from dynamiq.storages.vector.base import BaseWriterVectorStoreParams
+from dynamiq.storages.vector.base import BaseVectorStoreParams, BaseWriterVectorStoreParams
 from dynamiq.storages.vector.milvus.filter import Filter
 from dynamiq.storages.vector.utils import create_file_id_filter
 from dynamiq.types import Document
@@ -13,8 +13,12 @@ if TYPE_CHECKING:
     from pymilvus import MilvusClient
 
 
-class MilvusVectorStoreParams(BaseWriterVectorStoreParams):
+class MilvusVectorStoreParams(BaseVectorStoreParams):
     embedding_key: str = "embedding"
+
+
+class MilvusWriterVectorStoreParams(MilvusVectorStoreParams, BaseWriterVectorStoreParams):
+    dimension: int = 1536
 
 
 class MilvusVectorStore:

--- a/dynamiq/storages/vector/milvus/milvus.py
+++ b/dynamiq/storages/vector/milvus/milvus.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Optional
 
+from pydantic.types import PositiveInt
 from pymilvus import AnnSearchRequest, DataType, Function, FunctionType, RRFRanker
 
 from dynamiq.connections import Milvus
@@ -18,7 +19,7 @@ class MilvusVectorStoreParams(BaseVectorStoreParams):
 
 
 class MilvusWriterVectorStoreParams(MilvusVectorStoreParams, BaseWriterVectorStoreParams):
-    dimension: int = 1536
+    dimension: PositiveInt = 1536
 
 
 class MilvusVectorStore:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for defining embedding size in Milvus writer by introducing `dimension` parameter and renaming classes for clarity.
> 
>   - **Behavior**:
>     - Add `dimension` parameter to `MilvusWriterVectorStoreParams` in `milvus.py` to define embedding size.
>     - Update `MilvusVectorStore` to use `dimension` parameter for embedding field.
>   - **Classes**:
>     - Rename `MilvusVectorStoreParams` to `MilvusWriterVectorStoreParams` in `milvus.py` and `milvus.py`.
>     - Update `MilvusDocumentWriter` to inherit from `MilvusWriterVectorStoreParams` instead of `MilvusVectorStoreParams`.
>   - **Misc**:
>     - Update docstring in `MilvusDocumentWriter` to reflect changes in connection and vector store attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 74ff485cd441340cecc1a69c54735c173adc826f. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->