### PR TITLE
fix: context compaction retry

### DIFF
--- a/dynamiq/nodes/tools/context_manager.py
+++ b/dynamiq/nodes/tools/context_manager.py
@@ -233,10 +233,12 @@ class ContextManagerTool(Node):
     ) -> str:
         """Send *messages* to the LLM and return the generated text.
 
-        Retries on empty content since reasoning-heavy models and safety
-        filters can occasionally return content="" on an otherwise-successful
-        call.
+        Retries on LLM failure and on empty content since reasoning-heavy
+        models and safety filters can occasionally return content="" on an
+        otherwise-successful call, and transient provider errors can surface
+        as failed runs.
         """
+        last_error: str | None = None
         for attempt in range(1, self.max_retries + 1):
             llm_result = self.llm.run(
                 input_data={},
@@ -247,17 +249,26 @@ class ContextManagerTool(Node):
             self._run_depends = [NodeDependency(node=self.llm).to_dict(for_tracing=True)]
 
             if llm_result.status != RunnableStatus.SUCCESS:
-                error_msg = llm_result.error.message if llm_result.error else "Unknown error"
-                raise ValueError(f"Context Manager Tool: LLM failed to generate summary: {error_msg}")
+                last_error = llm_result.error.message if llm_result.error else "Unknown error"
+                suffix = " Retrying." if attempt < self.max_retries else ""
+                logger.warning(
+                    f"Context Manager Tool: LLM failed on attempt {attempt}/{self.max_retries}: "
+                    f"{last_error}.{suffix}"
+                )
+                continue
 
             summary = (llm_result.output or {}).get("content", "") or ""
             if summary.strip():
                 return summary
 
+            last_error = "empty summary"
             suffix = " Retrying." if attempt < self.max_retries else ""
             logger.warning(f"Context Manager Tool: empty summary on attempt {attempt}/{self.max_retries}.{suffix}")
 
-        raise ValueError(f"Context Manager Tool: LLM returned empty summary after {self.max_retries} attempts.")
+        raise ValueError(
+            f"Context Manager Tool: LLM failed to generate summary after {self.max_retries} attempts "
+            f"(last error: {last_error})."
+        )
 
     def _summarize_replace_history(
         self,

--- a/dynamiq/nodes/tools/context_manager.py
+++ b/dynamiq/nodes/tools/context_manager.py
@@ -70,6 +70,11 @@ class ContextManagerTool(Node):
 
     error_handling: ErrorHandling = Field(default_factory=lambda: ErrorHandling(timeout_seconds=3600))
     token_budget_ratio: float = Field(default=0.75, gt=0, lt=1)
+    max_retries: int = Field(
+        default=3,
+        ge=1,
+        description="Number of attempts to retry when the LLM failed or returns empty content for a summary call.",
+    )
     llm: Node = Field(..., description="LLM instance for generating summaries")
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -121,6 +126,26 @@ class ContextManagerTool(Node):
             ]
         )
         return max(raw_budget - prompt_overhead, 1)
+
+    def _flatten_messages_to_single(self, messages: list[Message | VisionMessage]) -> Message:
+        """Combine a list of conversation messages into one user message.
+
+        Some providers (e.g. MiniMax via Together) return empty content when
+        sent multi-turn assistant/tool histories without proper tool_call_id
+        threading. Flattening to a single user message with role-tagged blocks
+        avoids that failure mode for summarization, where strict turn structure
+        isn't needed.
+        """
+        parts: list[str] = []
+        for m in messages:
+            role = getattr(m, "role", None)
+            role_str = role.value if hasattr(role, "value") else str(role)
+            content = getattr(m, "content", "") or ""
+            if isinstance(content, str):
+                parts.append(f"[{role_str}]\n{content}")
+            else:
+                parts.append(f"[{role_str}]\n{content!r}")
+        return Message(content="\n\n".join(parts), role=MessageRole.ASSISTANT, static=True)
 
     def _count_message_tokens(self, messages: list[Message | VisionMessage]) -> int:
         """Count tokens for a list of messages using the summarization LLM's tokenizer."""
