### PR TITLE
chore: remove secrets from traces

### DIFF
--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -535,7 +535,17 @@ class Node(BaseModel, Runnable, ABC):
 
     @property
     def to_dict_exclude_secure_params(self):
-        return self.to_dict_exclude_params | {"connection": {"api_key": True}}
+        return self.to_dict_exclude_params | {
+            "connection": {
+                "api_key": True,
+                "access_token": True,
+                "access_key_id": True,
+                "password": True,
+                "private_key_id": True,
+                "private_key": True,
+                "secret_access_key": True,
+            }
+        }
 
     def to_dict(self, include_secure_params: bool = False, **kwargs) -> dict:
         """Converts the instance to a dictionary.

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -538,8 +538,10 @@ class Node(BaseModel, Runnable, ABC):
         return self.to_dict_exclude_params | {
             "connection": {
                 "api_key": True,
+                "browserbase_api_key": True,
                 "access_token": True,
                 "access_key_id": True,
+                "model_api_key": True,
                 "password": True,
                 "private_key_id": True,
                 "private_key": True,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance security by excluding additional sensitive fields from traces in `to_dict_exclude_secure_params` in `node.py`.
> 
>   - **Security**:
>     - Updated `to_dict_exclude_secure_params` in `node.py` to exclude additional sensitive fields: `browserbase_api_key`, `access_token`, `access_key_id`, `model_api_key`, `password`, `private_key_id`, `private_key`, `secret_access_key`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 43ea8e5bd537d6b53cb03e6b98950060473ce90c. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->