### PR TITLE
fix: resolve Pydantic deprecation warnings

### DIFF
--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -268,7 +268,7 @@ class Node(BaseModel, Runnable, ABC):
         fields_to_include = {}
         generated_schemas = {}
         for name in fields or cls._json_schema_fields:
-            field = cls.__fields__[name]
+            field = cls.model_fields[name]
             annotation = clear_annotation(field.annotation)
             parameter_name = name
             if field.alias:
@@ -279,7 +279,7 @@ class Node(BaseModel, Runnable, ABC):
                 fields_to_include[parameter_name] = (annotation, Field(..., description=field.description))
 
         model = create_model(cls.__name__, **fields_to_include)
-        schema = model.schema()
+        schema = model.model_json_schema()
         schema["additionalProperties"] = False
         for param, param_schema in generated_schemas.items():
             schema["properties"][param] = param_schema

--- a/dynamiq/nodes/tools/function_tool.py
+++ b/dynamiq/nodes/tools/function_tool.py
@@ -104,7 +104,7 @@ Examples:
         return {
             "name": self.name,
             "description": self.description,
-            "input_schema": input_model.schema(),
+            "input_schema": input_model.model_json_schema(),
             "output_schema": {
                 "type": "object",
                 "properties": {"content": {"type": "any"}},


### PR DESCRIPTION
## PR Summary
This small PR resolves the Pydantic deprecation warnings which you can find in the [CI logs](https://github.com/dynamiq-ai/dynamiq/actions/runs/16680788932/job/47218842540#step:7:454):
```python
/app/dynamiq/nodes/node.py:271: PydanticDeprecatedSince20: The `__fields__` attribute is deprecated, use `model_fields` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
/app/dynamiq/nodes/node.py:282: PydanticDeprecatedSince20: The `schema` method is deprecated; use `model_json_schema` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Pydantic deprecation warnings by updating deprecated methods and attributes in `node.py` and `function_tool.py`.
> 
>   - **Deprecation Fixes**:
>     - In `node.py`, replace `__fields__` with `model_fields` and `schema()` with `model_json_schema()` in `_generate_json_schema()`.
>     - In `function_tool.py`, replace `schema()` with `model_json_schema()` in `get_schema()`.
>   - **Misc**:
>     - Update Pydantic usage to avoid deprecation warnings in preparation for Pydantic V3.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 5587f3da6d5f3ee91ad1a85041577bdb782d9d5c. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->