### PR TITLE
fix: fix exist method in sandbox

### DIFF
--- a/dynamiq/sandboxes/e2b.py
+++ b/dynamiq/sandboxes/e2b.py
@@ -257,9 +257,9 @@ class E2BSandbox(Sandbox):
         """Return True when file exists in sandbox filesystem."""
         sandbox = self._ensure_sandbox()
         resolved_path = self._resolve_path(file_path)
-        check_cmd = f"test -f {shlex.quote(resolved_path)}"
+        check_cmd = f"if [ -f {shlex.quote(resolved_path)} ]; then echo __EXISTS__; " "else echo __MISSING__; fi"
         result = sandbox.commands.run(check_cmd)
-        return getattr(result, "exit_code", 1) == 0
+        return (result.stdout or "").strip() == "__EXISTS__"
 
     def retrieve(self, file_path: str) -> bytes:
         """Read file bytes from sandbox filesystem."""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to a file-existence check; primary risk is behavior differences if command stdout is altered or trimmed unexpectedly.
> 
> **Overview**
> Fixes `E2BSandbox.exists()` by switching from relying on the remote command `exit_code` (`test -f ...`) to an explicit stdout sentinel (`__EXISTS__`/`__MISSING__`) to determine file presence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09725e6c13014211ee1bddb76d9754c567e3afa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->