### PR TITLE
fix: truncation bug

### DIFF
--- a/dynamiq/memory/backends/pinecone.py
+++ b/dynamiq/memory/backends/pinecone.py
@@ -86,6 +86,7 @@ class Pinecone(MemoryBackend):
             original_length = len(content)
             max_chars = self.max_message_tokens * CHARS_PER_TOKEN
             if original_length > max_chars:
+                content = content[:max_chars]
                 metadata["truncated"] = True
                 metadata["original_length"] = original_length
                 metadata["truncated_length"] = max_chars

--- a/dynamiq/memory/backends/qdrant.py
+++ b/dynamiq/memory/backends/qdrant.py
@@ -82,6 +82,7 @@ class Qdrant(MemoryBackend):
             original_length = len(content)
             max_chars = self.max_message_tokens * CHARS_PER_TOKEN
             if original_length > max_chars:
+                content = content[:max_chars]
                 metadata["truncated"] = True
                 metadata["original_length"] = original_length
                 metadata["truncated_length"] = max_chars

--- a/dynamiq/memory/backends/weaviate.py
+++ b/dynamiq/memory/backends/weaviate.py
@@ -132,10 +132,12 @@ class Weaviate(MemoryBackend):
             **(message.metadata or {}),
         }
 
-        if self.message_truncation_enabled and message.content:
-            original_length = len(message.content)
+        content = message.content
+        if self.message_truncation_enabled and content:
+            original_length = len(content)
             max_chars = self.max_message_tokens * CHARS_PER_TOKEN
             if original_length > max_chars:
+                content = content[:max_chars]
                 doc_metadata["truncated"] = True
                 doc_metadata["original_length"] = original_length
                 doc_metadata["truncated_length"] = max_chars
@@ -151,7 +153,7 @@ class Weaviate(MemoryBackend):
 
         return Document(
             id=doc_id,
-            content=message.content,
+            content=content,
             metadata=sanitized_metadata,
             embedding=None,
         )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes truncation bug in `_message_to_document()` in `pinecone.py`, `qdrant.py`, and `weaviate.py` by properly slicing content to max allowed length.
> 
>   - **Behavior**:
>     - Fixes truncation bug in `_message_to_document()` in `pinecone.py`, `qdrant.py`, and `weaviate.py` by slicing `content` to `max_chars` when `original_length` exceeds `max_chars`.
>     - Ensures `metadata` correctly reflects truncation status and lengths.
>   - **Misc**:
>     - No changes to function signatures or additional features added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 005aae4ab013d9ebf118a8618131ce418942bd59. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->