### PR TITLE
feat: change logic for tool passing

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -98,7 +98,7 @@ class BaseLLM(ConnectionNode):
     thinking_enabled: bool | None = None
     budget_tokens: int = 1024
     response_format: dict[str, Any] | None = None
-    tools: list[Tool] | None = None
+    tools: list[Tool | dict] | None = None
     input_schema: ClassVar[type[BaseLLMInputSchema]] = BaseLLMInputSchema
     inference_mode: InferenceMode = Field(
         default=InferenceMode.DEFAULT,
@@ -292,9 +292,8 @@ class BaseLLM(ConnectionNode):
 
     def _get_response_format_and_tools(
         self,
-        input_data: BaseLLMInputSchema,
         prompt: Prompt | None = None,
-        tools: list[Tool] | None = None,
+        tools: list[Tool | dict] | None = None,
         response_format: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         """Get response format and tools
@@ -309,7 +308,7 @@ class BaseLLM(ConnectionNode):
             ValueError: If schema is None when using STRUCTURED_OUTPUT or FUNCTION_CALLING modes.
         """
         response_format = response_format or self.response_format or prompt.response_format
-        tools = tools or self.tools or prompt.format_tools(**dict(input_data))
+        tools = tools or self.tools or prompt.tools
 
         # Suppress DeprecationWarning if deprecated parameters are not set
         with warnings.catch_warnings():
@@ -327,6 +326,9 @@ class BaseLLM(ConnectionNode):
                     if schema is None:
                         raise ValueError("Schema must be provided when using FUNCTION_CALLING inference mode")
                     tools = tools or schema
+
+        if tools:
+            tools = [tool.model_dump() for tool in tools if isinstance(tool, Tool)]
 
         return response_format, tools
 
@@ -353,7 +355,7 @@ class BaseLLM(ConnectionNode):
         input_data: BaseLLMInputSchema,
         config: RunnableConfig = None,
         prompt: Prompt | None = None,
-        tools: list[Tool] | None = None,
+        tools: list[Tool | dict] | None = None,
         response_format: dict[str, Any] | None = None,
         **kwargs,
     ):
@@ -366,7 +368,7 @@ class BaseLLM(ConnectionNode):
             input_data (BaseLLMInputSchema): The input data for the LLM.
             config (RunnableConfig, optional): The configuration for the execution. Defaults to None.
             prompt (Prompt, optional): The prompt to use for this execution. Defaults to None.
-            tools list[Tool]: List of tools that llm can call.
+            tools (list[Tool|dict]): List of tools that llm can call.
             response_format (dict[str, Any]): JSON schema that specifies the structure of the llm's output
             **kwargs: Additional keyword arguments.
 
@@ -388,7 +390,6 @@ class BaseLLM(ConnectionNode):
             params.update(extra)
 
         response_format, tools = self._get_response_format_and_tools(
-            input_data=input_data,
             prompt=prompt,
             tools=tools,
             response_format=response_format,

--- a/dynamiq/prompts/prompts.py
+++ b/dynamiq/prompts/prompts.py
@@ -286,7 +286,7 @@ class Prompt(BasePrompt):
     """
 
     messages: list[Message | VisionMessage]
-    tools: list[Tool] | None = None
+    tools: list[Tool | dict] | None = None
     response_format: dict[str, Any] | None = None
     _Template: Any = PrivateAttr()
 
@@ -345,7 +345,4 @@ class Prompt(BasePrompt):
         return out
 
     def format_tools(self, **kwargs) -> list[dict] | None:
-        out = None
-        if self.tools:
-            out = [tool.model_dump() for tool in self.tools]
-        return out
+        pass

--- a/examples/components/llm/llms/function_calling.py
+++ b/examples/components/llm/llms/function_calling.py
@@ -6,7 +6,6 @@ from dynamiq.connections.managers import ConnectionManager
 from dynamiq.flows import Flow
 from dynamiq.nodes.llms import OpenAI
 from dynamiq.prompts import Message, Prompt
-from dynamiq.prompts.prompts import Tool, ToolFunction, ToolFunctionParameters
 
 
 def get_current_time(location: str) -> str:
@@ -34,23 +33,20 @@ def main():
     cm = ConnectionManager()
 
     tools = [
-        Tool(
-            function=ToolFunction(
-                name="get_current_time",
-                description="Get the current time in a given location",
-                parameters=ToolFunctionParameters(
-                    type="object",
-                    required=["location"],
-                    properties={
-                        "location": {
-                            "type": "string",
-                            "description": "The city, e.g. San Francisco",
-                        }
-                    },
-                ),
-            ),
-        )
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_time",
+                "description": "Get the current time in a given location",
+                "parameters": {
+                    "type": "object",
+                    "required": ["location"],
+                    "properties": {"location": {"type": "string", "description": "The city, e.g. San Francisco"}},
+                },
+            },
+        }
     ]
+
     openai_node = OpenAI(
         name="openAI",
         model="gpt-3.5-turbo-1106",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR updates the LLM tool handling logic to support tools as either `Tool` objects or dictionaries, affecting `BaseLLM`, `Prompt`, and example usage.
> 
>   - **Behavior**:
>     - `tools` in `BaseLLM` and `Prompt` can now be a list of `Tool` or `dict`.
>     - `_get_response_format_and_tools()` in `base.py` now processes `tools` as `Tool` or `dict`.
>     - `execute()` in `base.py` updated to handle `tools` as `Tool` or `dict`.
>   - **Prompts**:
>     - `format_tools()` in `prompts.py` is now a no-op.
>   - **Examples**:
>     - `function_calling.py` updated to use dictionary format for `tools`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 147495b64d6cc053097f3570ee6ebbd44fd185f8. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->