### PR TITLE
fix: include metadata in retrievers

### DIFF
--- a/dynamiq/nodes/retrievers/retriever.py
+++ b/dynamiq/nodes/retrievers/retriever.py
@@ -48,7 +48,7 @@ class VectorStoreRetriever(Node):
     alpha: float = 0.0
 
     input_schema: ClassVar[type[VectorStoreRetrieverInputSchema]] = VectorStoreRetrieverInputSchema
-    _EXCLUDED_METADATA_FIELDS: ClassVar[frozenset[str]] = frozenset({"embedding", "embeddings", "vector", "vectors"})
+    _EXCLUDED_METADATA_FIELDS: ClassVar[tuple[str, ...]] = ("embedding", "embeddings", "vector", "vectors")
 
     def __init__(self, **kwargs):
         """


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `format_content()` in `retriever.py` to include all metadata except specified exclusions when `metadata_fields` is `None`.
> 
>   - **Behavior**:
>     - `format_content()` in `retriever.py` now includes all metadata fields except those in `_EXCLUDED_METADATA_FIELDS` and fields containing "id" if `metadata_fields` is `None`.
>     - Introduces `_EXCLUDED_METADATA_FIELDS` to exclude "embedding", "embeddings", "vector", "vectors" by default.
>   - **Misc**:
>     - Updates docstring for `format_content()` to reflect new behavior when `metadata_fields` is `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 87ff409c793fd33a83322946c9073aeef3ac055f. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->