### PR TITLE
fix: simplify tool input schemas

### DIFF
--- a/dynamiq/nodes/tools/exa_search.py
+++ b/dynamiq/nodes/tools/exa_search.py
@@ -231,8 +231,7 @@ class ExaInputSchema(BaseModel):
     include_full_content: bool | None = Field(
         default=None,
         description=(
-            "Shortcut flag: True requests default text/highlight/summary payloads for each result "
-            "(equivalent to ContentsRequest with simple booleans)."
+            "Shortcut flag: True requests default text/highlight/summary payloads for each result"
         ),
     )
     use_autoprompt: bool | None = Field(
@@ -297,6 +296,7 @@ class ExaInputSchema(BaseModel):
             "Return all page contents concatenated into a single context string. True uses defaults; provide "
             "ContextOptions to set a maxCharacters budget (Exa recommends >=10000)."
         ),
+        json_schema_extra={"is_accessible_to_agent": False},
     )
     moderation: bool | None = Field(
         default=None,
@@ -308,6 +308,7 @@ class ExaInputSchema(BaseModel):
             "Full customization of Exa's contents payload (text/highlights/summary/livecrawl/subpages/extras/context). "
             "Use this when include_full_content is insufficient."
         ),
+        json_schema_extra={"is_accessible_to_agent": False},
     )
 
 

--- a/dynamiq/nodes/tools/firecrawl_search.py
+++ b/dynamiq/nodes/tools/firecrawl_search.py
@@ -12,30 +12,22 @@ from dynamiq.runnables import RunnableConfig
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_FIRECRAWL_SEARCH = """Search the web with Firecrawl across web, news, and image verticals.
-
 What it does:
 - Returns SERP results with geo/time filters and category biasing (github/research/pdf)
 - Lets you control result count, recency, geo bias, timeout, and URL validation in one call
-
 Parameters (FirecrawlSearchInput):
 - `query` (required): search string.
 - `limit` (1-100): max results to return (default 5).
-- `sources` (list of objects): choose verticals with optional per-source settings:
-  - Web: {"type":"web","tbs":"qdr:d","location":"San Francisco,California,United States"}
-  - News: {"type":"news"}
-  - Images: {"type":"images"}
 - `categories` (list): bias results toward content types, e.g., ["github","research","pdf"].
 - `tbs`: time filter (qdr:h/d/w/m/y or custom ranges like cdr:1,cd_min:MM/DD/YYYY,cd_max:MM/DD/YYYY).
 - `location`: city/state/country string for geo bias.
 - `country`: ISO country code for geo targeting (e.g., "US").
 - `timeout`: request timeout in milliseconds (default 60000).
 - `ignoreInvalidURLs`: true to drop invalid links from the response.
-
 Examples:
 {"query": "firecrawl docs", "limit": 5}
-{"query": "openai funding", "sources": [{"type": "news"}], "limit": 3}
-{"query": "sunset wallpaper imagesize:1920x1080", "sources": [{"type": "images"}], "limit": 5}
-{"query": "langchain github", "categories": ["github"], "tbs": "qdr:w"}"""
+{"query": "openai funding",  "limit": 3}
+{"query": "dynamiq github", "categories": ["github"], "tbs": "qdr:w"}"""
 
 
 class SourceWeb(BaseModel):
@@ -70,7 +62,9 @@ class FirecrawlSearchInput(BaseModel):
     query: str = Field(..., description="Search query to execute on Firecrawl.")
     limit: int | None = Field(default=None, ge=1, le=100, description="Maximum number of search results to return.")
     sources: list[SourceType] | None = Field(
-        default=None, description="Result types to fetch: web/news/images with optional per-source options."
+        default=None,
+        description="Result types to fetch: web/news/images with optional per-source options.",
+        json_schema_extra={"is_accessible_to_agent": False},
     )
     categories: list[CategoryType] | None = Field(
         default=None,

--- a/dynamiq/nodes/tools/tavily.py
+++ b/dynamiq/nodes/tools/tavily.py
@@ -98,6 +98,7 @@ class TavilyInputSchema(BaseModel):
     include_favicon: bool | None = Field(
         default=None,
         description="Include the favicon URL for each result.",
+        json_schema_extra={"is_accessible_to_agent": False},
     )
     include_answer: bool | Literal["basic", "advanced"] | None = Field(
         default=None,
@@ -122,6 +123,7 @@ class TavilyInputSchema(BaseModel):
     use_cache: bool | None = Field(
         default=None,
         description="Use cached Tavily results when available.",
+        json_schema_extra={"is_accessible_to_agent": False},
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Hide advanced parameters from agents in Exa, Firecrawl, and Tavily input schemas; minor description/example cleanups.
> 
> - **Input Schemas (agent exposure reduced)**:
>   - `dynamiq/nodes/tools/exa_search.py`:
>     - Add `json_schema_extra={"is_accessible_to_agent": false}` to `ExaInputSchema.contents` and `ExaInputSchema.context`.
>     - Tweak `include_full_content` description.
>   - `dynamiq/nodes/tools/firecrawl_search.py`:
>     - Add `json_schema_extra={"is_accessible_to_agent": false}` to `FirecrawlSearchInput.sources`.
>     - Streamline `DESCRIPTION_FIRECRAWL_SEARCH` examples.
>   - `dynamiq/nodes/tools/tavily.py`:
>     - Add `json_schema_extra={"is_accessible_to_agent": false}` to `TavilyInputSchema.include_favicon` and `TavilyInputSchema.use_cache`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e3ad92d300aaa830646aa18323818d5ba706c8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplified input schemas for Exa, Firecrawl, and Tavily tools by removing redundant parameters and adding `json_schema_extra` attributes for agent accessibility.
> 
>   - **ExaInputSchema** in `exa_search.py`:
>     - Removed redundant description text in `include_full_content`.
>     - Added `json_schema_extra={"is_accessible_to_agent": False}` to `context` and `contents` fields.
>   - **FirecrawlSearchInput** in `firecrawl_search.py`:
>     - Removed `sources` parameter from examples and description.
>     - Added `json_schema_extra={"is_accessible_to_agent": False}` to `sources` field.
>   - **TavilyInputSchema** in `tavily.py`:
>     - Added `json_schema_extra={"is_accessible_to_agent": False}` to `include_favicon` and `use_cache` fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dynamiq-ai%2Fdynamiq&utm_source=github&utm_medium=referral)<sup> for 9e3ad92d300aaa830646aa18323818d5ba706c8f. You can [customize](https://app.ellipsis.dev/dynamiq-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->