### PR TITLE
fix: firecrawl search

### DIFF
--- a/examples/components/tools/use_firecrawl_search.py
+++ b/examples/components/tools/use_firecrawl_search.py
@@ -1,5 +1,5 @@
 from dynamiq.connections import Firecrawl
-from dynamiq.nodes.tools.firecrawl_search import FirecrawlSearchTool, SourceNews, SourceWeb
+from dynamiq.nodes.tools.firecrawl_search import FirecrawlSearchTool
 
 
 def basic_search_example():
@@ -27,7 +27,7 @@ def search_with_scrape_example():
         connection=firecrawl_connection,
         is_optimized_for_agents=True,
         limit=3,
-        sources=[SourceWeb(tbs="qdr:w"), SourceNews()],
+        sources=[{"type": "web"}],
         categories=["github"],
         country="US",
     )

--- a/tests/integration/nodes/tools/test_firecrawl_search.py
+++ b/tests/integration/nodes/tools/test_firecrawl_search.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dynamiq.connections import Firecrawl
-from dynamiq.nodes.tools.firecrawl_search import FirecrawlSearchTool, SourceImages, SourceNews, SourceWeb
+from dynamiq.nodes.tools.firecrawl_search import FirecrawlSearchTool
 from dynamiq.runnables import RunnableResult, RunnableStatus
 
 
@@ -106,7 +106,11 @@ def test_firecrawl_search_with_overrides(mock_firecrawl_search_requests_scrape, 
     input_data = {
         "query": "firecrawl web scraping",
         "limit": 3,
-        "sources": [SourceWeb(tbs="qdr:w"), SourceNews(), SourceImages()],
+        "sources": [
+            {"type": "web", "tbs": "qdr:w"},
+            {"type": "news"},
+            {"type": "images"},
+        ],
         "categories": ["github"],
         "location": "Germany",
         "tbs": "qdr:d",
@@ -154,3 +158,15 @@ def test_firecrawl_search_agent_output(mock_firecrawl_search_requests, mock_fire
     assert "https://www.firecrawl.dev/" in content
     assert "News Results" in content
     assert "Image Results" in content
+
+
+def test_firecrawl_sources_as_strings(mock_firecrawl_search_requests):
+    connection = Firecrawl(api_key="test_key")
+    tool = FirecrawlSearchTool(connection=connection)
+
+    input_data = {"query": "firecrawl", "sources": ["web", "news"]}
+    result = tool.run(input_data, None)
+
+    assert result.status == RunnableStatus.SUCCESS
+    payload = mock_firecrawl_search_requests.call_args[1]["json"]
+    assert payload["sources"] == [{"type": "web"}, {"type": "news"}]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Accepts `sources` as strings or dicts, adds normalization/validation, and updates payload building, examples, and tests.
> 
> - **Firecrawl Search Tool**:
>   - Replace Pydantic source models with flexible `sources` input (`list[str | dict]`), defaulting to `['web']`.
>   - Add `_normalize_sources` to coerce strings to dicts, drop `None` fields, and validate against `ALLOWED_SOURCE_TYPES` (`web`, `news`, `images`).
>   - Update payload construction to use normalized `sources`; extend input schema and constants accordingly.
> - **Examples/Tests**:
>   - Update example usage to pass `sources` as dicts/strings.
>   - Adjust integration tests for new `sources` format and defaults; add test verifying string `sources` normalize to `[{'type': 'web'}, {'type': 'news'}]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 618b44e67152469aa9e0c698655f0656ad3d60e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `FirecrawlSearchTool` to simplify source type handling by accepting strings or dicts, updating examples and tests accordingly.
> 
>   - **Behavior**:
>     - Refactor `sources` in `FirecrawlSearchTool` to accept list of strings or dicts, simplifying source type handling.
>     - Add `_normalize_sources()` to ensure sources are dicts with allowed types.
>     - Remove `SourceWeb`, `SourceImages`, `SourceNews` classes and `SourceType` union.
>   - **Examples**:
>     - Update `use_firecrawl_search.py` to use new `sources` format.
>   - **Tests**:
>     - Update `test_firecrawl_search.py` to test new `sources` format and ensure backward compatibility with string inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 618b44e67152469aa9e0c698655f0656ad3d60e1. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->