### PR TITLE
fix: bug in filereadtool

### DIFF
--- a/dynamiq/nodes/tools/file_tools.py
+++ b/dynamiq/nodes/tools/file_tools.py
@@ -132,9 +132,9 @@ class FileReadTool(Node):
         last_chunk = content[-chunk_size:] if total_size > chunk_size else content
 
         separator = f"\n\n--- CHUNKED FILE: {file_path} ({total_size:,} bytes total) ---\n".encode()
-        first_sep = f"\n--- FIRST {len():,} BYTES ---\n".encode()
-        middle_sep = f"\n--- MIDDLE {len():,} BYTES (from position {middle_start:,}) ---\n".encode()
-        last_sep = f"\n--- LAST {len():,} BYTES ---\n".encode()
+        first_sep = f"\n--- FIRST {len(first_chunk):,} BYTES ---\n".encode()
+        middle_sep = f"\n--- MIDDLE {len(middle_chunk):,} BYTES (from position {middle_start:,}) ---\n".encode()
+        last_sep = f"\n--- LAST {len(last_chunk):,} BYTES ---\n".encode()
 
         chunked_bytes = (
             separator


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes incorrect `len()` usage in `FileReadTool._create_chunked_content` for chunk length display in `file_tools.py`.
> 
>   - **Bug Fix**:
>     - Corrected `len()` usage in `_create_chunked_content` method of `FileReadTool` in `file_tools.py`.
>     - Fixed chunk length display in `first_sep`, `middle_sep`, and `last_sep` strings by using `len(first_chunk)`, `len(middle_chunk)`, and `len(last_chunk)` respectively.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for fbf34fa85273420e596dded6ed1b718f352a8818. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->