### PR TITLE
fix: add file messages handling for anthropic

### DIFF
--- a/dynamiq/nodes/llms/anthropic.py
+++ b/dynamiq/nodes/llms/anthropic.py
@@ -1,5 +1,7 @@
 from dynamiq.connections import Anthropic as AnthropicConnection
 from dynamiq.nodes.llms.base import BaseLLM
+from dynamiq.prompts.prompts import VisionMessageType
+from dynamiq.utils.logger import logger
 
 
 class Anthropic(BaseLLM):
@@ -22,3 +24,38 @@ class Anthropic(BaseLLM):
         if kwargs.get("client") is None and kwargs.get("connection") is None:
             kwargs["connection"] = AnthropicConnection()
         super().__init__(**kwargs)
+
+    @staticmethod
+    def _convert_non_image_to_file_content(messages: list[dict]) -> list[dict]:
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+
+            new_content = []
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == VisionMessageType.IMAGE_URL and "image_url" in item:
+                    url = item["image_url"].get("url", "")
+                    if url.startswith("data:") and not url.startswith("data:image/"):
+                        logger.debug("Anthropic: converting non-image image_url to file content format")
+                        new_content.append(
+                            {
+                                "type": VisionMessageType.FILE,
+                                "file": {"file_data": url},
+                            }
+                        )
+                    else:
+                        new_content.append(item)
+                else:
+                    new_content.append(item)
+
+            message["content"] = new_content
+
+        return messages
+
+    def get_messages(self, prompt, input_data) -> list[dict]:
+        """
+        Format messages and convert non-image files to Anthropic file content format.
+        """
+        messages = super().get_messages(prompt, input_data)
+        return self._convert_non_image_to_file_content(messages)

--- a/tests/integration_with_creds/agents/test_agent_llms.py
+++ b/tests/integration_with_creds/agents/test_agent_llms.py
@@ -16,6 +16,8 @@ from dynamiq.prompts import (
     VisionMessage,
     VisionMessageFileContent,
     VisionMessageFileData,
+    VisionMessageImageContent,
+    VisionMessageImageURL,
     VisionMessageTextContent,
 )
 from dynamiq.runnables import RunnableConfig, RunnableStatus
@@ -222,7 +224,7 @@ def test_react_agent_google_models(model, inference_mode, emoji_agent_role, agen
 
 @pytest.mark.integration
 @pytest.mark.parametrize("model", ["claude-sonnet-4-5", "claude-opus-4-5", "claude-opus-4-6"])
-def test_anthropic_llm_with_base64_pdf(model):
+def test_anthropic_llm_with_base64_pdf_file(model):
     """Test Anthropic LLM with base64 PDF file input."""
     pdf_bytes = BytesIO()
     c = canvas.Canvas(pdf_bytes)
@@ -242,6 +244,44 @@ def test_anthropic_llm_with_base64_pdf(model):
                 content=[
                     VisionMessageFileContent(
                         file=VisionMessageFileData(file_data=pdf_data_url),
+                    ),
+                    VisionMessageTextContent(text="What is in this file?"),
+                ],
+            )
+        ]
+    )
+
+    result = llm.run(input_data={}, prompt=prompt)
+
+    assert result.status == RunnableStatus.SUCCESS
+    assert result.output is not None
+    assert "content" in result.output
+    assert isinstance(result.output["content"], str)
+    assert len(result.output["content"]) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("model", ["claude-sonnet-4-5", "claude-opus-4-5", "claude-opus-4-6"])
+def test_anthropic_llm_with_base64_pdf_image(model):
+    """Test Anthropic LLM with base64 PDF file input."""
+    pdf_bytes = BytesIO()
+    c = canvas.Canvas(pdf_bytes)
+    c.drawString(100, 750, "Test PDF Content")
+    c.save()
+    pdf_bytes.seek(0)
+
+    base64_pdf = base64.b64encode(pdf_bytes.getvalue()).decode("utf-8")
+    pdf_data_url = f"data:application/pdf;base64,{base64_pdf}"
+
+    llm = create_claude_llm(model)
+
+    prompt = Prompt(
+        messages=[
+            VisionMessage(
+                role="user",
+                content=[
+                    VisionMessageImageContent(
+                        image_url=VisionMessageImageURL(url=pdf_data_url),
                     ),
                     VisionMessageTextContent(text="What is in this file?"),
                 ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches request message serialization for Anthropic vision inputs; mis-detection could alter how image and file payloads are sent, though changes are narrowly scoped and covered by integration tests.
> 
> **Overview**
> Fixes Anthropic vision message formatting by converting any `image_url` content that actually contains a non-image `data:` URL (e.g., PDFs) into Anthropic’s `file` content shape before sending messages.
> 
> Updates integration coverage by renaming the existing base64 PDF test to explicitly use `VisionMessageFileContent`, and adds a new test that sends a base64 PDF via `VisionMessageImageContent` to verify the new auto-conversion path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15c915860a7a44ae22be6367739211432d103bb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->