### PR TITLE
feat: delete todo state after run

### DIFF
--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -30,6 +30,7 @@ from dynamiq.nodes.tools.parallel_tool_calls import PARALLEL_TOOL_NAME, Parallel
 from dynamiq.nodes.tools.python import Python
 from dynamiq.nodes.tools.python_code_executor import PythonCodeExecutor
 from dynamiq.nodes.tools.skills_tool import SkillsTool
+from dynamiq.nodes.tools.todo_tools import TodoWriteTool
 from dynamiq.nodes.types import InferenceMode
 from dynamiq.prompts import Message, MessageRole, Prompt, VisionMessage
 from dynamiq.runnables import RunnableConfig, RunnableResult, RunnableStatus
@@ -551,6 +552,21 @@ class Agent(Node):
 
         return custom_metadata
 
+    def _clear_todos_file(self) -> None:
+        """Delete the persisted todos file and reset in-memory todo state.
+
+        Invoked unconditionally from execute()'s finally block.
+        Failures are logged but never propagate — cleanup must not break the agent run.
+        """
+        try:
+            for tool in self.tools:
+                if isinstance(tool, TodoWriteTool):
+                    tool.clear()
+            if getattr(self, "state", None) is not None:
+                self.state.update_todos([])
+        except Exception as e:
+            logger.warning(f"Agent {self.name} - {self.id}: todo cleanup failed: {e}")
+
     def execute(
         self,
         input_data: AgentInputSchema,
@@ -645,6 +661,7 @@ class Agent(Node):
             raise
         finally:
             self._current_call_context = None
+            self._clear_todos_file()
 
         if use_memory:
             try:

--- a/dynamiq/nodes/tools/todo_tools.py
+++ b/dynamiq/nodes/tools/todo_tools.py
@@ -144,6 +144,20 @@ RULES:
                 overwrite=True,
             )
 
+    def clear(self) -> bool:
+        """Delete the todos file from storage.
+
+        Errors are logged and swallowed — cleanup must never fail the agent run.
+        Returns True if the file was removed (or absent); False on failure.
+        """
+        try:
+            if isinstance(self.file_store, Sandbox):
+                return bool(self.file_store.delete_file(TODOS_FILE_PATH))
+            return bool(self.file_store.delete(TODOS_FILE_PATH))
+        except Exception as e:
+            logger.warning(f"TodoWriteTool: failed to clear todos file: {e}")
+            return False
+
     def execute(
         self, input_data: TodoWriteInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:

--- a/dynamiq/sandboxes/base.py
+++ b/dynamiq/sandboxes/base.py
@@ -2,6 +2,7 @@ import abc
 import io
 import logging
 import mimetypes
+import shlex
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
@@ -280,6 +281,30 @@ class Sandbox(abc.ABC, BaseModel):
             f"{self.__class__.__name__} does not support file retrieval. "
             "Use a sandbox backend that supports file operations (e.g., E2BSandbox)."
         )
