### PR TITLE
perf: reuse executors and share resources across flow runs

### DIFF
--- a/dynamiq/connections/managers.py
+++ b/dynamiq/connections/managers.py
@@ -205,6 +205,23 @@ class ConnectionManager:
         return self.serializer.loads(value)
 
 
+# Shared default ConnectionManager instance.
+# ConnectionManager is thread-safe (per-connection locks with double-checked locking),
+# so a single instance can be safely shared across multiple Flow instances.
+_default_connection_manager: ConnectionManager | None = None
+_default_connection_manager_lock = threading.Lock()
+
+
+def get_default_connection_manager() -> ConnectionManager:
+    """Return (and lazily create) the shared default ConnectionManager singleton."""
+    global _default_connection_manager
+    if _default_connection_manager is None:
+        with _default_connection_manager_lock:
+            if _default_connection_manager is None:
+                _default_connection_manager = ConnectionManager()
+    return _default_connection_manager
+
+
 @contextmanager
 def get_connection_manager():
     """

--- a/dynamiq/executors/base.py
+++ b/dynamiq/executors/base.py
@@ -34,6 +34,14 @@ class BaseExecutor(ABC):
         """
         raise NotImplementedError
 
+    def reset(self):
+        """Reset per-run state so the executor can be reused for the next run.
+
+        Subclasses that maintain per-run bookkeeping should override this.
+        The default implementation is a no-op.
+        """
+        pass
+
     @abstractmethod
     def execute(
         self,

--- a/dynamiq/executors/pool.py
+++ b/dynamiq/executors/pool.py
@@ -10,7 +10,23 @@ from dynamiq.runnables import RunnableConfig, RunnableResult, RunnableStatus
 from dynamiq.runnables.base import RunnableResultError
 from dynamiq.utils.logger import logger
 
-MAX_WORKERS_THREAD_POOL_EXECUTOR = 8
+
+def _default_thread_max_workers() -> int:
+    """Return the default max_workers for thread pool executors.
+
+    Resolution order:
+    1. ``DYNAMIQ_MAX_WORKERS`` environment variable (explicit deployment override).
+    2. ``min(32, os.cpu_count() + 4)`` — the same heuristic used by Python's
+       stdlib ``ThreadPoolExecutor`` since 3.8, well-suited for I/O-bound
+       workloads such as LLM API calls.
+    """
+    env_val = os.environ.get("DYNAMIQ_MAX_WORKERS")
+    if env_val is not None:
+        return int(env_val)
+    return min(32, (os.cpu_count() or 1) + 4)
+
+
+MAX_WORKERS_THREAD_POOL_EXECUTOR = _default_thread_max_workers()
 MAX_WORKERS_PROCESS_POOL_EXECUTOR = os.cpu_count()
 
 
@@ -44,6 +60,13 @@ class PoolExecutor(BaseExecutor):
             wait (bool, optional): Whether to wait for pending futures to complete. Defaults to True.
         """
         self.executor.shutdown(wait=wait)
+
+    def reset(self):
+        """
+        Resets per-run state so the executor can be reused across multiple flow runs
+        without creating a new thread pool.
+        """
+        self.node_by_future = {}
 
     def execute(
         self,

--- a/dynamiq/flows/flow.py
+++ b/dynamiq/flows/flow.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from pydantic import Field, computed_field, field_validator
 
-from dynamiq.connections.managers import ConnectionManager
+from dynamiq.connections.managers import ConnectionManager, get_default_connection_manager
 from dynamiq.executors.base import BaseExecutor
 from dynamiq.executors.pool import ThreadExecutor
 from dynamiq.flows.base import BaseFlow
@@ -44,7 +44,7 @@ class Flow(BaseFlow):
     nodes: list[Node] = []
     executor: type[BaseExecutor] = ThreadExecutor
     max_node_workers: int | None = None
-    connection_manager: ConnectionManager = Field(default_factory=ConnectionManager)
+    connection_manager: ConnectionManager = Field(default_factory=get_default_connection_manager)
 
     def __init__(self, **kwargs):
         """
@@ -56,6 +56,7 @@ class Flow(BaseFlow):
         super().__init__(**kwargs)
         self._node_by_id = {node.id: node for node in self.nodes}
         self._ts = None
+        self._run_executor = None
 
         self._init_components()
         self.reset_run_state()
@@ -222,6 +223,42 @@ class Flow(BaseFlow):
         }
         self._ts = self.init_node_topological_sorter(nodes=self.nodes)
 
