### PR TITLE
feat: human in the loop

### DIFF
--- a/dynamiq/nodes/agents/orchestrators/graph.py
+++ b/dynamiq/nodes/agents/orchestrators/graph.py
@@ -372,5 +372,4 @@ class GraphOrchestrator(Orchestrator):
         self.manager.streaming = self.streaming
         for state in self.states:
             for task in state.tasks:
-                if isinstance(task, Agent):
-                    task.streaming = self.streaming
+                task.streaming = self.streaming

--- a/dynamiq/nodes/agents/orchestrators/graph_state.py
+++ b/dynamiq/nodes/agents/orchestrators/graph_state.py
@@ -235,13 +235,17 @@ class GraphState(Node):
             raise OrchestratorError(f"Failed to execute {task.name} with Error: {error_msg}")
 
         context = response.output.get("content")
-        if not isinstance(context, dict):
-            raise OrchestratorError(
-                f"Error: Task returned invalid data format. Expected a dictionary got {type(context)}"
-            )
 
-        if "result" not in context:
-            raise OrchestratorError("Error: Task returned dictionary with no 'result' key in it.")
+        if isinstance(task, FunctionTool) or isinstance(task, Python):
+            if not isinstance(context, dict):
+                raise OrchestratorError(
+                    f"Error: Task returned invalid data format. Expected a dictionary got {type(context)}"
+                )
+
+            if "result" not in context:
+                raise OrchestratorError("Error: Task returned dictionary with no 'result' key in it.")
+        else:
+            return context, {}
 
         context.pop("history", None)
 

--- a/dynamiq/nodes/tools/human_feedback.py
+++ b/dynamiq/nodes/tools/human_feedback.py
@@ -104,7 +104,7 @@ class HumanFeedbackTool(Node):
         msg_template = self.msg_template
         self.description += (
             f"\nThis is the template of message to send: '{msg_template}'."
-            "Parameters will be substituted based on the provided input data."
+            " Parameters will be substituted based on the provided input data."
         )
         return self
 
@@ -231,7 +231,7 @@ class MessageSenderTool(Node):
         msg_template = self.msg_template
         self.description += (
             f"\nThis is the template of message to send: '{msg_template}'."
-            "Parameters will be substituted based on the provided input data."
+            " Parameters will be substituted based on the provided input data."
         )
         return self
 

--- a/dynamiq/nodes/tools/human_feedback.py
+++ b/dynamiq/nodes/tools/human_feedback.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Literal
 
 from jinja2 import Template
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from dynamiq.nodes import NodeGroup
 from dynamiq.nodes.node import Node, ensure_config
@@ -71,7 +71,6 @@ class OutputMethodCallable(ABC):
 
 
 class HumanFeedbackInputSchema(BaseModel):
-    input: str = Field(default="", description="Parameter to provide a question to the user.")
     model_config = ConfigDict(extra="allow")
 
 
@@ -99,6 +98,15 @@ class HumanFeedbackTool(Node):
     input_schema: ClassVar[type[HumanFeedbackInputSchema]] = HumanFeedbackInputSchema
     msg_template: str = "{{input}}"
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @model_validator(mode="after")
+    def update_description(self):
+        msg_template = self.msg_template
+        self.description += (
+            f"\nThis is the template of message to send: '{msg_template}'."
+            "Parameters will be substituted based on the provided input data."
+        )
+        return self
 
     def input_method_console(self, prompt: str) -> str:
         """
@@ -195,7 +203,6 @@ class HumanFeedbackTool(Node):
 
 
 class MessageSenderInputSchema(BaseModel):
-    input: str = Field(default="", description="Parameter to provide a message to the user.")
     model_config = ConfigDict(extra="allow")
 
 
@@ -218,6 +225,15 @@ class MessageSenderTool(Node):
     output_method: FeedbackMethod | OutputMethodCallable = FeedbackMethod.CONSOLE
     input_schema: ClassVar[type[MessageSenderInputSchema]] = MessageSenderInputSchema
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @model_validator(mode="after")
+    def update_description(self):
+        msg_template = self.msg_template
+        self.description += (
+            f"\nThis is the template of message to send: '{msg_template}'."
+            "Parameters will be substituted based on the provided input data."
+        )
+        return self
 
     def output_method_console(self, prompt: str) -> None:
         """

--- a/examples/components/tools/human_in_the_loop/confirmation_email_writer/console/console_agent.py
+++ b/examples/components/tools/human_in_the_loop/confirmation_email_writer/console/console_agent.py
@@ -1,6 +1,7 @@
 from dynamiq.nodes.agents import ReActAgent
 from dynamiq.nodes.tools.human_feedback import HumanFeedbackTool, MessageSenderTool
 from dynamiq.nodes.tools.python import Python
