### PR TITLE
fix: add logic for passing connection params in CohereReranker

### DIFF
--- a/dynamiq/nodes/rankers/cohere.py
+++ b/dynamiq/nodes/rankers/cohere.py
@@ -74,7 +74,9 @@ class CohereReranker(Node):
 
         logger.debug(f"Node {self.name} - {self.id}: Reranking {len(documents)} documents")
 
-        response = self._rerank(model=self.model, query=query, documents=document_texts, top_n=self.top_k)
+        response = self._rerank(
+            model=self.model, query=query, documents=document_texts, top_n=self.top_k, **self.connection.conn_params
+        )
 
         reranked_documents = []
         for result in response.results:

--- a/tests/integration/nodes/rerankers/test_cohere.py
+++ b/tests/integration/nodes/rerankers/test_cohere.py
@@ -85,6 +85,7 @@ def test_workflow_with_cohere_reranker(mock_rerank_executor):
         query=input_data["query"],
         documents=[doc.content for doc in documents],
         top_n=2,
+        api_key="api_key",
     )
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Pass connection parameters to `_rerank()` in `CohereReranker` and update test to verify this behavior.
> 
>   - **Behavior**:
>     - In `CohereReranker.execute()`, pass `self.connection.conn_params` to `_rerank()` for connection parameters.
>   - **Tests**:
>     - Update `test_workflow_with_cohere_reranker()` in `test_cohere.py` to include `api_key` in mock call verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 7b84ed3d9b9b80c9f4be77f5b29bdfd8041953d4. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->