### PR TITLE
fix: resolve datetime deprecation warnings

### DIFF
--- a/dynamiq/memory/memory.py
+++ b/dynamiq/memory/memory.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, ClassVar
 
@@ -67,7 +67,7 @@ class Memory(BaseModel):
         try:
             metadata = metadata or {}
             if "timestamp" not in metadata:
-                metadata["timestamp"] = datetime.utcnow().timestamp()
+                metadata["timestamp"] = datetime.now(timezone.utc).timestamp()
 
             sanitized_metadata = {}
             for key, value in metadata.items():


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` deprecation warnings:
```python
/app/dynamiq/memory/memory.py:70: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```