### PR TITLE
fix: xml parser

### DIFF
--- a/dynamiq/nodes/agents/utils.py
+++ b/dynamiq/nodes/agents/utils.py
@@ -31,15 +31,13 @@ class XMLParser:
     def _clean_content(text: str) -> str:
         """
         Cleans the input string to remove common LLM artifacts and isolate XML.
-        - Removes markdown code fences (```json, ```, etc.).
         - Strips leading/trailing whitespace.
         - Attempts to extract the first well-formed XML block if surrounded by text.
         """
         if not isinstance(text, str):
             return ""
 
-        cleaned = re.sub(r"^```(?:[a-zA-Z]+\s*)?|```$", "", text.strip(), flags=re.MULTILINE)
-        cleaned = cleaned.strip()
+        cleaned = text.strip()
 
         xml_match = re.search(r"<(\w+)\b[^>]*>.*?</\1>", cleaned, re.DOTALL)
         if xml_match:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified `XMLParser._clean_content` by removing markdown code fence stripping.
> 
>   - **Behavior**:
>     - In `XMLParser._clean_content`, removed regex substitution that stripped markdown code fences from input text.
>     - Now only strips leading/trailing whitespace and extracts XML blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 39f947e13da131df189279563c90bf6dcc2518d9. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->