### PR TITLE
feat: add session id to tracing data for E2B tool

### DIFF
--- a/dynamiq/callbacks/tracing.py
+++ b/dynamiq/callbacks/tracing.py
@@ -477,8 +477,8 @@ class TracingCallbackHandler(BaseModel, BaseCallbackHandler):
         if prompt_messages := kwargs.get("prompt_messages"):
             run.metadata["node"]["prompt"]["messages"] = prompt_messages
 
-        if session_id := kwargs.get("session_id"):
-            run.metadata["session_id"] = session_id
+        if tool_data := kwargs.get("tool_data"):
+            run.metadata["tool_data"] = tool_data
 
     def flush(self):
         """Flush the runs to the tracing client."""

--- a/dynamiq/nodes/tools/e2b_sandbox.py
+++ b/dynamiq/nodes/tools/e2b_sandbox.py
@@ -690,10 +690,10 @@ class E2BInterpreterTool(ConnectionNode):
             if self.files:
                 self._upload_files(files=self.files, sandbox=sandbox)
 
-        session_id = sandbox.sandbox_id
+        tool_data = {"tool_session_id": sandbox.sandbox_id, "tool_session_url": sandbox.envd_api_url}
         self.run_on_node_execute_run(
             config.callbacks,
-            session_id=session_id,
+            tool_data=tool_data,
             **kwargs,
         )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add session ID to tracing data for E2B tool by updating `on_node_execute_run()` and `execute()` functions.
> 
>   - **Behavior**:
>     - Add `tool_data` to `run.metadata` in `on_node_execute_run()` in `tracing.py`.
>     - Pass `tool_data` with `tool_session_id` and `tool_session_url` in `execute()` in `e2b_sandbox.py`.
>   - **Misc**:
>     - Remove redundant call to `run_on_node_execute_run()` in `execute()` in `e2b_sandbox.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 63daa6e79e827067c49754b9408f553dbf64c06b. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->