### PR TITLE
fix: prevent race conditions in Map node parallel execution

### DIFF
--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -917,9 +917,6 @@ class Agent(Node):
         cleaned = re.sub(r"\n{3,}", "\n\n", prompt_text)
         return cleaned.strip()
 
-    def get_clone_init_attrs(self) -> list[str]:
-        return super().get_clone_init_attrs() + ["_prompt"]
-
     def get_clone_attr_initializers(self) -> dict[str, Callable[[Node], Any]]:
         base = super().get_clone_attr_initializers()
         from dynamiq.prompts import Prompt

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -917,6 +917,20 @@ class Agent(Node):
         cleaned = re.sub(r"\n{3,}", "\n\n", prompt_text)
         return cleaned.strip()
 
+    def get_clone_reset_attrs(self) -> list[str]:
+        return super().get_clone_reset_attrs() + ["_prompt"]
+
+    def get_clone_attr_initializers(self) -> dict[str, Callable[[Node], Any]]:
+        base = super().get_clone_attr_initializers()
+        from dynamiq.prompts import Prompt
+
+        base.update(
+            {
+                "_prompt": (lambda _self: Prompt(messages=[]) if Prompt else None),
+            }
+        )
+        return base
+
 
 class AgentManagerInputSchema(BaseModel):
     action: str = Field(..., description="Parameter to provide action to the manager")

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -917,8 +917,8 @@ class Agent(Node):
         cleaned = re.sub(r"\n{3,}", "\n\n", prompt_text)
         return cleaned.strip()
 
-    def get_clone_reset_attrs(self) -> list[str]:
-        return super().get_clone_reset_attrs() + ["_prompt"]
+    def get_clone_init_attrs(self) -> list[str]:
+        return super().get_clone_init_attrs() + ["_prompt"]
 
     def get_clone_attr_initializers(self) -> dict[str, Callable[[Node], Any]]:
         base = super().get_clone_attr_initializers()

--- a/dynamiq/nodes/agents/react.py
+++ b/dynamiq/nodes/agents/react.py
@@ -880,8 +880,8 @@ class ReActAgent(Agent):
             logger.info(f"Agent {self.name} - {self.id}: Summarization of tool output finished.")
             return summary_offset
 
-    def get_clone_reset_attrs(self) -> list[str]:
-        return super().get_clone_reset_attrs() + ["_tool_cache"]
+    def get_clone_init_attrs(self) -> list[str]:
+        return super().get_clone_init_attrs() + ["_tool_cache"]
 
     def get_clone_attr_initializers(self) -> dict[str, Callable[[Node], Any]]:
         base = super().get_clone_attr_initializers()

--- a/dynamiq/nodes/agents/react.py
+++ b/dynamiq/nodes/agents/react.py
@@ -880,9 +880,6 @@ class ReActAgent(Agent):
             logger.info(f"Agent {self.name} - {self.id}: Summarization of tool output finished.")
             return summary_offset
 
-    def get_clone_init_attrs(self) -> list[str]:
-        return super().get_clone_init_attrs() + ["_tool_cache"]
-
     def get_clone_attr_initializers(self) -> dict[str, Callable[[Node], Any]]:
         base = super().get_clone_attr_initializers()
         base.update(

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -529,10 +529,6 @@ class Node(BaseModel, Runnable, ABC):
         """List of method names to call on the clone to reset per-run state."""
         return list(self._clone_init_methods_names)
 
-    def get_clone_init_attrs(self) -> list[str]:
-        """List of attribute names to re-initialize on the clone."""
-        return []
-
     def get_clone_attr_initializers(self) -> dict[str, Callable[["Node"], Any]]:
         """Mapping of attribute name -> initializer callable(node) -> value.
 
@@ -564,10 +560,9 @@ class Node(BaseModel, Runnable, ABC):
                     pass  # nosec
 
         init_map = self.get_clone_attr_initializers()
-        for attr_name in self.get_clone_init_attrs():
+        for attr_name, init_fn in init_map.items():
             try:
                 if hasattr(clone_node, attr_name):
-                    init_fn = init_map.get(attr_name)
                     value = init_fn(clone_node) if callable(init_fn) else None
                     if value is not None:
                         setattr(clone_node, attr_name, value)

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -556,8 +556,7 @@ class Node(BaseModel, Runnable, ABC):
                 try:
                     setattr(clone_node, _field_name, _new_val)
                 except Exception as e:
-                    logger.warning(f"Clone: unable to set field '{_field_name}' during nested clone: {e}")  # nosec
-                    pass  # nosec
+                    logger.warning(f"Clone: unable to set field '{_field_name}' during nested clone: {e}")
 
         init_map = self.get_clone_attr_initializers()
         for attr_name, init_fn in init_map.items():
@@ -570,11 +569,9 @@ class Node(BaseModel, Runnable, ABC):
                         try:
                             setattr(clone_node, attr_name, None)
                         except Exception as e:
-                            logger.warning(f"Clone: failed to set attr '{attr_name}': {e}")  # nosec
-                            pass  # nosec
+                            logger.warning(f"Clone: failed to set attr '{attr_name}': {e}")
             except Exception as e:
-                logger.warning(f"Clone: initializer for attr '{attr_name}' failed: {e}")  # nosec
-                pass
+                logger.warning(f"Clone: initializer for attr '{attr_name}' failed: {e}")
 
         for method_name in self.get_clone_init_methods_names():
             try:
@@ -582,8 +579,7 @@ class Node(BaseModel, Runnable, ABC):
                 if callable(method):
                     method()
             except Exception as e:
-                logger.warning(f"Clone: method '{method_name}' invocation failed: {e}")  # nosec
-                pass  # nosec
+                logger.warning(f"Clone: method '{method_name}' invocation failed: {e}")
 
         return clone_node
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Implements node cloning and ID regeneration to prevent race conditions in parallel execution of Map nodes.
> 
>   - **Behavior**:
>     - Implements `clone()` method in `Node` class to create safe clones of nodes, ensuring unique instances for parallel execution.
>     - Adds `regenerate_ids()` method in `Map` class to assign new IDs to cloned nodes and their components.
>     - Updates `execute_workflow()` in `Map` to use cloned nodes with regenerated IDs, preventing race conditions.
>   - **Functions**:
>     - Adds `get_clone_attr_initializers()` in `base.py` and `react.py` to initialize attributes for cloned nodes.
>     - Adds `get_clone_init_methods_names()` in `node.py` to specify methods for resetting cloned node state.
>   - **Misc**:
>     - Minor import adjustments in `react.py` and `operators.py` to support new functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for eb3273693512f54ac7b06cb3ca668860b8c846a5. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->