### PR TITLE
fix: file download extensions

### DIFF
--- a/dynamiq/nodes/tools/e2b_sandbox.py
+++ b/dynamiq/nodes/tools/e2b_sandbox.py
@@ -640,8 +640,6 @@ class E2BInterpreterTool(ConnectionNode):
         """
         try:
             collected_files = {}
-            extensions = ["csv", "xlsx", "xls", "txt", "json", "png", "jpg", "jpeg", "gif", "pdf", "html", "md"]
-            patterns = " -o ".join([f"-name '*.{ext}'" for ext in extensions])
 
             search_dirs = ["/home/user/output"]
 
@@ -659,7 +657,7 @@ class E2BInterpreterTool(ConnectionNode):
                 max_depth = "3"  # Allow deeper search in /home/user/output directory
                 cmd = (
                     f"cd {shlex.quote(search_dir)} && find . -maxdepth {max_depth} "
-                    f"-type f \\( {patterns} \\) -printf '%P\\n' 2>/dev/null | head -20"
+                    f"-type f -printf '%P\\n' 2>/dev/null | head -20"
                 )
                 res = sandbox.commands.run(cmd)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `_collect_output_files` in `e2b_sandbox.py` now collects all files from `/home/user/output` without filtering by extension.
> 
>   - **Behavior**:
>     - `_collect_output_files` in `e2b_sandbox.py` now collects all files from `/home/user/output` without filtering by extension.
>   - **Code Removal**:
>     - Removed `extensions` list and `patterns` string construction from `_collect_output_files` in `e2b_sandbox.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for ca5a592fc2066173f7beb922583cec62b4f80ffa. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->