### PR TITLE
feat: add client check and auto reinit

### DIFF
--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -1546,6 +1546,13 @@ class ConnectionNode(Node, ABC):
         Automatically detects closed connections and reinitializes them.
         """
         if self.is_client_closed():
+            if self.connection is None:
+                logger.debug(
+                    f"Node {self.name} - {self.id}: Client connection is closed but no connection available "
+                    f"for reinitialization."
+                )
+                return
+
             logger.warning(f"Node {self.name} - {self.id}: Client connection is closed. Reinitializing")
             connection_manager = self._connection_manager or ConnectionManager()
 
@@ -1630,6 +1637,13 @@ class VectorStoreNode(ConnectionNode, BaseVectorStoreParams, ABC):
         Automatically detects closed connections and reinitializes them.
         """
         if self.is_client_closed():
+            if self.connection is None:
+                logger.debug(
+                    f"Node {self.name} - {self.id}: Vector store client connection is closed but no connection "
+                    f"available for reinitialization."
+                )
+                return
+
             logger.warning(f"Node {self.name} - {self.id}: Vector store client connection is closed. Reinitializing")
             connection_manager = self._connection_manager or ConnectionManager()
 

--- a/tests/unit/nodes/test_connection_management.py
+++ b/tests/unit/nodes/test_connection_management.py
@@ -203,6 +203,18 @@ def test_ensure_client_uses_cached_connection_manager(connection_node_instance, 
     )
 
 
+def test_ensure_client_skips_reinitialization_when_no_connection(connection_node_instance, mock_connection_manager):
+    """Test that ensure_client doesn't attempt reinitialization when connection is None."""
+    connection_node_instance.client = MockClosedClient(closed=True)
+    connection_node_instance.connection = None
+
+    # Should not raise an error, just skip reinitialization
+    connection_node_instance.ensure_client()
+
+    # Should not attempt to call connection manager
+    mock_connection_manager.get_connection_client.assert_not_called()
+
+
 # Tests for VectorStoreNode
 @pytest.mark.parametrize(
     "client,expected_result,test_id",
@@ -248,6 +260,20 @@ def test_vector_store_node_ensure_client_reinitializes_both_client_and_vector_st
     # Should have reinitialized vector store
     assert vector_store_node_instance.vector_store is not None
     assert vector_store_node_instance.client == new_client
+
+
+def test_vector_store_node_ensure_client_skips_reinitialization_when_no_connection(
+    vector_store_node_instance, mock_connection_manager
+):
+    """Test that VectorStoreNode ensure_client doesn't attempt reinitialization when connection is None."""
+    vector_store_node_instance.vector_store.client = MockClosedClient(closed=True)
+    vector_store_node_instance.connection = None
+
+    # Should not raise an error, just skip reinitialization
+    vector_store_node_instance.ensure_client()
+
+    # Should not attempt to call connection manager
+    mock_connection_manager.get_connection_client.assert_not_called()
 
 
 def test_execute_with_retry_calls_ensure_client_before_execution(connection_node_instance, mocker, success_result):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances client connection management in `ConnectionNode` and `VectorStoreNode` with automatic reconnection and adds unit tests for these features.
> 
>   - **Behavior**:
>     - Adds `ensure_client()` to `ConnectionNode` and `VectorStoreNode` for automatic reconnection if client is closed.
>     - `execute_with_retry()` in `node.py` now calls `ensure_client()` before execution.
>   - **Connection Management**:
>     - `is_client_closed()` checks client connection status in `ConnectionNode` and `VectorStoreNode`.
>     - `init_components()` caches `ConnectionManager` in `ConnectionNode` and `VectorStoreNode`.
>   - **Testing**:
>     - New tests in `test_connection_management.py` for `ensure_client()` and `is_client_closed()` behaviors.
>     - Tests cover scenarios for closed, open, and non-existent clients, and reconnection logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 4f07bb44ba6f20607966ac35c70f6f38401a4b89. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds automatic client reconnection for `ConnectionNode`/`VectorStoreNode` and integrates connection checks into `execute_with_retry`, with unit tests.
> 
> - **Core runtime**:
>   - `Node.execute_with_retry`: ensures client before each attempt; retries on connection check/init failures with backoff and logs; supports timeout path.
>   - `Node.ensure_client()`: new hook (no-op) for subclasses to manage connections.
> - **Connection management**:
>   - `ConnectionNode`:
>     - Cache `ConnectionManager` in `_connection_manager` via `init_components`.
>     - Add `is_client_closed()` and `ensure_client()` to auto-reinit `client`; raise `ConnectionManagerException` on failure.
>   - `VectorStoreNode`:
>     - Cache `ConnectionManager`; prefer existing `vector_store.client`.
>     - Extend `is_client_closed()` to check `vector_store.client`.
>     - `ensure_client()`: reinit `client` with `init_type=VECTOR_STORE` and rebuild `vector_store`.
> - **Tests**:
>   - Add `tests/unit/nodes/test_connection_management.py` covering client closed detection, reconnection flows, retry behavior in `execute_with_retry`, and connection manager caching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f07bb44ba6f20607966ac35c70f6f38401a4b89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->