@@ -206,23 +231,32 @@ class ContextManagerTool(Node):
         config: RunnableConfig | None = None,
         **kwargs,
     ) -> str:
-        """Send *messages* to the LLM and return the generated text."""
-        llm_result = self.llm.run(
-            input_data={},
-            prompt=Prompt(messages=messages),
-            config=config,
-            **(kwargs | {"parent_run_id": kwargs.get("run_id"), "run_depends": []}),
-        )
-        self._run_depends = [NodeDependency(node=self.llm).to_dict(for_tracing=True)]
+        """Send *messages* to the LLM and return the generated text.
 
-        if llm_result.status != RunnableStatus.SUCCESS:
-            error_msg = llm_result.error.message if llm_result.error else "Unknown error"
-            raise ValueError(f"Context Manager Tool: LLM failed to generate summary: {error_msg}")
+        Retries on empty content since reasoning-heavy models and safety
+        filters can occasionally return content="" on an otherwise-successful
+        call.
+        """
+        for attempt in range(1, self.max_retries + 1):
+            llm_result = self.llm.run(
+                input_data={},
+                prompt=Prompt(messages=messages),
+                config=config,
+                **(kwargs | {"parent_run_id": kwargs.get("run_id"), "run_depends": []}),
+            )
+            self._run_depends = [NodeDependency(node=self.llm).to_dict(for_tracing=True)]
 
