### PR TITLE
feat: registry override

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -178,6 +178,10 @@ class BaseLLM(ConnectionNode):
     group: Literal[NodeGroup.LLMS] = NodeGroup.LLMS
     temperature: float | None = None
     max_tokens: int | None = None
+    model_info: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional model metadata overrides (e.g. max_input_tokens, supports_vision, supports_pdf_input).",
+    )
     stop: list[str] | None = None
     error_handling: ErrorHandling = Field(default_factory=lambda: ErrorHandling(timeout_seconds=600))
     top_p: float | None = None
@@ -313,6 +317,9 @@ class BaseLLM(ConnectionNode):
         Returns:
             int: Number of tokens.
         """
+        if self.model_info and self.model_info.get("max_input_tokens"):
+            return self.model_info["max_input_tokens"]
+
         info = self._get_litellm_model_info()
         if info is not None:
             max_input = info.get("max_input_tokens")
@@ -334,6 +341,8 @@ class BaseLLM(ConnectionNode):
     @property
     def is_vision_supported(self) -> bool:
         """Check if the LLM supports vision/image processing."""
+        if self.model_info and "supports_vision" in self.model_info:
+            return self.model_info["supports_vision"]
         if self._get_litellm_model_info() is not None:
             try:
                 return supports_vision(self.model)
@@ -345,6 +354,8 @@ class BaseLLM(ConnectionNode):
     @property
     def is_pdf_input_supported(self) -> bool:
         """Check if the LLM supports PDF input."""
+        if self.model_info and "supports_pdf_input" in self.model_info:
+            return self.model_info["supports_pdf_input"]
         if self._get_litellm_model_info() is not None:
             try:
                 return supports_pdf_input(self.model)

--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -64,6 +64,16 @@ LLM_CONNECTION_ERROR_INDICATORS = (
 )
 
 
+class ModelInfo(BaseModel):
+    """Structured model metadata overrides."""
+
+    model_config = ConfigDict(extra="allow")
+
+    max_input_tokens: int | None = None
+    supports_vision: bool | None = None
+    supports_pdf_input: bool | None = None
+
+
 class FallbackTrigger(str, Enum):
     ANY = "any"
     RATE_LIMIT = "rate_limit"
@@ -178,7 +188,7 @@ class BaseLLM(ConnectionNode):
     group: Literal[NodeGroup.LLMS] = NodeGroup.LLMS
     temperature: float | None = None
     max_tokens: int | None = None
-    model_info: dict[str, Any] | None = Field(
+    model_info: ModelInfo | None = Field(
         default=None,
         description="Optional model metadata overrides (e.g. max_input_tokens, supports_vision, supports_pdf_input).",
     )
@@ -317,8 +327,8 @@ class BaseLLM(ConnectionNode):
         Returns:
             int: Number of tokens.
         """
-        if self.model_info and self.model_info.get("max_input_tokens"):
-            return self.model_info["max_input_tokens"]
+        if self.model_info and self.model_info.max_input_tokens is not None:
+            return self.model_info.max_input_tokens
 
         info = self._get_litellm_model_info()
         if info is not None:
@@ -341,8 +351,8 @@ class BaseLLM(ConnectionNode):
     @property
     def is_vision_supported(self) -> bool:
         """Check if the LLM supports vision/image processing."""
-        if self.model_info and "supports_vision" in self.model_info:
-            return self.model_info["supports_vision"]
+        if self.model_info and self.model_info.supports_vision is not None:
+            return self.model_info.supports_vision
         if self._get_litellm_model_info() is not None:
             try:
                 return supports_vision(self.model)
@@ -354,8 +364,8 @@ class BaseLLM(ConnectionNode):
     @property
     def is_pdf_input_supported(self) -> bool:
         """Check if the LLM supports PDF input."""
-        if self.model_info and "supports_pdf_input" in self.model_info:
-            return self.model_info["supports_pdf_input"]
+        if self.model_info and self.model_info.supports_pdf_input is not None:
+            return self.model_info.supports_pdf_input
         if self._get_litellm_model_info() is not None:
             try:
                 return supports_pdf_input(self.model)