+from dynamiq.nodes.types import InferenceMode
 from dynamiq.types.feedback import ApprovalConfig, FeedbackMethod
 from examples.llm_setup import setup_llm
 
@@ -47,6 +48,7 @@ def run_agent(query) -> dict:
             "You are a helpful assistant that has access to the internet using Tavily Tool."
             "You can request some clarifications using HumanFeedbackTool and send messages using MessageSenderTool "
         ),
+        inference_mode=InferenceMode.XML,
         llm=llm,
         tools=[email_sender_tool, human_feedback_tool, message_sender_tool],
     )

--- a/examples/components/tools/human_in_the_loop/streaming_orchestrator/client_streaming.py
+++ b/examples/components/tools/human_in_the_loop/streaming_orchestrator/client_streaming.py
@@ -1,0 +1,126 @@
+import asyncio
+import json
+import logging
+import time
+
+import websockets
+from websocket import WebSocket
+
+from dynamiq.types.feedback import APPROVAL_EVENT
+from dynamiq.types.streaming import StreamingEventMessage
+from examples.components.tools.human_in_the_loop.streaming_orchestrator.server_streaming import PORT
+
+logger = logging.getLogger(__name__)
+WS_URI = f"ws://localhost:{PORT}/ws"
+WF_ID = "dag-workflow"
+
+
+async def handle_event_data(websocket: WebSocket, event: StreamingEventMessage, restart_count: int) -> bool:
+    """Handle the event data received from the websocket.
+
+    Args:
+        websocket: The websocket connection
+        event: The event received from the server
+        restart_count: The number of times the workflow has been restarted
+
+    Returns:
+        bool: Whether to break the receive loop
+    """
+    # Handle approval event
+    if event.event == APPROVAL_EVENT:
+        feedback = input(event.data["template"])
+
+        feedback_message = StreamingEventMessage(
+            entity_id=event.entity_id,
+            wf_run_id=event.wf_run_id,
+            data={"feedback": feedback},
+            event=APPROVAL_EVENT,
+        )
+
+        await websocket.send(feedback_message.to_json())
+
+    # Handle content from choices
+    if "choices" in event.data:
+        if content := event.data.get("choices")[0].get("delta").get("content"):
+            logger.info(f"Client: {content}")
+
+    # Handle incoming message
+    if event.source.type == "dynamiq.nodes.tools.MessageSenderTool":
+        logger.info(f"Client: {event.data["prompt"]}")
+
+    # Handle feedback request
+    if event.source.type == "dynamiq.nodes.tools.HumanFeedbackTool":
+        feedback = input(f"Client: {event.data["prompt"]}")
+        wf_run_event = StreamingEventMessage(
+            entity_id=WF_ID,
+            data={"content": feedback},
+        )
+        await websocket.send(wf_run_event.to_json())
+    return False
+
+
+async def websocket_client(input_query: str | None = None) -> float:
+    """Run a websocket client and return the execution time in seconds.
+
+    Args:
+        input_query: The query to send. If None, will prompt for input.
+
+    Returns:
+        float: The execution time in seconds.
+    """
+    start_time = time.time()
+    restart_count = 0
+    max_restarts = 0
+
+    async with websockets.connect(WS_URI, open_timeout=60) as websocket:
+        if input_query is None:
+            input_query = input("Provide request: ")
+
+        logger.info(f"Client: Starting with query '{input_query}'")
+
+        wf_run_event = StreamingEventMessage(entity_id=None, data={"stream": True, "input": {"input": input_query}})
+        await websocket.send(wf_run_event.to_json())
+
+        try:
+            while True:
+                event_data = json.loads(await websocket.recv())
+                try:
+                    event = StreamingEventMessage(**event_data)
+                    if event.source.type == "dynamiq.workflows.Workflow":
+                        print(event)
+                        break
+                except Exception as e:
+                    logger.error(f"Client: Error while parsing message. Error: {e}")
+                    continue
+
+                should_break = await handle_event_data(websocket, event, restart_count)
+
+                if should_break:
+                    if restart_count < max_restarts:
+                        logger.info("Client: Restarting workflow in same WebSocket connection")
+                        wf_run_event = StreamingEventMessage(
+                            entity_id=WF_ID,
+                            data={
+                                "stream": True,
+                                "input": {"input": input_query},
+                            },
+                        )
+                        await websocket.send(wf_run_event.to_json())
+                        restart_count += 1
+                    else:
+                        break
+
+        except websockets.ConnectionClosed:
+            logger.error("Client: WebSocket connection closed by the server")
+
+        await websocket.close()
+
+    execution_time = time.time() - start_time
+    logger.info(f"Client: Completed in {execution_time:.2f} seconds")
+    return execution_time
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    query = input("Describe details of the email: ")
+    execution_time = asyncio.run(websocket_client(query))

