### PR TITLE
feat: add possibility to override method inside HttpApiCall

### DIFF
--- a/dynamiq/nodes/tools/http_api_call.py
+++ b/dynamiq/nodes/tools/http_api_call.py
@@ -83,7 +83,6 @@ class HttpApiCallInputSchema(BaseModel):
     payload_type: RequestPayloadType = Field(default=None, description="Parameter to specify the type of payload data.")
     headers: dict = Field(default={}, description="Parameter to provide headers to the request.")
     params: dict = Field(default={}, description="Parameter to provide GET parameters in URL.")
-    method: HTTPMethod = Field(default=None, description="Parameter to specify the HTTP method for sending request.")
 
     @field_validator("data", "headers", "params", mode="before")
     @classmethod
@@ -161,7 +160,7 @@ class HttpApiCall(ConnectionNode):
             raise ValueError("No url provided.")
         headers = input_data.headers
         params = input_data.params
-        method = input_data.method or self.method or self.connection.method
+        method = self.method or self.connection.method
 
         try:
             response = self.client.request(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `method` attribute to `HttpApiCall` to allow overriding HTTP method, updating `execute()` to use it if provided.
> 
>   - **Behavior**:
>     - Adds `method` attribute to `HttpApiCall` to allow overriding the HTTP method.
>     - Updates `execute()` in `HttpApiCall` to use `method` attribute if provided, otherwise defaults to connection's method.
>   - **Imports**:
>     - Imports `HTTPMethod` from `dynamiq.connections` in `http_api_call.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 6d9f7e0d247fe560b6b7191a33dc2d77941ab15f. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->