### PR TITLE
fix: client reinit

### DIFF
--- a/dynamiq/connections/managers.py
+++ b/dynamiq/connections/managers.py
@@ -17,12 +17,10 @@ class ConnectionManagerException(Exception):
 class ConnectionClientInitType(str, enum.Enum):
     """Enumeration of connection client initialization types."""
     DEFAULT = "DEFAULT"
-    VECTOR_STORE = "VECTOR_STORE"
 
 
 CONNECTION_METHOD_BY_INIT_TYPE = {
     ConnectionClientInitType.DEFAULT: "connect",
-    ConnectionClientInitType.VECTOR_STORE: "connect_to_vector_store",
 }
 
 

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, computed_field, 
 from dynamiq.cache.utils import cache_wf_entity
 from dynamiq.callbacks import BaseCallbackHandler, NodeCallbackHandler, TracingCallbackHandler
 from dynamiq.connections import BaseConnection
-from dynamiq.connections.managers import ConnectionClientInitType, ConnectionManager, ConnectionManagerException
+from dynamiq.connections.managers import ConnectionManager, ConnectionManagerException
 from dynamiq.nodes.dry_run import DryRunMixin
 from dynamiq.nodes.exceptions import (
     NodeConditionFailedException,
@@ -1653,9 +1653,7 @@ class VectorStoreNode(ConnectionNode, BaseVectorStoreParams, ABC):
             connection_manager = self._connection_manager or ConnectionManager()
 
             try:
-                self.client = connection_manager.get_connection_client(
-                    connection=self.connection, init_type=ConnectionClientInitType.VECTOR_STORE
-                )
+                self.client = connection_manager.get_connection_client(connection=self.connection)
                 self.vector_store = self.connect_to_vector_store()
                 logger.info(f"Node {self.name} - {self.id}: Vector store reinitialized successfully")
             except Exception as e:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Drops vector-store-specific client init; nodes now use the default connection client API, with tests updated accordingly.
> 
> - **Connections**:
>   - Remove `ConnectionClientInitType.VECTOR_STORE` and its mapping from `CONNECTION_METHOD_BY_INIT_TYPE`.
>   - `get_connection_client` now effectively uses only `DEFAULT` (`connect`).
> - **Nodes**:
>   - Stop importing/using `ConnectionClientInitType`.
>   - `ConnectionNode.init_components` and `ensure_client` call `ConnectionManager.get_connection_client(connection=...)`.
>   - `VectorStoreNode.ensure_client` reinitializes client via default `get_connection_client` and rebuilds vector store with `connect_to_vector_store()`.
> - **Tests**:
>   - Update imports and expectations to remove `ConnectionClientInitType` usage.
>   - Adjust assertions to match unified client reinit path for `ConnectionNode` and `VectorStoreNode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3e3a8d9d4a19207cb28067f329ac3c80f097e70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `VECTOR_STORE` initialization type from `ConnectionManager` and update related client reinitialization logic.
> 
>   - **Behavior**:
>     - Removed `VECTOR_STORE` from `ConnectionClientInitType` in `managers.py`.
>     - Updated `ensure_client()` in `node.py` to no longer specify `init_type` when calling `get_connection_client()`.
>   - **Tests**:
>     - Updated `test_connection_management.py` to remove `init_type` parameter in `get_connection_client()` calls.
>     - Removed comments related to `VECTOR_STORE` initialization in test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for c3e3a8d9d4a19207cb28067f329ac3c80f097e70. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->