### PR TITLE
fix: handle unprotected JSON parsing in mime detection and Steel Browser API

### DIFF
--- a/dynamiq/nodes/tools/stagehand.py
+++ b/dynamiq/nodes/tools/stagehand.py
@@ -255,14 +255,25 @@ class Stagehand(ConnectionNode):
         files = {"file": (file_name, io.BytesIO(file_bytes))}
         response = requests.post(url, headers=self._get_steel_browser_headers(), files=files, timeout=self.timeout)
         response.raise_for_status()
-        return response.json()
+        try:
+            return response.json()
+        except ValueError as e:
+            logger.error(f"Failed to parse JSON from Steel Browser upload response: {e}")
+            raise ToolExecutionException(
+                f"Steel Browser API returned invalid JSON after file upload: {e}",
+                recoverable=True,
+            )
 
     def _list_steel_browser_session_files(self, session_id: str) -> list[dict]:
         """List all files in the Steel Browser session's filesystem."""
         url = f"{self._get_steel_browser_base_url()}/sessions/{session_id}/files"
         response = requests.get(url, headers=self._get_steel_browser_headers(), timeout=self.timeout)
         response.raise_for_status()
-        payload = response.json()
+        try:
+            payload = response.json()
+        except ValueError as e:
+            logger.error(f"Failed to parse JSON from Steel Browser files response: {e}")
+            return []
         if isinstance(payload, dict):
             logger.info(f"Steel session files: {payload.get('data') or []}")
             return payload.get("data") or []

--- a/dynamiq/nodes/tools/utils.py
+++ b/dynamiq/nodes/tools/utils.py
@@ -74,8 +74,11 @@ def guess_mime_type_from_bytes(data: bytes, filename: str = None) -> str:
     elif data.startswith(b"<?xml"):
         return "application/xml"
     elif data.startswith(b"{") or data.startswith(b"["):
-        json.loads(data.decode("utf-8"))
-        return "application/json"
+        try:
+            json.loads(data.decode("utf-8"))
+            return "application/json"
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
     elif data.startswith(b"Name,") or b"," in data[:100] and b"\n" in data[:100]:
         return "text/csv"
     elif data.startswith(b"#") or (b" " in data and b"\n" in data and len(data.split(b"\n")) > 1):


### PR DESCRIPTION
## Summary

Was reading through the tool utilities and noticed a few places where JSON parsing can throw unhandled exceptions:

1. **`guess_mime_type_from_bytes()`** in `nodes/tools/utils.py` — `json.loads()` is called on data that starts with `{` or `[` but may not be valid JSON (e.g., a binary file or truncated payload). An unhandled `JSONDecodeError` or `UnicodeDecodeError` crashes the MIME detection instead of falling through to the next heuristic. Wrapped it in try-except so the function continues to the CSV/text/octet-stream fallbacks, matching the best-effort behavior of the rest of the function.

2. **`_upload_file_bytes_to_steel_browser_session()`** and **`_list_steel_browser_session_files()`** in `nodes/tools/stagehand.py` — `response.json()` is called after `raise_for_status()`, but a 2xx response with a non-JSON body (e.g., a proxy returning an HTML error page, or an empty body) still throws `ValueError`. The rest of the codebase already handles this — for example, `memory/backends/dynamiq.py` wraps `response.json()` in try-except. Applied the same pattern here: for upload, raise a recoverable `ToolExecutionException`; for listing, log and return an empty list.

## Test plan

- [ ] Verify `guess_mime_type_from_bytes(b"{not json")` returns a fallback MIME type instead of crashing
- [ ] Verify Steel Browser file operations gracefully handle non-JSON API responses
- [ ] Existing tests still pass