### PR TITLE
fix: md tags in parsing per agent

### DIFF
--- a/dynamiq/nodes/agents/utils.py
+++ b/dynamiq/nodes/agents/utils.py
@@ -67,7 +67,10 @@ class XMLParser:
 
     @staticmethod
     def _extract_data_lxml(
-        root: LET._Element, required_tags: Sequence[str], optional_tags: Sequence[str] = None
+        root: LET._Element,
+        required_tags: Sequence[str],
+        optional_tags: Sequence[str] = None,
+        preserve_format_tags: Sequence[str] = None,
     ) -> dict[str, str]:
         """
         Extracts text content from specified tags using XPath.
@@ -77,6 +80,8 @@ class XMLParser:
         """
         data = {}
         optional_tags = optional_tags or []
+        preserve_format_tags = preserve_format_tags or ["answer"]
+
         all_tags = list(required_tags) + list(optional_tags)
 
         for tag in all_tags:
@@ -86,7 +91,10 @@ class XMLParser:
             if elements:
                 element_found = True
                 for elem in elements:
-                    text = "".join(elem.itertext()).strip()
+                    if tag in preserve_format_tags:
+                        text = LET.tostring(elem, encoding="unicode", method="text")
+                    else:
+                        text = "".join(elem.itertext()).strip()
                     if text:
                         tag_content = text
                         break
@@ -158,6 +166,7 @@ class XMLParser:
         required_tags: Sequence[str],
         optional_tags: Sequence[str] = None,
         json_fields: Sequence[str] = None,
+        preserve_format_tags: Sequence[str] = None,
         attempt_wrap: bool = True,
     ) -> dict[str, Any]:
         """
@@ -168,6 +177,8 @@ class XMLParser:
             required_tags (Sequence[str]): A list/tuple of tag names that MUST be present.
             optional_tags (Sequence[str], optional): A list/tuple of optional tag names. Defaults to None.
             json_fields (Sequence[str], optional): A list/tuple of fields whose content should be parsed as JSON.
+            preserve_format_tags (Sequence[str], optional): A list/tuple of tags
+            whose content should be preserved as-is.
             attempt_wrap (bool): If initial parsing fails, try wrapping the content in <root> and parse again.
 
         Returns:
@@ -203,7 +214,7 @@ class XMLParser:
             )
 
         try:
-            extracted_data = XMLParser._extract_data_lxml(root, required_tags, optional_tags)
+            extracted_data = XMLParser._extract_data_lxml(root, required_tags, optional_tags, preserve_format_tags)
         except TagNotFoundError as e:
             raise e
         except Exception as e:

--- a/tests/integration/nodes/agents/test_agent_methods.py
+++ b/tests/integration/nodes/agents/test_agent_methods.py
@@ -255,3 +255,29 @@ def test_xmlparser_extract_regex_not_found():
     text = "Blah blah"
     result = XMLParser.extract_first_tag_regex(text, ["output", "final_answer"])
     assert result is None
+
+
+def test_xmlparser_parse_with_chart_in_answer():
+    """Test that XML parser preserves markdown code blocks for charts in answer tags."""
+    text = """<output>
+  <thought>The user wants to create a chart.</thought>
+  <answer>
+    # Total Approved Expenses
+    ```chart
+    {
+      "title": "Total Approved Expenses Per Month (USD)",
+      "width": 500,
+      "height": 300,
+      "data": {
+        "values": [
+          {"month": "January 2025", "amount": 745982.33}
+        ]
+      }
+    }
+    ```
+    The chart shows January expenses.
+  </answer>
+</output>"""
+
+    result = XMLParser.parse(text, required_tags=["thought", "answer"])
+    assert "```chart" in result["answer"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `preserve_format_tags` to `XMLParser` to preserve markdown code blocks in specified tags during parsing.
> 
>   - **Behavior**:
>     - Add `preserve_format_tags` parameter to `XMLParser._extract_data_lxml()` and `XMLParser.parse()` to preserve markdown code blocks in specified tags.
>     - Default `preserve_format_tags` to `["answer"]`.
>   - **Tests**:
>     - Add `test_xmlparser_parse_with_chart_in_answer()` in `test_agent_methods.py` to verify preservation of markdown code blocks in `answer` tags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for cf7ba34cd2f840169c370d20c7af72a9fda52f7d. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->