### PR TITLE
feat: update secret params tracing for memory

### DIFF
--- a/dynamiq/memory/backends/dynamo_db.py
+++ b/dynamiq/memory/backends/dynamo_db.py
@@ -103,6 +103,16 @@ class DynamoDB(MemoryBackend):
     _dynamodb_table: Any = PrivateAttr(default=None)
     _dynamodb_client: Any = PrivateAttr(default=None)
 
+    @property
+    def to_dict_exclude_params(self):
+        """Define parameters to exclude when converting the class instance to a dictionary."""
+        return super().to_dict_exclude_params | {
+            "connection": {
+                "access_key_id": True,
+                "secret_access_key": True,
+            }
+        }
+
     def to_dict(self, include_secure_params: bool = False, **kwargs) -> dict[str, Any]:
         exclude = kwargs.pop("exclude", self.to_dict_exclude_params.copy())
         data = self.model_dump(exclude=exclude, **kwargs)

--- a/dynamiq/memory/backends/pinecone.py
+++ b/dynamiq/memory/backends/pinecone.py
@@ -44,7 +44,13 @@ class Pinecone(MemoryBackend):
     @property
     def to_dict_exclude_params(self):
         """Define parameters to exclude when converting the class instance to a dictionary."""
-        return super().to_dict_exclude_params | {"embedder": True, "vector_store": True}
+        return super().to_dict_exclude_params | {
+            "embedder": True,
+            "vector_store": True,
+            "connection": {
+                "api_key": True,
+            },
+        }
 
     def to_dict(self, include_secure_params: bool = False, **kwargs) -> dict:
         """Converts the instance to a dictionary."""

--- a/dynamiq/memory/backends/postgresql.py
+++ b/dynamiq/memory/backends/postgresql.py
@@ -53,7 +53,13 @@ class PostgreSQL(MemoryBackend):
     @property
     def to_dict_exclude_params(self) -> dict[str, bool]:
         """Define parameters to exclude during serialization."""
-        return super().to_dict_exclude_params | {"_conn": True, "_is_closed": True}
+        return super().to_dict_exclude_params | {
+            "_conn": True,
+            "_is_closed": True,
+            "connection": {
+                "password": True,
+            },
+        }
 
     def to_dict(self, include_secure_params: bool = False, **kwargs) -> dict[str, Any]:
         """Converts the instance to a dictionary."""

--- a/dynamiq/memory/backends/postgresql.py
+++ b/dynamiq/memory/backends/postgresql.py
@@ -58,6 +58,8 @@ class PostgreSQL(MemoryBackend):
             "_is_closed": True,
             "connection": {
                 "password": True,
+                "host": True,
+                "user": True,
             },
         }
 

--- a/dynamiq/memory/backends/qdrant.py
+++ b/dynamiq/memory/backends/qdrant.py
@@ -43,7 +43,13 @@ class Qdrant(MemoryBackend):
     @property
     def to_dict_exclude_params(self):
         """Define parameters to exclude when converting the class instance to a dictionary."""
-        return super().to_dict_exclude_params | {"embedder": True, "vector_store": True}
+        return super().to_dict_exclude_params | {
+            "embedder": True,
+            "vector_store": True,
+            "connection": {
+                "api_key": True,
+            },
+        }
 
     def to_dict(self, include_secure_params: bool = False, **kwargs) -> dict:
         """Converts the instance to a dictionary."""

--- a/dynamiq/memory/backends/weaviate.py
+++ b/dynamiq/memory/backends/weaviate.py
@@ -65,6 +65,9 @@ class Weaviate(MemoryBackend):
         return super().to_dict_exclude_params | {
             "embedder": True,
             "_vector_store": True,
+            "connection": {
+                "api_key": True,
+            },
         }
 
     def to_dict(self, include_secure_params: bool = False, **kwargs) -> dict[str, Any]:

--- a/dynamiq/memory/backends/weaviate.py
+++ b/dynamiq/memory/backends/weaviate.py
@@ -67,6 +67,9 @@ class Weaviate(MemoryBackend):
             "_vector_store": True,
             "connection": {
                 "api_key": True,
+                "url": True,
+                "http_host": True,
+                "grpc_host": True,
             },
         }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `to_dict_exclude_params` in memory backends to exclude secure connection parameters during serialization.
> 
>   - **Behavior**:
>     - Update `to_dict_exclude_params` in `DynamoDB`, `Pinecone`, `PostgreSQL`, `Qdrant`, and `Weaviate` classes to exclude secure connection parameters during serialization.
>     - Excludes parameters like `access_key_id`, `secret_access_key`, `api_key`, `password`, `host`, `user`, `url`, `http_host`, and `grpc_host`.
>   - **Files**:
>     - `dynamo_db.py`: Excludes `access_key_id` and `secret_access_key`.
>     - `pinecone.py`, `qdrant.py`: Excludes `api_key`.
>     - `postgresql.py`: Excludes `password`, `host`, `user`.
>     - `weaviate.py`: Excludes `api_key`, `url`, `http_host`, `grpc_host`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for bda00ea5571888296d11b74b1ecdabfc5c21a288. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->