### PR TITLE
fix: support docs without metadata in Pinecone

### DIFF
--- a/dynamiq/storages/vector/pinecone/pinecone.py
+++ b/dynamiq/storages/vector/pinecone/pinecone.py
@@ -354,7 +354,7 @@ class PineconeVectorStore(BaseVectorStore):
             doc_for_pinecone = {
                 "id": document.id,
                 "values": embedding,
-                "metadata": dict(document.metadata),
+                "metadata": dict(document.metadata or {}),
             }
 
             if document.content is not None:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of documents without metadata in `_convert_documents_to_pinecone_format()` in `pinecone.py`.
> 
>   - **Behavior**:
>     - Fixes handling of documents without metadata in `_convert_documents_to_pinecone_format()` in `pinecone.py` by using `dict(document.metadata or {})` to ensure `metadata` is always a dictionary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 6a42ca7217ece60ae5ac8226dfdd3f2c9b99429f. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->