### PR TITLE
feat: kwargs for python node

### DIFF
--- a/tests/integration/nodes/tools/test_python.py
+++ b/tests/integration/nodes/tools/test_python.py
@@ -12,6 +12,22 @@ from dynamiq.types import Document
 from dynamiq.utils import JsonWorkflowEncoder
 
 
+def test_python_node_with_kwargs():
+    """Test Python node with additional keyword arguments."""
+    python_code = """
+def run(input_data, config = None, **kwargs):
+    return str(config)
+"""
+    python_node = Python(code=python_code, model_config=ConfigDict())
+    input_data = {}
+    config = RunnableConfig(callbacks=[])
+    result = python_node.run(input_data, config=config)
+    assert isinstance(result, RunnableResult)
+    assert result.status == RunnableStatus.SUCCESS
+    assert result.output["content"] == str(config)
+    assert result.input == input_data
+
+
 def test_python_node_with_input():
     """Test Python node with specific input data for name and age calculation."""
     python_code = """


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for passing `**kwargs` to the `run` function in the `Python` node if it accepts them.
> 
>   - **Behavior**:
>     - `Python` node now supports passing `**kwargs` to the `run` function if it accepts them.
>     - Adds `accepts_kwargs()` method in `Python` class to check for `**kwargs` in `run` function.
>     - Modifies `execute()` in `Python` class to pass `kwargs` if `run` accepts them.
>   - **Tests**:
>     - Adds `test_python_node_with_kwargs()` in `test_python.py` to verify `kwargs` handling in `Python` node.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for b5a16b8be2c0292dd0171a98c865c20dfc9bb8b9. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->