+
+    def delete_file(self, file_path: str) -> bool:
+        """Delete a file from the sandbox filesystem.
+
+        Default implementation routes through ``run_command_shell`` with ``rm -f``,
+        which is portable across every concrete sandbox backend. Subclasses may
+        override to use a vendor-native delete primitive if available.
+
+        Args:
+            file_path: Path to the file (relative paths resolved against base_path).
+
+        Returns:
+            True if the file was removed (or was already absent), False otherwise.
+            Never raises — callers can treat the boolean as authoritative.
+        """
+        try:
+            resolved_path = self._resolve_path(file_path)
+            result = self.run_command_shell(f"rm -f {shlex.quote(resolved_path)}")
+            return getattr(result, "is_success", True)
+        except NotImplementedError:
+            raise
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"{self.__class__.__name__}.delete_file({file_path}) failed: {e}")
+            return False
 
     def apply_public_preview_branding(
         self, public_host: str | None, public_url: str | None

--- a/dynamiq/sandboxes/base.py
+++ b/dynamiq/sandboxes/base.py
@@ -300,8 +300,6 @@ class Sandbox(abc.ABC, BaseModel):
             resolved_path = self._resolve_path(file_path)
             result = self.run_command_shell(f"rm -f {shlex.quote(resolved_path)}")
             return getattr(result, "is_success", True)
-        except NotImplementedError:
-            raise
         except Exception as e:
             logging.getLogger(__name__).warning(f"{self.__class__.__name__}.delete_file({file_path}) failed: {e}")
             return False

--- a/tests/integration/nodes/agents/test_agent_methods.py
+++ b/tests/integration/nodes/agents/test_agent_methods.py
@@ -628,6 +628,35 @@ def test_agent_state_updates_with_todos(openai_node):
     assert state.todos == []
 
 
+def test_clear_todos_file_deletes_file_and_resets_agent_state_todos():
+    """_clear_todos_file both deletes the todos file from storage and empties AgentState.todos."""
+    import types
+
+    from dynamiq.nodes.agents.agent import AgentState
+    from dynamiq.nodes.agents.base import Agent
+    from dynamiq.nodes.tools.todo_tools import TODOS_FILE_PATH, TodoItem, TodoStatus, TodoWriteTool
+    from dynamiq.storages.file.in_memory import InMemoryFileStore
+
+    backend = InMemoryFileStore()
+    backend.store(file_path=TODOS_FILE_PATH, content=b'{"todos": []}', content_type="application/json")
+    assert backend.exists(TODOS_FILE_PATH), "precondition: todos file exists in storage"
+
+    state = AgentState()
+    state.update_todos([TodoItem(id="1", content="do X", status=TodoStatus.IN_PROGRESS)])
+    assert state.todos, "precondition: state has one todo"
+
+    dummy = types.SimpleNamespace(
+        tools=[TodoWriteTool(file_store=backend)],
+        state=state,
+        name="A",
+        id="id",
+    )
+    Agent._clear_todos_file(dummy)
+
+    assert not backend.exists(TODOS_FILE_PATH), "todos file must be deleted from storage"
+    assert state.todos == []
+
+
 def test_execute_file_store_file_upload_flow(openai_node, mocker):
     """Regression: full execute() with file store — deduplicates batch and pre-existing
     names, stores files correctly, and injects saved paths into the LLM message."""

--- a/tests/integration_with_creds/agents/test_agent_todos.py
+++ b/tests/integration_with_creds/agents/test_agent_todos.py
@@ -36,8 +36,16 @@ def run_config():
 
 
 @pytest.mark.integration
-def test_agent_todo_state_updates(openai_llm, run_config):
-    """Test that Agent todo state is updated when using TodoWriteTool."""
+def test_agent_todo_state_updates(openai_llm, run_config, monkeypatch):
+    """Verify the agent writes todos mid-run and that end-of-run cleanup wipes them.
+
+    The todos file and ``agent.state.todos`` only exist during the run — ``Agent.execute()``
+    unconditionally deletes them in its ``finally`` block. To observe that the file
+    really did exist, we intercept ``_clear_todos_file`` and snapshot the pre-cleanup
+    state, then check post-run that cleanup actually ran.
+    """
+    from dynamiq.nodes.agents.agent import TodoItem
+    from dynamiq.nodes.agents.base import Agent as AgentBase
     from dynamiq.nodes.tools.todo_tools import TODOS_FILE_PATH, TodoWriteTool
 
     file_store_backend = InMemoryFileStore()
@@ -63,6 +71,19 @@ def test_agent_todo_state_updates(openai_llm, run_config):
     todo_tools = [t for t in agent.tools if isinstance(t, TodoWriteTool)]
     assert len(todo_tools) == 1, "TodoWriteTool should be automatically added"
 
+    # Snapshot file + state at the instant before cleanup deletes them.
+    snapshot: dict = {}
+    original_clear = AgentBase._clear_todos_file
+
+    def _snapshot_then_clear(self):
+        snapshot["file_existed"] = file_store_backend.exists(TODOS_FILE_PATH)
+        if snapshot["file_existed"]:
+            snapshot["file_content"] = file_store_backend.retrieve(TODOS_FILE_PATH)
+        snapshot["state_todos"] = list(self.state.todos) if self.state is not None else []
+        return original_clear(self)
+
+    monkeypatch.setattr(AgentBase, "_clear_todos_file", _snapshot_then_clear)
+
     workflow = Workflow(flow=Flow(nodes=[agent]))
     tracing = TracingCallbackHandler()
     config = run_config.model_copy(update={"callbacks": [tracing]})
@@ -79,21 +100,24 @@ def test_agent_todo_state_updates(openai_llm, run_config):
     agent_output = result.output[agent.id]["output"]["content"]
     logger.info(f"Agent output: {agent_output}")
 
-    # Check that todos were created in the file store
-    assert file_store_backend.exists(TODOS_FILE_PATH), "Todos file should exist in file store"
-
-    # Verify the agent state has exactly 3 todos
-    todos_content = file_store_backend.retrieve(TODOS_FILE_PATH).decode("utf-8")
-    todos_data = json.loads(todos_content)
+    # The todos file MUST have existed at the moment cleanup was about to run,
+    # proving TodoWriteTool wrote it during the loop.
+    assert snapshot.get("file_existed"), "Todos file should have existed before cleanup fired"
+    todos_data = json.loads(snapshot["file_content"].decode("utf-8"))
     assert "todos" in todos_data, "Todos data should have 'todos' key"
-    assert len(todos_data["todos"]) == 3, f"Should have exactly 3 todos, got {len(todos_data['todos'])}"
+    assert (
+        len(todos_data["todos"]) == 3
+    ), f"Pre-cleanup todos file should contain 3 items, got {len(todos_data['todos'])}"
 
-    # Verify AgentState also has the todos
-    from dynamiq.nodes.agents.agent import TodoItem
+    # In-memory state must also have carried 3 TodoItem objects at that moment.
+    pre_cleanup_state = snapshot["state_todos"]
+    assert len(pre_cleanup_state) == 3, f"Pre-cleanup state should have 3 todos, got {len(pre_cleanup_state)}"
+    assert all(isinstance(t, TodoItem) for t in pre_cleanup_state), "All pre-cleanup todos should be TodoItem instances"
 
-    assert len(agent.state.todos) == 3, f"AgentState should have 3 todos, got {len(agent.state.todos)}"
-    assert all(
-        isinstance(t, TodoItem) for t in agent.state.todos
-    ), "All todos in AgentState should be TodoItem instances"
+    # After execute() returns, the cleanup must have completed: file gone, state empty.
+    assert not file_store_backend.exists(
+        TODOS_FILE_PATH
+    ), "Todos file should be deleted by Agent cleanup in execute()'s finally block"
+    assert agent.state.todos == [], f"AgentState.todos should be empty after cleanup; got {agent.state.todos}"
 
     logger.info("--- Test Passed for Todo State Updates ---")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes end-of-run behavior by deleting todo artifacts that may have been relied on for post-run inspection; touches sandbox file deletion via shell execution, so failures could be backend-specific (though errors are swallowed).
> 
> **Overview**
> `Agent.execute()` now performs unconditional todo cleanup in a `finally` block via a new `_clear_todos_file()` helper, deleting any persisted `todos.json` and resetting in-memory `state.todos` after each run.
> 
> `TodoWriteTool` gains a `clear()` method (swallowing/logging errors), and `Sandbox` adds a default `delete_file()` implementation (via `rm -f`) to support todo deletion across sandbox backends. Tests are updated/added to assert the pre-cleanup todo file/state exist during execution and are removed once the run completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f578299f486138514e70c63d3d8df9a9a393a5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->