### PR TITLE
ci: increase allowed PR title length

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: deepakputhraya/action-pr-title@v1.0.2
         with:
           prefix_case_sensitive: true
-          max_length: 64
+          max_length: 255


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase PR title length limit in the PR lint workflow from 64 to 255.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 523a0add59891ca181eea64a005f936b48a1ee1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->