### PR TITLE
feat: update output configuration for non-streaming logic

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -79,6 +79,11 @@ class BaseLLM(ConnectionNode):
         - InferenceMode.STRUCTURED_OUTPUT: Produces structured JSON output.
         - InferenceMode.FUNCTION_CALLING: Structured output for tools (functions) to be called.
         dict[str, Any] | type[BaseModel] | None: schema_ for structured output. Defaults to empty dict.
+        response_transformer (ResponseTransformer): Specifies the format of the response returned by the node.
+        - ResponseTransformer.DEFAULT: Returns only the generated content (default), as a plain text string.
+        - ResponseTransformer.CHAT_COMPLETION: Returns the full response object in chat completion format, including
+            metadata such as token usage, role, and message structure.
+
     """
 
     MODEL_PREFIX: ClassVar[str | None] = None

--- a/dynamiq/nodes/types.py
+++ b/dynamiq/nodes/types.py
@@ -80,3 +80,10 @@ class ChoiceCondition(BaseModel):
     value: Any = None
     is_not: bool = False
     operands: list["ChoiceCondition"] | None = None
+
+
+class ResponseTransformer(str, Enum):
+    """Represents an output transformer for LLM."""
+
+    DEFAULT = "default"
+    CHAT_COMPLETION = "chat_completion"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `ResponseTransformer` enum to handle different response formats in `BaseLLM`, updating `_handle_completion_response()` to support detailed response metadata.
> 
>   - **Behavior**:
>     - Adds `ResponseTransformer` enum in `types.py` to specify response formats for LLM nodes.
>     - Updates `_handle_completion_response()` in `base.py` to use `ResponseTransformer` for response formatting.
>     - Supports `DEFAULT` and `CHAT_COMPLETION` formats, with `DEFAULT` returning plain text and `CHAT_COMPLETION` returning full response metadata.
>   - **Classes**:
>     - Adds `response_transformer` attribute to `BaseLLM` in `base.py` with default `ResponseTransformer.DEFAULT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 61d0cd6e6c34c1d8a8a76ca117578813c27856bc. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->