### PR TITLE
chore: improve conn manager and yaml loader

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,9 +62,6 @@ jobs:
         env:
           SKIP: 'no-commit-to-branch'
 
-      - name: Run conventional commits checker
-        uses: opensource-nepal/commitlint@v1.2.0
-
   test:
     needs:
       - build

--- a/dynamiq/serializers/loaders/yaml.py
+++ b/dynamiq/serializers/loaders/yaml.py
@@ -288,7 +288,7 @@ class WorkflowYAMLLoader:
             try:
                 connection = conn_cls(**conn_init_data)
             except Exception as e:
-                raise WorkflowYAMLLoaderException(f"Connection '{conn_id}' data is invalid. Error: {e}")
+                raise WorkflowYAMLLoaderException(f"Connection '{conn_id}' data is invalid. Error: {str(e) or repr(e)}")
 
             connections[conn_id] = connection
 
@@ -329,7 +329,9 @@ class WorkflowYAMLLoader:
         try:
             connection = conn_cls(**conn_init_data)
         except Exception as e:
-            raise WorkflowYAMLLoaderException(f"Inline connection for node '{node_id}' data is invalid. Error: {e}")
+            raise WorkflowYAMLLoaderException(
+                f"Inline connection for node '{node_id}' data is invalid. Error: {str(e) or repr(e)}"
+            )
 
         return connection
 
@@ -350,7 +352,9 @@ class WorkflowYAMLLoader:
         try:
             return Prompt(**prompt_init_data)
         except Exception as e:
-            raise WorkflowYAMLLoaderException(f"Prompt '{prompt_init_data.get('id')}' data is invalid. Error: {e}")
+            raise WorkflowYAMLLoaderException(
+                f"Prompt '{prompt_init_data.get('id')}' data is invalid. Error: {str(e) or repr(e)}"
+            )
 
     @classmethod
     def get_prompts(cls, data: dict[str, dict]) -> dict[str, Prompt]:
@@ -555,7 +559,8 @@ class WorkflowYAMLLoader:
                 dependency = NodeDependency(**dependency_init_data)
             except Exception as e:
                 raise WorkflowYAMLLoaderException(
-                    f"Dependency '{dependency_data.get('node')}' data for node '{node_id}' " f"is invalid. Error: {e}"
+                    f"Dependency '{dependency_data.get('node')}' data for node '{node_id}' "
+                    f"is invalid. Error: {str(e) or repr(e)}"
                 )
 
             if dependency.option:
@@ -748,7 +753,7 @@ class WorkflowYAMLLoader:
                 except WorkflowYAMLLoaderException:
                     raise
                 except Exception as e:
-                    raise WorkflowYAMLLoaderException(f"Node '{node_id}' processing failed. Error: {e}")
+                    raise WorkflowYAMLLoaderException(f"Node '{node_id}' processing failed. Error: {str(e) or repr(e)}")
 
         return new_nodes
 
@@ -842,7 +847,8 @@ class WorkflowYAMLLoader:
                 node.is_postponed_component_init = False
 
         except Exception as e:
-            raise WorkflowYAMLLoaderException(f"Node '{node_id}' data is invalid. Error: {e}")
+            logger.exception(f"Node '{node_id}' data is invalid")
+            raise WorkflowYAMLLoaderException(f"Node '{node_id}' data is invalid. Error: {str(e) or repr(e)}")
 
         return node_id, node
 
@@ -1015,7 +1021,7 @@ class WorkflowYAMLLoader:
             try:
                 flow = Flow(**flow_init_data)
             except Exception as e:
-                raise WorkflowYAMLLoaderException(f"Flow '{flow_id}' data is invalid. Error: {e}")
+                raise WorkflowYAMLLoaderException(f"Flow '{flow_id}' data is invalid. Error: {str(e) or repr(e)}")
 
             new_flows[flow_id] = flow
         return new_flows
@@ -1089,7 +1095,7 @@ class WorkflowYAMLLoader:
             try:
                 wf = Workflow(id=wf_id, flow=flow, version=version)
             except Exception as e:
-                raise WorkflowYAMLLoaderException(f"Workflow '{wf_id}' data is invalid. Error: {e}")
+                raise WorkflowYAMLLoaderException(f"Workflow '{wf_id}' data is invalid. Error: {str(e) or repr(e)}")
 
             workflows[wf_id] = wf
         return workflows


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces concurrency control around connection client initialization, which can affect runtime behavior under parallel workloads and potentially surface deadlocks/races if misused. YAML loader and CI changes are low risk but may alter failure modes and log volume.
> 
> **Overview**
> Removes the conventional-commits checker step from the GitHub Actions `lint` job.
> 
> Makes `ConnectionManager.get_connection_client` thread-safe by adding per-connection locks with a double-checked initialization path, plus a small helper to consistently detect whether an existing client is still usable.
> 
> Improves `WorkflowYAMLLoader` exceptions by emitting more reliable error strings (`str(e) or repr(e)`) and logging full stack traces for invalid node initialization cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2dfc8470e1fac97531cdee4c89678c7799a48f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->