--- a/dynamiq/nodes/llms/model_registry.json
+++ b/dynamiq/nodes/llms/model_registry.json
@@ -45,7 +45,22 @@
         "output_cost_per_token": 0.0000032
     },
     "MiniMaxAI/MiniMax-M2.5": {
-        "max_input_tokens": 192000,
+        "max_input_tokens": 228700,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "litellm_provider": "minimax",
+        "supports_vision": true,
+        "supports_pdf_input": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "input_cost_per_token": 0.0000003,
+        "output_cost_per_token": 0.0000012
+    },
+    "MiniMaxAI/MiniMax-M2.7": {
+        "max_input_tokens": 202752,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",

--- a/tests/unit/nodes/agents/test_sub_agent_tool.py
+++ b/tests/unit/nodes/agents/test_sub_agent_tool.py
@@ -549,7 +549,8 @@ class TestYamlRoundtrip:
         serialization and is not duplicated after reload.
         """
         openai_conn = OpenAIConnection(id="openai-conn", api_key="test-key")
-        parent_llm = OpenAI(id="parent-llm", connection=openai_conn, model="gpt-4o")
+        model_info = {"max_input_tokens": 99_999, "supports_vision": True, "supports_pdf_input": True}
+        parent_llm = OpenAI(id="parent-llm", connection=openai_conn, model="gpt-4o", model_info=model_info)
         child_llm = OpenAI(id="child-llm", connection=openai_conn, model="gpt-4o")
 
         child_agent = Agent(
@@ -600,6 +601,7 @@ class TestYamlRoundtrip:
         assert wrapper.agent.name == "Researcher Agent"
         assert wrapper.agent.description == "I am a research agent"
         assert wrapper.max_calls == 5
+        assert loaded_agent.llm.model_info == model_info
 
         rt_path = tmp_path / "sub_agent_tool_rt.yaml"
         loaded.to_yaml_file(rt_path)
@@ -617,6 +619,7 @@ class TestYamlRoundtrip:
         assert SubAgentTool.INITIALIZED_HINT in rt_wrapper.description
         assert rt_wrapper.agent.name == "Researcher Agent"
         assert rt_wrapper.agent.description == "I am a research agent"
+        assert rt_agent.llm.model_info == model_info
 
     def test_agent_as_tool_yaml_roundtrip_backward_compat(self, tmp_path):
         """Roundtrip with a raw Agent passed as a tool (backward-compatible auto-wrap).

--- a/tests/unit/nodes/agents/test_sub_agent_tool.py
+++ b/tests/unit/nodes/agents/test_sub_agent_tool.py
@@ -11,6 +11,7 @@ from dynamiq.nodes.agents import Agent
 from dynamiq.nodes.agents.base import ToolParams
 from dynamiq.nodes.agents.components import schema_generator
 from dynamiq.nodes.llms import OpenAI
+from dynamiq.nodes.llms.base import ModelInfo
 from dynamiq.nodes.tools.agent_tool import SubAgentTool
 from dynamiq.nodes.tools.parallel_tool_calls import PARALLEL_TOOL_NAME
 from dynamiq.nodes.tools.python import Python
@@ -549,7 +550,7 @@ class TestYamlRoundtrip:
         serialization and is not duplicated after reload.
         """
         openai_conn = OpenAIConnection(id="openai-conn", api_key="test-key")
-        model_info = {"max_input_tokens": 99_999, "supports_vision": True, "supports_pdf_input": True}
+        model_info = ModelInfo(max_input_tokens=99_999, supports_vision=True, supports_pdf_input=True)
         parent_llm = OpenAI(id="parent-llm", connection=openai_conn, model="gpt-4o", model_info=model_info)
         child_llm = OpenAI(id="child-llm", connection=openai_conn, model="gpt-4o")
 

--- a/tests/unit/nodes/llms/test_model_registry.py
+++ b/tests/unit/nodes/llms/test_model_registry.py
@@ -100,3 +100,33 @@ def test_totally_unknown_model_returns_default():
 
     llm = TogetherAI(model="unknown/x", connection=TogetherAIConnection(api_key="test-key"))
     assert llm.get_token_limit() == LLM_DEFAULT_MAX_TOKENS
+
+
+@pytest.mark.usefixtures("_litellm_unknown", "_patch_registry")
+def test_model_info_override_takes_priority():
+    """model_info on the LLM instance overrides both litellm and model_registry."""
+    from dynamiq.connections import TogetherAI as TogetherAIConnection
+    from dynamiq.nodes.llms.togetherai import TogetherAI
+
+    llm = TogetherAI(
+        model=MODEL_A,
+        connection=TogetherAIConnection(api_key="test-key"),
+        model_info={"max_input_tokens": 99_999, "supports_vision": True, "supports_pdf_input": True},
+    )
+
+    # Registry has 50_000 for MODEL_A, but model_info should win
+    assert llm.get_token_limit() == 99_999
+    assert llm.is_vision_supported is True
+    assert llm.is_pdf_input_supported is True
+
+
+@pytest.mark.usefixtures("_litellm_unknown", "_patch_registry")
+def test_model_info_none_falls_through():
+    """When model_info is None, the existing lookup chain is used."""
+    from dynamiq.connections import TogetherAI as TogetherAIConnection
+    from dynamiq.nodes.llms.togetherai import TogetherAI
+
+    llm = TogetherAI(model=MODEL_B, connection=TogetherAIConnection(api_key="test-key"))
+    assert llm.model_info is None
+    assert llm.get_token_limit() == 200_000
+    assert llm.is_vision_supported is True


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect core LLM capability detection and token-limit enforcement, which could alter behavior for any node relying on these properties if misconfigured. The logic is straightforward but applies broadly and depends on correct serialization/typing of `model_info`.
> 
> **Overview**
> Adds a `ModelInfo` object to `BaseLLM` so callers can override model metadata (token limits, vision support, PDF input support) per LLM instance.
> 
> Updates `get_token_limit`, `is_vision_supported`, and `is_pdf_input_supported` to prefer `model_info` values before falling back to LiteLLM and the custom `model_registry`, and extends the bundled `model_registry.json` with updated MiniMax model limits plus a new `MiniMaxAI/MiniMax-M2.7` entry.
> 
> Expands unit tests to verify `model_info` serialization through YAML roundtrips and that overrides take priority over both LiteLLM and the registry (with passthrough behavior when `model_info` is unset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60527804817da3ac78053bcb1d968f87f7d7e7af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->