### PR TITLE
feat: update prefix for watsonx models

### DIFF
--- a/dynamiq/nodes/llms/watsonx.py
+++ b/dynamiq/nodes/llms/watsonx.py
@@ -12,7 +12,7 @@ class WatsonX(BaseLLM):
         MODEL_PREFIX (str): The prefix for the WatsonX model name.
     """
     connection: WatsonXConnection | None = None
-    MODEL_PREFIX = "watsonx_text/"
+    MODEL_PREFIX = "watsonx/"
 
     def __init__(self, **kwargs):
         """Initialize the WatsonX LLM node.

--- a/tests/integration/nodes/llms/test_watsonx.py
+++ b/tests/integration/nodes/llms/test_watsonx.py
@@ -42,8 +42,8 @@ def get_watsonx_workflow(
 @pytest.mark.parametrize(
     ("model", "expected_model"),
     [
-        ("watsonx_text/ibm/granite-13b-chat-v2", "watsonx_text/ibm/granite-13b-chat-v2"),
-        ("ibm/granite-13b-chat-v2", "watsonx_text/ibm/granite-13b-chat-v2"),
+        ("watsonx/ibm/granite-13b-chat-v2", "watsonx/ibm/granite-13b-chat-v2"),
+        ("ibm/granite-13b-chat-v2", "watsonx/ibm/granite-13b-chat-v2"),
     ],
 )
 def test_workflow_with_watsonx_ai(mock_llm_response_text, mock_llm_executor, model, expected_model):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches WatsonX model prefix from "watsonx_text/" to "watsonx/" and updates integration tests to match.
> 
> - **LLM Node (`WatsonX`)**:
>   - Update `MODEL_PREFIX` in `dynamiq/nodes/llms/watsonx.py` from `"watsonx_text/"` to `"watsonx/"`.
> - **Tests**:
>   - Adjust parametrized models in `tests/integration/nodes/llms/test_watsonx.py` to use `"watsonx/"` prefix and expected values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f6b01db7eef91de0be5a41b4c65bfdd3e99eba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `MODEL_PREFIX` for WatsonX models and adjust test cases accordingly.
> 
>   - **Behavior**:
>     - Update `MODEL_PREFIX` in `WatsonX` class in `watsonx.py` from `"watsonx_text/"` to `"watsonx/"`.
>   - **Tests**:
>     - Update test cases in `test_watsonx.py` to use the new model prefix `"watsonx/"` instead of `"watsonx_text/"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 7f6b01db7eef91de0be5a41b4c65bfdd3e99eba9. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->