-        summary = llm_result.output.get("content", "")
-        if not summary:
-            raise ValueError("Context Manager Tool: LLM returned empty summary.")
-        return summary
+            if llm_result.status != RunnableStatus.SUCCESS:
+                error_msg = llm_result.error.message if llm_result.error else "Unknown error"
+                raise ValueError(f"Context Manager Tool: LLM failed to generate summary: {error_msg}")
+
+            summary = (llm_result.output or {}).get("content", "") or ""
+            if summary.strip():
+                return summary
+
+            logger.warning(f"Context Manager Tool: empty summary on attempt {attempt}/{self.max_retries}. Retrying.")
+
+        raise ValueError(f"Context Manager Tool: LLM returned empty summary after {self.max_retries} attempts.")
 
     def _summarize_replace_history(
         self,
@@ -251,7 +285,8 @@ class ContextManagerTool(Node):
 
         if message_tokens <= budget:
             logger.info("Context Manager Tool: History fits in context, single-pass summary.")
-            summary_messages = messages + [
+            summary_messages = [
+                self._flatten_messages_to_single(messages),
                 Message(content=HISTORY_SUMMARIZATION_PROMPT_REPLACE, role=MessageRole.USER, static=True),
             ]
             summary = self._call_llm_for_summary(summary_messages, config, **kwargs)
@@ -267,7 +302,8 @@ class ContextManagerTool(Node):
         chunk_summaries: list[str] = []
         for idx, chunk in enumerate(chunks):
             logger.info(f"Context Manager Tool: Summarizing chunk {idx + 1}/{len(chunks)}.")
-            chunk_messages = chunk + [
+            chunk_messages = [
+                self._flatten_messages_to_single(chunk),
                 Message(content=HISTORY_SUMMARIZATION_PROMPT_REPLACE, role=MessageRole.USER, static=True),
             ]
             chunk_summaries.append(self._call_llm_for_summary(chunk_messages, config, **kwargs))

--- a/dynamiq/nodes/tools/context_manager.py
+++ b/dynamiq/nodes/tools/context_manager.py
@@ -128,7 +128,7 @@ class ContextManagerTool(Node):
         return max(raw_budget - prompt_overhead, 1)
 
     def _flatten_messages_to_single(self, messages: list[Message | VisionMessage]) -> Message:
-        """Combine a list of conversation messages into one user message.
+        """Combine a list of conversation messages into one assistant message.
 
         Some providers (e.g. MiniMax via Together) return empty content when
         sent multi-turn assistant/tool histories without proper tool_call_id
@@ -254,7 +254,8 @@ class ContextManagerTool(Node):
             if summary.strip():
                 return summary
 
-            logger.warning(f"Context Manager Tool: empty summary on attempt {attempt}/{self.max_retries}. Retrying.")
+            suffix = " Retrying." if attempt < self.max_retries else ""
+            logger.warning(f"Context Manager Tool: empty summary on attempt {attempt}/{self.max_retries}.{suffix}")
 
         raise ValueError(f"Context Manager Tool: LLM returned empty summary after {self.max_retries} attempts.")
 

--- a/tests/integration/nodes/tools/test_context_manager.py
+++ b/tests/integration/nodes/tools/test_context_manager.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from dynamiq.nodes.tools.context_manager import ContextManagerTool
+from dynamiq.prompts import Message, MessageRole
+from dynamiq.runnables import RunnableStatus
+
+
+def _mock_tool(outputs):
+    llm = MagicMock()
+    llm.model = "gpt-4o-mini"
+    llm.get_token_limit.return_value = 128_000
+    llm.is_postponed_component_init = False
+    llm.to_dict.return_value = {}
+    llm.run.side_effect = [MagicMock(status=RunnableStatus.SUCCESS, output=out) for out in outputs]
+    return ContextManagerTool(llm=llm, max_retries=3), llm
+
+
+def test_retry_returns_summary_after_empty_attempts():
+    tool, llm = _mock_tool([{"content": ""}, {"content": "  "}, {"content": "ok"}])
+    assert tool._call_llm_for_summary([Message(role=MessageRole.USER, content="x")]) == "ok"
+    assert llm.run.call_count == 3
+
+
+def test_retry_raises_when_all_attempts_empty():
+    tool, llm = _mock_tool([{"content": ""}] * 3)
+    with pytest.raises(ValueError, match="empty summary after 3 attempts"):
+        tool._call_llm_for_summary([Message(role=MessageRole.USER, content="x")])
+    assert llm.run.call_count == 3

--- a/tests/integration/nodes/tools/test_context_manager.py
+++ b/tests/integration/nodes/tools/test_context_manager.py
@@ -2,13 +2,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dynamiq.nodes.llms.base import BaseLLM
 from dynamiq.nodes.tools.context_manager import ContextManagerTool
 from dynamiq.prompts import Message, MessageRole
 from dynamiq.runnables import RunnableStatus
 
 
 def _mock_tool(outputs):
-    llm = MagicMock()
+    llm = MagicMock(spec=BaseLLM)
+    llm.id = "mock-llm"
+    llm.name = "mock-llm"
+    llm.type = "mock-llm"
     llm.model = "gpt-4o-mini"
     llm.get_token_limit.return_value = 128_000
     llm.is_postponed_component_init = False

--- a/tests/integration/nodes/tools/test_context_manager.py
+++ b/tests/integration/nodes/tools/test_context_manager.py
@@ -25,6 +25,6 @@ def test_retry_returns_summary_after_empty_attempts():
 
 def test_retry_raises_when_all_attempts_empty():
     tool, llm = _mock_tool([{"content": ""}] * 3)
-    with pytest.raises(ValueError, match="empty summary after 3 attempts"):
+    with pytest.raises(ValueError, match="failed to generate summary after 3 attempts"):
         tool._call_llm_for_summary([Message(role=MessageRole.USER, content="x")])
     assert llm.run.call_count == 3

--- a/tests/integration_with_creds/agents/test_agent_context_manager.py
+++ b/tests/integration_with_creds/agents/test_agent_context_manager.py
@@ -5,18 +5,14 @@ Tests the agent's ability to automatically invoke the Context Manager Tool
 when token limits are exceeded.
 """
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.nodes.agents import Agent
 from dynamiq.nodes.agents.utils import SummarizationConfig
 from dynamiq.nodes.llms import OpenAI
-from dynamiq.nodes.tools.context_manager import ContextManagerTool
 from dynamiq.nodes.tools.python import Python
 from dynamiq.nodes.types import InferenceMode
-from dynamiq.prompts import Message, MessageRole
 from dynamiq.runnables import RunnableConfig, RunnableStatus
 from dynamiq.utils.logger import logger
 
@@ -170,26 +166,3 @@ def test_automatic_context_manager_auto_clean(llm_instance, python_tool, run_con
 
     logger.info(result.output)
     assert "apple" in result.output["content"], "Result is not correct"
-
-
-def _mock_tool(outputs):
-    llm = MagicMock()
-    llm.model = "gpt-4o-mini"
-    llm.get_token_limit.return_value = 128_000
-    llm.is_postponed_component_init = False
-    llm.to_dict.return_value = {}
-    llm.run.side_effect = [MagicMock(status=RunnableStatus.SUCCESS, output=out) for out in outputs]
-    return ContextManagerTool(llm=llm, max_retries=3), llm
-
-
-def test_retry_returns_summary_after_empty_attempts():
-    tool, llm = _mock_tool([{"content": ""}, {"content": "  "}, {"content": "ok"}])
-    assert tool._call_llm_for_summary([Message(role=MessageRole.USER, content="x")]) == "ok"
-    assert llm.run.call_count == 3
-
-
-def test_retry_raises_when_all_attempts_empty():
-    tool, llm = _mock_tool([{"content": ""}] * 3)
-    with pytest.raises(ValueError, match="empty summary after 3 attempts"):
-        tool._call_llm_for_summary([Message(role=MessageRole.USER, content="x")])
-    assert llm.run.call_count == 3

--- a/tests/integration_with_creds/agents/test_agent_context_manager.py
+++ b/tests/integration_with_creds/agents/test_agent_context_manager.py
@@ -5,14 +5,18 @@ Tests the agent's ability to automatically invoke the Context Manager Tool
 when token limits are exceeded.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.nodes.agents import Agent
 from dynamiq.nodes.agents.utils import SummarizationConfig
 from dynamiq.nodes.llms import OpenAI
+from dynamiq.nodes.tools.context_manager import ContextManagerTool
 from dynamiq.nodes.tools.python import Python
 from dynamiq.nodes.types import InferenceMode
+from dynamiq.prompts import Message, MessageRole
 from dynamiq.runnables import RunnableConfig, RunnableStatus
 from dynamiq.utils.logger import logger
 
@@ -166,3 +170,26 @@ def test_automatic_context_manager_auto_clean(llm_instance, python_tool, run_con
 
     logger.info(result.output)
     assert "apple" in result.output["content"], "Result is not correct"
+
+
+def _mock_tool(outputs):
+    llm = MagicMock()
+    llm.model = "gpt-4o-mini"
+    llm.get_token_limit.return_value = 128_000
+    llm.is_postponed_component_init = False
+    llm.to_dict.return_value = {}
+    llm.run.side_effect = [MagicMock(status=RunnableStatus.SUCCESS, output=out) for out in outputs]
+    return ContextManagerTool(llm=llm, max_retries=3), llm
+
+
+def test_retry_returns_summary_after_empty_attempts():
+    tool, llm = _mock_tool([{"content": ""}, {"content": "  "}, {"content": "ok"}])
+    assert tool._call_llm_for_summary([Message(role=MessageRole.USER, content="x")]) == "ok"
+    assert llm.run.call_count == 3
+
+
+def test_retry_raises_when_all_attempts_empty():
+    tool, llm = _mock_tool([{"content": ""}] * 3)
+    with pytest.raises(ValueError, match="empty summary after 3 attempts"):
+        tool._call_llm_for_summary([Message(role=MessageRole.USER, content="x")])
+    assert llm.run.call_count == 3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Behavior changes in how histories are packaged and how failed/empty summaries are handled, which could affect summary quality and add latency via retries. Limited scope and covered by targeted tests.
> 
> **Overview**
> Makes context compaction more reliable by **flattening multi-turn histories into a single role-tagged message** before summarization (both single-pass and chunked paths) to avoid provider issues with tool/threading metadata.
> 
> Adds configurable `max_retries` and updates `_call_llm_for_summary` to **retry on failed LLM runs and empty/whitespace summaries**, logging warnings and raising a clearer error after exhaustion. Includes integration tests covering the empty-summary retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350759bad916a8dfbd5a7efb8b23386ca4fcc1d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->