+    def _get_run_executor(self, max_workers: int | None = None) -> BaseExecutor:
+        """Return the cached run executor, creating it lazily on first use.
+
+        The underlying thread pool is reused across multiple ``run_sync`` calls
+        to avoid the overhead of creating and destroying threads on every request.
+
+        If *max_workers* differs from the cached executor's value the old
+        executor is shut down and a fresh one is created.
+        """
+        if self._run_executor is not None and max_workers is not None and self._run_executor.max_workers != max_workers:
+            self._run_executor.shutdown(wait=True)
+            self._run_executor = None
+        if self._run_executor is None:
+            self._run_executor = self.executor(max_workers=max_workers)
+        return self._run_executor
+
+    def close(self):
+        """Shut down the cached executor and release resources.
+
+        Call this when the Flow instance will no longer be used (e.g. at
+        application shutdown) or use the Flow as a context manager::
+
+            with Flow(nodes=[...]) as flow:
+                flow.run_sync(data)
+        """
+        if self._run_executor is not None:
+            self._run_executor.shutdown(wait=True)
+            self._run_executor = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
     def _cleanup_dry_run(self, config: RunnableConfig = None):
         """
         Clean up resources created during dry run.
@@ -304,7 +341,7 @@ class Flow(BaseFlow):
                 max_workers = (
                     config.max_node_workers if config else self.max_node_workers
                 )
-                run_executor = self.executor(max_workers=max_workers)
+                run_executor = self._get_run_executor(max_workers=max_workers)
 
                 while self._ts.is_active():
                     ready_nodes = self._get_nodes_ready_to_run(input_data=input_data)
@@ -318,8 +355,6 @@ class Flow(BaseFlow):
 
                     # Wait for ready nodes to be processed and reduce CPU usage
                     time.sleep(0.003)
-
-                run_executor.shutdown()
 
             output = self._get_output()
             failed_nodes = self._get_failed_nodes_with_raise_behavior()
@@ -354,6 +389,8 @@ class Flow(BaseFlow):
                 error=RunnableResultError.from_exception(e, failed_nodes=failed_nodes),
             )
         finally:
+            if self._run_executor is not None:
+                self._run_executor.reset()
             self._cleanup_dry_run(config)
 
     async def run_async(self, input_data: Any, config: RunnableConfig = None, **kwargs) -> RunnableResult:
@@ -402,9 +439,10 @@ class Flow(BaseFlow):
 
                         self._results.update(results)
                         self._ts.done(*results.keys())
-
-                    # Wait for ready nodes to be processed and reduce CPU usage by yielding control to the event loop
-                    await asyncio.sleep(0.003)
+                    else:
+                        # Only sleep when no nodes were dispatched to reduce
+                        # CPU usage while waiting for dependencies to complete.
+                        await asyncio.sleep(0.003)
 
             output = self._get_output()
             failed_nodes = self._get_failed_nodes_with_raise_behavior()

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -990,11 +990,10 @@ class Node(BaseModel, Runnable, DryRunMixin, ABC):
         error = None
         n_attempt = self.error_handling.max_retries + 1
         executor = None
-        timed_out = False
 
         try:
             if timeout is not None:
-                executor = ContextAwareThreadPoolExecutor()
+                executor = ContextAwareThreadPoolExecutor(max_workers=1)
 
             for attempt in range(n_attempt):
                 merged_kwargs = merge(kwargs, {"execution_run_id": uuid4()})
@@ -1032,7 +1031,6 @@ class Node(BaseModel, Runnable, DryRunMixin, ABC):
                     return output
                 except TimeoutError as e:
                     error = e
-                    timed_out = True
                     self.run_on_node_execute_error(config.callbacks, error, **merged_kwargs)
                     logger.warning(f"Node {self.name} - {self.id}: timeout.")
                 except Exception as e:
@@ -1052,9 +1050,7 @@ class Node(BaseModel, Runnable, DryRunMixin, ABC):
             raise error
         finally:
             if executor is not None:
-                # Use cancel_futures=True and wait=False when timeout occurred to prevent
-                # blocking on threads that may be stuck waiting (e.g., on input_queue.get())
-                executor.shutdown(wait=not timed_out, cancel_futures=timed_out)
+                executor.shutdown(wait=False)
 
     def execute_with_timeout(
         self,
@@ -1087,8 +1083,10 @@ class Node(BaseModel, Runnable, DryRunMixin, ABC):
             return future.result(timeout=timeout)
         except TimeoutError:
             # Cancel the future to prevent further execution if possible.
-            # Note: cancel() only works if the task hasn't started yet.
-            # For running tasks, we rely on executor.shutdown(cancel_futures=True).
+            # Note: cancel() only prevents tasks that have not started yet.
+            # Already-running tasks will continue until they complete; this is
+            # a Python threading limitation.  The per-node executor is shut
+            # down (wait=False) in the finally block of execute_with_retry.
             future.cancel()
             raise
 


### PR DESCRIPTION
## Summary

Performance optimization to reduce per-request overhead in flow execution by reusing executors, sharing resources across runs, and scaling thread pools to match system capacity. Targets scenarios with many sequential or parallel requests (e.g. 50+ concurrent) where thread pool churn, undersized pools, and redundant resource creation caused significant overhead.

## Changes

### 1. PoolExecutor.reset() (`dynamiq/executors/pool.py`, `dynamiq/executors/base.py`)
- Added `reset()` to `BaseExecutor` interface (no-op default for backward compatibility)
- `PoolExecutor.reset()` clears `node_by_future` dict without destroying the thread pool

### 2. Flow executor caching (`dynamiq/flows/flow.py`)
- `_get_run_executor()` lazily creates and caches the executor
- Detects `max_workers` changes and recreates the executor when needed
- Handles `max_workers=None` (default) correctly by skipping comparison against the resolved integer value
- `run_sync()` calls `reset()` in `finally` block (exception-safe) instead of `shutdown()`
- Added `close()` method and `__enter__`/`__exit__` context manager support

### 3. Per-node timeout executor (`dynamiq/nodes/node.py`)
- Timeout enforcement uses a dedicated per-node `ContextAwareThreadPoolExecutor(max_workers=1)`
- Executor is shut down with `shutdown(wait=False)` in the `finally` block of `execute_with_retry`
- **Why per-node?** A shared bounded pool caused false timeouts under concurrency: when 50+ timeout-guarded nodes shared one pool, tasks queued up and `future.result(timeout=T)` measured wall-clock from submission rather than task start, causing queued tasks to timeout before executing

### 4. Shared ConnectionManager (`dynamiq/connections/managers.py`, `dynamiq/flows/flow.py`)
- Added `get_default_connection_manager()` singleton
- Flow defaults to the shared instance

### 5. Async conditional sleep (`dynamiq/flows/flow.py`)
- `asyncio.sleep(0.003)` only triggers when no nodes were dispatched (idle polling)

### 6. Smart thread pool sizing (`dynamiq/executors/pool.py`)
- Replaced hardcoded `MAX_WORKERS_THREAD_POOL_EXECUTOR = 8` with `min(32, os.cpu_count() + 4)` — Python stdlib's proven heuristic for I/O-bound workloads
- Configurable via `DYNAMIQ_MAX_WORKERS` environment variable for deployment-level tuning
- Examples: 8-core -> 12 workers (was 8), 16-core -> 20 workers, 28+ core -> 32 workers (capped)

## Configuration

| Environment Variable | Default | Description |
|---------------------|---------|-------------|
| `DYNAMIQ_MAX_WORKERS` | `min(32, cpu_count + 4)` | Thread pool size for flow node execution |

Per-flow override: set `max_node_workers` on the `Flow` instance or in `RunnableConfig`.

## Cursor Bugbot Issues - All Resolved

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | HIGH | `reset()` only called in success path | Moved to `finally` block |
| 2 | HIGH | Executor cache defeated by `max_workers` None mismatch | Skip comparison when `max_workers` is `None` (default); only recreate when explicitly changed |
| 3 | HIGH | Shared timeout pool causes false timeouts under concurrency | Reverted to per-node `ContextAwareThreadPoolExecutor(max_workers=1)` with `shutdown(wait=False)` |
| 4 | MEDIUM | Shared timeout executor thread leak | Resolved by reverting to per-node executor with `shutdown(wait=False)` in finally |
| 5 | LOW | `reset()` not defined on `BaseExecutor` | Added with no-op default for backward compatibility |

## Test Results
- All 718 unit tests pass locally (Python 3.10)
- flake8, darker clean
- `test_background_thread_runs_until_streaming_timeout_after_execute_timeout` passes with per-node timeout executor

## Impact on 50 Parallel Requests

**Before:** Each `run_sync()` call created and destroyed a thread pool (8 threads), a timeout executor, and a connection manager. 50 parallel requests = 150+ redundant resource allocations + constant thread churn.

**After:**
- Flow-level thread pools are reused across runs (zero churn)
- Pool sizes scale with CPU count (12 threads on 8-core, up to 32)
- Single shared connection manager
- Per-node timeout executors remain lightweight (`max_workers=1`) and are properly cleaned up
- Deployments can tune via `DYNAMIQ_MAX_WORKERS=64` for high-concurrency scenarios
- Conditional sleep reduces idle polling overhead