--- a/examples/components/tools/human_in_the_loop/streaming_orchestrator/client_streaming.py
+++ b/examples/components/tools/human_in_the_loop/streaming_orchestrator/client_streaming.py
@@ -46,11 +46,11 @@ async def handle_event_data(websocket: WebSocket, event: StreamingEventMessage, 
 
     # Handle incoming message
     if event.source.type == "dynamiq.nodes.tools.MessageSenderTool":
-        logger.info(f"Client: {event.data["prompt"]}")
+        logger.info(f"Client: {event.data['prompt']}")
 
     # Handle feedback request
     if event.source.type == "dynamiq.nodes.tools.HumanFeedbackTool":
-        feedback = input(f"Client: {event.data["prompt"]}")
+        feedback = input(f"Client: {event.data['prompt']}")
         wf_run_event = StreamingEventMessage(
             entity_id=WF_ID,
             data={"content": feedback},

--- a/examples/components/tools/human_in_the_loop/streaming_orchestrator/server_streaming.py
+++ b/examples/components/tools/human_in_the_loop/streaming_orchestrator/server_streaming.py
@@ -45,7 +45,7 @@ def create_orchestrator() -> GraphOrchestrator:
     def process_feedback(context: dict[str, Any], **kwargs):
         feedback = context.get("history")[-1]["content"]
         if feedback == "SEND":
-            return {"result": "Email was send!", **context}
+            return {"result": "Email was sent!", **context}
         elif feedback == "CANCEL":
             return {"result": "Email was canceled!", **context}
         return {"result": "Unknown command", **context}

--- a/examples/components/tools/human_in_the_loop/streaming_orchestrator/server_streaming.py
+++ b/examples/components/tools/human_in_the_loop/streaming_orchestrator/server_streaming.py
@@ -1,0 +1,170 @@
+import asyncio
+import logging
+from queue import Queue
+from typing import Any
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from dynamiq import Workflow
+from dynamiq.callbacks.streaming import AsyncStreamingIteratorCallbackHandler
+from dynamiq.connections import Anthropic as AnthropicConnection
+from dynamiq.flows import Flow
+from dynamiq.nodes.agents import SimpleAgent
+from dynamiq.nodes.agents.orchestrators.graph import END, START, GraphAgentManager, GraphOrchestrator
+from dynamiq.nodes.llms.anthropic import Anthropic
+from dynamiq.nodes.node import InputTransformer, NodeDependency
+from dynamiq.nodes.tools.human_feedback import HumanFeedbackTool, MessageSenderTool
+from dynamiq.runnables import RunnableConfig, RunnableResult
+from dynamiq.runnables.base import NodeRunnableConfig
+from dynamiq.types.feedback import FeedbackMethod
+from dynamiq.types.streaming import StreamingConfig, StreamingEventMessage
+from dynamiq.utils.logger import logger
+
+HOST = "127.0.0.1"
+PORT = 6001
+
+app = FastAPI()
+
+logging.basicConfig(level=logging.INFO)
+
+
+def create_orchestrator() -> GraphOrchestrator:
+    """
+    Creates orchestrator.
+
+    Returns:
+        GraphOrchestrator: The configured orchestrator.
+    """
+    llm = Anthropic(
+        name="LLM",
+        connection=AnthropicConnection(),
+        model="claude-3-5-sonnet-20241022",
+        temperature=0.1,
+    )
+
+    def process_feedback(context: dict[str, Any], **kwargs):
+        feedback = context.get("history")[-1]["content"]
+        if feedback == "SEND":
+            return {"result": "Email was send!", **context}
+        elif feedback == "CANCEL":
+            return {"result": "Email was canceled!", **context}
+        return {"result": "Unknown command", **context}
+
+    orchestrator = GraphOrchestrator(
+        name="Graph orchestrator",
+        manager=GraphAgentManager(llm=llm),
+    )
+
+    agent = SimpleAgent(llm=llm)
+    human_feedback_tool = HumanFeedbackTool(
+        input_transformer=InputTransformer(
+            selector={
+                "sketch": "$.history[-1].content",
+            },
+        ),
+        input_method=FeedbackMethod.STREAM,
+        msg_template="Generated draft of email: {{sketch}}." " Approve by sending SEND, cancel by sending CANCEL.",
+    )
+    orchestrator.add_state_by_tasks("generate_sketch", [agent])
+    orchestrator.add_state_by_tasks("gather_feedback", [human_feedback_tool])
+    orchestrator.add_state_by_tasks("process_feedback", [process_feedback])
+
+    orchestrator.add_edge(START, "generate_sketch")
+    orchestrator.add_edge("generate_sketch", "gather_feedback")
+    orchestrator.add_edge("gather_feedback", "process_feedback")
+    orchestrator.add_edge("process_feedback", END)
+
+    return orchestrator, human_feedback_tool.id
+
+
+def run_workflow(nodes, input_data, config) -> RunnableResult:
+    """Runs orchestrator"""
+    wf = Workflow(flow=Flow(nodes=nodes))
+
+    _ = wf.run(input_data=input_data, config=config)
+
+
+async def _send_stream_events_by_ws(websocket: WebSocket, send_handler: Any):
+    """Sends streaming events by websocket."""
+    try:
+        async for event in send_handler:
+            await websocket.send_text(event.to_json())
+        logger.info("All streaming events sent")
+    except WebSocketDisconnect as e:
+        logger.error(f"WebSocket disconnected. Error: {e}")
+    except asyncio.CancelledError:
+        logger.error("Task cancelled")
+    except Exception as e:
+        logger.error(f"Unexpected error. Error: {e}")
+    finally:
+        pass
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    logger.info("WebSocket connected")
+
+    message_queue = Queue()
+
+    message_tool = MessageSenderTool(
+        output_method=FeedbackMethod.STREAM,
+        msg_template="Workflow started execution!",
+        streaming=StreamingConfig(enabled=True),
+    )
+
+    orchestrator, feedback_tool_id = create_orchestrator()
+
+    final_status_tool = MessageSenderTool(
+        output_method=FeedbackMethod.STREAM,
+        msg_template="Workflow finished with status: {{status}}",
+        streaming=StreamingConfig(enabled=True),
+        depends=[NodeDependency(orchestrator)],
+        input_transformer=InputTransformer(
+            selector={
+                "status": f"$.{orchestrator.id}.output.content",
+            },
+        ),
+    )
+
+    send_handler = AsyncStreamingIteratorCallbackHandler()
+
+    asyncio.create_task(_send_stream_events_by_ws(websocket, send_handler))
+    await asyncio.sleep(0.01)
+
+    config = RunnableConfig(
+        callbacks=[send_handler],
+        nodes_override={
+            feedback_tool_id: NodeRunnableConfig(
+                streaming=StreamingConfig(
+                    enabled=True,
+                    input_queue=message_queue,
+                )
+            )
+        },
+    )
+
+    try:
+        while True:
+            ws_data = await websocket.receive_text()
+            try:
+                ws_event = StreamingEventMessage.model_validate_json(ws_data)
+            except ValueError as e:
+                logger.error(f"Error parsing WebSocket message: {e}")
+
+            if ws_event.entity_id is None:
+                asyncio.get_running_loop().run_in_executor(
+                    None, run_workflow, [message_tool, orchestrator, final_status_tool], ws_event.data["input"], config
+                )
+
+            else:
+                message_queue.put(ws_event.to_json())
+
+    except WebSocketDisconnect:
+        logging.info("WebSocket disconnected")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host=HOST, port=PORT)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces human-in-the-loop with streaming, modifies orchestrator task handling, and adds tools for feedback and messaging.
> 
>   - **Behavior**:
>     - Removes `Agent` type check in `setup_streaming()` in `graph.py`, enabling streaming for all tasks.
>     - Updates `_submit_task()` in `graph_state.py` to handle non-dict responses for non-`FunctionTool`/`Python` tasks.
>   - **Tools**:
>     - Adds `msg_template` attribute to `HumanFeedbackTool` and `MessageSenderTool` in `human_feedback.py`.
>     - Implements `model_validator` to append `msg_template` to `description` in `human_feedback.py`.
>   - **Examples**:
>     - Adds `client_streaming.py` and `server_streaming.py` for streaming orchestrator example.
>     - Updates `console_agent.py` to use `InferenceMode.XML` and include `HumanFeedbackTool` and `MessageSenderTool`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for bdc8649f872cfb59b1c218fce52ba17fab149829. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->