### PR TITLE
fix: yaml roundtrip

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -213,12 +213,12 @@ class Agent(HistoryManagerMixin, BaseAgent):
             if self.summarization_config.enabled:
                 has_context_tool = any(isinstance(t, ContextManagerTool) for t in self.tools)
                 if not has_context_tool:
-                    self.tools.append(
-                        ContextManagerTool(
-                            llm=self.llm,
-                            name="context-manager",
-                        )
+                    context_tool = ContextManagerTool(
+                        llm=self.llm,
+                        name="context-manager",
                     )
+                    self.tools.append(context_tool)
+                    self._excluded_tool_ids.add(context_tool.id)
         except Exception as e:
             logger.error(f"Failed to ensure ContextManagerTool: {e}")
         return self
@@ -231,12 +231,12 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 has_todo_write = any(isinstance(t, TodoWriteTool) for t in self.tools)
 
                 if not has_todo_write:
-                    self.tools.append(
-                        TodoWriteTool(
-                            name="todo-write",
-                            file_store=self.file_store.backend,
-                        )
+                    todo_tool = TodoWriteTool(
+                        name="todo-write",
+                        file_store=self.file_store.backend,
                     )
+                    self.tools.append(todo_tool)
+                    self._excluded_tool_ids.add(todo_tool.id)
                     logger.info("Agent: Added TodoWriteTool")
         except Exception as e:
             logger.error(f"Failed to ensure TodoWriteTool: {e}")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches agent tool serialization/deserialization behavior; mistakes could drop or duplicate tools in saved workflows, affecting runtime behavior across YAML loads.
> 
> **Overview**
> Fixes YAML roundtrips for agents by unifying the “do not serialize these tools” bookkeeping into a single `_excluded_tool_ids` set and using it in `Agent.to_dict()` to filter out tools that are recreated from config on load (e.g., sandbox tools and MCP subtools).
> 
> Auto-injected tools added by validators (`ContextManagerTool` when summarization is enabled, and `TodoWriteTool` when todo is enabled) are now also marked excluded to prevent duplication after serialization/deserialization, and the sandbox integration test is extended to cover the context manager tool case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db0bc9f6dd38626ae20a287d38519253e39728b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->