### PR TITLE
feat: add possibility to rewrite method type in HttpApiCall

### DIFF
--- a/dynamiq/nodes/tools/http_api_call.py
+++ b/dynamiq/nodes/tools/http_api_call.py
@@ -109,6 +109,7 @@ class HttpApiCallInputSchema(BaseModel):
     payload_type: RequestPayloadType = Field(default=None, description="Parameter to specify the type of payload data.")
     headers: dict = Field(default={}, description="Parameter to provide headers to the request.")
     params: dict = Field(default={}, description="Parameter to provide GET parameters in URL.")
+    method: HTTPMethod | None = Field(default=None, description="Parameter to specify HTTP method.")
     files: dict[str, io.BytesIO] = Field(
         default={},
         description="Parameter to provide files to the request. Maps parameter names to file paths for file uploads. "
@@ -203,7 +204,7 @@ class HttpApiCall(ConnectionNode):
             raise ValueError("No url provided.")
         headers = input_data.headers
         params = input_data.params
-        method = self.method or self.connection.method
+        method = input_data.method or self.method or self.connection.method
 
         try:
             response = self.client.request(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to request construction that only affects which HTTP verb is sent when `method` is provided.
> 
> **Overview**
> Adds an optional `method` override to `HttpApiCallInputSchema`, allowing callers to choose the HTTP verb per execution.
> 
> Updates `HttpApiCall.execute` to prefer `input_data.method` over the node’s configured `method`/connection default when issuing the request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e1e9cdf8143b5e0c00c6b753f7ac827ed3ded6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->