### PR TITLE
feat: update url setup in DynamiqTracingClient

### DIFF
--- a/dynamiq/clients/dynamiq.py
+++ b/dynamiq/clients/dynamiq.py
@@ -38,8 +38,8 @@ class HttpClientError(HttpBaseError):
 
 class DynamiqTracingClient(BaseTracingClient):
 
-    def __init__(self, base_url: str = DYNAMIQ_BASE_URL, access_key: str | None = None, timeout: float = 60.0):
-        self.base_url = base_url
+    def __init__(self, base_url: str | None = None, access_key: str | None = None, timeout: float = 60.0):
+        self.base_url = base_url or DYNAMIQ_BASE_URL
         self.access_key = access_key or get_env_var("DYNAMIQ_ACCESS_KEY") or get_env_var("DYNAMIQ_SERVICE_TOKEN")
         if self.access_key is None:
             raise ValueError("No API key provided")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `DynamiqTracingClient` now allows optional `base_url`, defaulting to `DYNAMIQ_BASE_URL`, and handles missing `access_key` with a `ValueError`.
> 
>   - **Behavior**:
>     - `DynamiqTracingClient.__init__()` now accepts `base_url` as `None`, defaulting to `DYNAMIQ_BASE_URL` if not provided.
>     - `access_key` defaults to environment variables `DYNAMIQ_ACCESS_KEY` or `DYNAMIQ_SERVICE_TOKEN` if not provided.
>   - **Error Handling**:
>     - Raises `ValueError` if `access_key` is not provided or found in environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 66c4a87b7d91741adcf569b2eeb8ea0f0520a827. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->