### PR TITLE
chore: remove truncate metadata from traces

### DIFF
--- a/tests/integration/nodes/embedders/test_embedding_tracing.py
+++ b/tests/integration/nodes/embedders/test_embedding_tracing.py
@@ -59,15 +59,6 @@ def test_workflow_with_openai_text_embedder(mock_embedding_executor_truncate_tra
     openai_run = tracing_runs[2]
     assert openai_run.parent_run_id == flow_run.id
     assert openai_run.input == input
-    assert openai_run.metadata["truncated"] == {
-        "input": {},
-        "output": {
-            "embedding": {
-                "original_length": 30,
-                "truncated_length": 20,
-            }
-        },
-    }
     assert (
         openai_run.output
         == format_value({"query": "I love pizza!", **mock_embedding_tracing_output}, truncate_enabled=True)[0]
@@ -145,15 +136,6 @@ def test_workflow_with_openai_document_embedder(mock_embedding_executor_truncate
     assert flow_run.status == RunStatus.SUCCEEDED
     openai_run = tracing_runs[2]
     assert openai_run.parent_run_id == flow_run.id
-    assert openai_run.metadata["truncated"] == {
-        "input": {},
-        "output": {
-            "documents[0].embedding": {
-                "original_length": 30,
-                "truncated_length": 20,
-            }
-        },
-    }
     embedder_tracing_output = {
         **input,
         "meta": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove truncation metadata handling from tracing logic and update related tests.
> 
>   - **Behavior**:
>     - Removed truncation metadata handling from `Run` and `ExecutionRun` in `tracing.py`.
>     - Updated `format_value` calls to only return formatted input/output without truncation metadata.
>   - **Tests**:
>     - Removed assertions related to truncation metadata in `test_workflow_with_openai_text_embedder` and `test_workflow_with_openai_document_embedder` in `test_embedding_tracing.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 10d93a3486a1eb8aa9fedc93d862c9e6f0f61560. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->