### PR TITLE
fix: tracing client flush on error and skip

### DIFF
--- a/dynamiq/callbacks/tracing.py
+++ b/dynamiq/callbacks/tracing.py
@@ -272,6 +272,8 @@ class TracingCallbackHandler(BaseModel, BaseCallbackHandler):
             "traceback": traceback.format_exc(),
         }
 
+        self.flush()
+
     def on_flow_start(
         self, serialized: dict[str, Any], input_data: dict[str, Any], **kwargs: Any
     ):
@@ -341,6 +343,10 @@ class TracingCallbackHandler(BaseModel, BaseCallbackHandler):
             "traceback": traceback.format_exc(),
         }
 
+        # If parent_run_id is None, the run is the highest in the execution tree
+        if run.parent_run_id is None:
+            self.flush()
+
     def on_node_start(
         self, serialized: dict[str, Any], input_data: dict[str, Any], **kwargs: Any
     ):
@@ -397,6 +403,10 @@ class TracingCallbackHandler(BaseModel, BaseCallbackHandler):
             "traceback": traceback.format_exc(),
         }
 
+        # If parent_run_id is None, the run is the highest in the execution tree
+        if run.parent_run_id is None:
+            self.flush()
+
     def on_node_skip(
         self,
         serialized: dict[str, Any],
@@ -425,6 +435,10 @@ class TracingCallbackHandler(BaseModel, BaseCallbackHandler):
         run.metadata["skip"] = format_value(skip_data)
         if human_feedback:
             run.metadata["human_feedback"] = human_feedback
+
+        # If parent_run_id is None, the run is the highest in the execution tree
+        if run.parent_run_id is None:
+            self.flush()
 
     def on_node_execute_start(
         self, serialized: dict[str, Any], input_data: dict[str, Any], **kwargs: Any

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,13 @@ def mock_tracing_client(mocker):
 
 
 @pytest.fixture
+def mock_tracing_client_with_flush(mocker):
+    mock_client = mocker.Mock(spec=BaseTracingClient)
+    mock_client.trace = mocker.Mock()
+    return mock_client
+
+
+@pytest.fixture
 def mock_redis_backend(mocker, mock_redis):
     yield mocker.patch(
         "dynamiq.cache.backends.RedisCache.from_config",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure tracing data flushes on workflow/flow/node errors and node skips, and update tests to assert flush behavior.
> 
> - **Tracing (`dynamiq/callbacks/tracing.py`)**:
>   - On errors: add `self.flush()` in `on_workflow_error` (always) and in `on_flow_error`/`on_node_error` when `run.parent_run_id is None`.
>   - On skips: add `self.flush()` in `on_node_skip` when `run.parent_run_id is None`.
> - **Tests**:
>   - Add `mock_tracing_client_with_flush` fixture (`tests/conftest.py`).
>   - Update integration tests to pass `TracingCallbackHandler(client=mock_tracing_client_with_flush)` and assert `trace.call_count == 1` and expected flushed run counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f643405a09e9f6d5b17b69323c445d5382246b39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure tracing client flushes data on errors and skips by adding flush calls in `tracing.py` and updating tests to verify this behavior.
> 
>   - **Behavior**:
>     - Adds `self.flush()` in `on_workflow_error`, `on_flow_error`, `on_node_error`, and `on_node_skip` in `tracing.py` to ensure tracing data is flushed on errors and skips.
>     - Flushes only if `parent_run_id` is `None`, indicating the highest run in the execution tree.
>   - **Testing**:
>     - Adds `mock_tracing_client_with_flush` fixture in `conftest.py` to mock tracing client with flush capability.
>     - Updates tests in `test_flow.py` to use `mock_tracing_client_with_flush` and verify flush behavior with assertions on `trace.call_count` and flushed run count.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for f310673c29455cf4134b3e72a081c09f7c1bf556. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->