### PR TITLE
feat: add structured output of agent

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -3,7 +3,7 @@ from concurrent.futures import as_completed
 from typing import Any, Callable, Mapping
 
 from litellm import get_supported_openai_params, supports_function_calling
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
 from dynamiq.callbacks import AgentStreamingParserCallback, StreamingQueueCallbackHandler
 from dynamiq.executors.context import ContextAwareThreadPoolExecutor
@@ -109,13 +109,13 @@ class Agent(HistoryManagerMixin, BaseAgent):
     format_schema: list = Field(default_factory=list)
     summarization_config: SummarizationConfig = Field(default_factory=SummarizationConfig)
     state: AgentState = Field(default_factory=AgentState, exclude=True)
-    response_format: dict[str, Any] | type[BaseModel] | None = Field(
+    response_format: dict[str, Any] | None = Field(
         default=None,
         description=(
-            "Optional schema for structured final output. Accepts a JSON schema dict or a "
-            "pydantic BaseModel subclass, matching BaseLLM.response_format. When set, the "
-            "agent returns a parsed BaseModel instance (if a model class was given) or a "
-            "dict (if a schema dict was given) instead of a string. Default None keeps the "
+            "Optional JSON schema (dict) for structured final output. Also accepts a "
+            "pydantic BaseModel subclass as input convenience — it is converted to its "
+            "JSON schema dict immediately and stored as dict. When set, the agent's "
+            "final answer is parsed from JSON into a dict. Default None keeps the "
             "existing string-return behaviour."
         ),
     )
@@ -126,9 +126,17 @@ class Agent(HistoryManagerMixin, BaseAgent):
     _streaming_tool_run_id: str | None = None
     _streaming_tool_run_ids: list[str] = PrivateAttr(default_factory=list)
 
-    @property
-    def to_dict_exclude_params(self):
-        return super().to_dict_exclude_params | {"response_format": True}
+    @field_validator("response_format", mode="before")
+    @classmethod
+    def _normalize_response_format(cls, v):
+        """Accept a pydantic BaseModel subclass as input but store it as a dict schema."""
+        if v is None or isinstance(v, dict):
+            return v
+        if isinstance(v, type) and issubclass(v, BaseModel):
+            from dynamiq.nodes.agents.components import schema_generator
+
+            return schema_generator.unwrap_response_format(v)
+        return v
 
     def get_clone_attr_initializers(self) -> dict[str, Callable[[Node], Any]]:
         """
@@ -1629,20 +1637,13 @@ class Agent(HistoryManagerMixin, BaseAgent):
         )
 
     def _coerce_to_response_format(self, final_answer: Any) -> Any:
-        """Convert the raw final answer into the shape requested by ``response_format``.
+        """Parse the raw final answer into a dict matching ``response_format``.
 
-        - If ``response_format`` is a pydantic BaseModel subclass, returns a
-          validated instance of that model.
-        - If ``response_format`` is a dict (JSON schema), returns a plain dict.
-        - FUNCTION_CALLING mode may already pass a dict (litellm parses the
-          function arguments); other modes pass a JSON string.
+        ``response_format`` is always a JSON schema dict (BaseModel input is
+        converted to dict at validation time). FUNCTION_CALLING mode may pass an
+        already-parsed dict; other modes pass a JSON string that needs parsing.
         """
         if self.response_format is None:
-            return final_answer
-
-        is_model = isinstance(self.response_format, type) and issubclass(self.response_format, BaseModel)
-
-        if is_model and isinstance(final_answer, self.response_format):
             return final_answer
 
         if isinstance(final_answer, str):
@@ -1652,14 +1653,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 raise ParsingError(f"Final answer is not valid JSON for response_format: {e}") from e
 
         if isinstance(final_answer, (dict, list)):
-            if is_model:
-                try:
-                    return self.response_format.model_validate(final_answer)
-                except Exception as e:
-                    raise ParsingError(
-                        f"Final answer did not validate against response_format "
-                        f"{self.response_format.__name__}: {e}"
-                    ) from e
             return final_answer
 
         raise ParsingError(

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1417,7 +1417,10 @@ class Agent(HistoryManagerMixin, BaseAgent):
                     **kwargs,
                 )
             if self.response_format is not None:
-                max_loop_final_answer = self._coerce_to_response_format(max_loop_final_answer)
+                try:
+                    max_loop_final_answer = self._coerce_to_response_format(max_loop_final_answer)
+                except ParsingError as e:
+                    raise ParsingError(f"Max-loops fallback answer could not be coerced to response_format: {e}") from e
             return max_loop_final_answer
 
     def _try_summarize_history(
@@ -1522,7 +1525,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             str: Final answer provided by the agent.
         """
         # Use model-specific max loops prompt from prompt manager
-        max_loops_prompt = self.system_prompt_manager.max_loops_prompt
+        max_loops_prompt = self.system_prompt_manager.render_max_loops_prompt()
 
         system_message = Message(content=max_loops_prompt, role=MessageRole.SYSTEM, static=True)
         conversation_history = Message(

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -107,6 +107,16 @@ class Agent(HistoryManagerMixin, BaseAgent):
     format_schema: list = Field(default_factory=list)
     summarization_config: SummarizationConfig = Field(default_factory=SummarizationConfig)
     state: AgentState = Field(default_factory=AgentState, exclude=True)
+    response_format: dict[str, Any] | type[BaseModel] | None = Field(
+        default=None,
+        description=(
+            "Optional schema for structured final output. Accepts a JSON schema dict or a "
+            "pydantic BaseModel subclass, matching BaseLLM.response_format. When set, the "
+            "agent returns a parsed BaseModel instance (if a model class was given) or a "
+            "dict (if a schema dict was given) instead of a string. Default None keeps the "
+            "existing string-return behaviour."
+        ),
+    )
 
     _tools: list[Tool] = []
     _response_format: dict[str, Any] | None = None
@@ -1304,7 +1314,10 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 # Handle final answer
                 if result[1] == "final_answer":
                     self._resolve_requested_output_files(strict=True)
-                    return result[2]
+                    final_answer = result[2]
+                    if self.response_format is not None:
+                        final_answer = self._coerce_to_response_format(final_answer)
+                    return final_answer
 
                 # Handle recovery (for modes that support it)
                 # Check if action is None, which indicates (None, None, None) recovery
@@ -1382,6 +1395,8 @@ class Agent(HistoryManagerMixin, BaseAgent):
                     config=config,
                     **kwargs,
                 )
+            if self.response_format is not None:
+                max_loop_final_answer = self._coerce_to_response_format(max_loop_final_answer)
             return max_loop_final_answer
 
     def _try_summarize_history(
@@ -1555,7 +1570,11 @@ class Agent(HistoryManagerMixin, BaseAgent):
         # Handle function calling schema generation first
         if self.inference_mode == InferenceMode.FUNCTION_CALLING:
             self._tools = schema_generator.generate_function_calling_schemas(
-                self.tools, self.delegation_allowed, self.sanitize_tool_name, self.llm
+                self.tools,
+                self.delegation_allowed,
+                self.sanitize_tool_name,
+                self.llm,
+                response_format=self.response_format,
             )
         elif self.inference_mode == InferenceMode.STRUCTURED_OUTPUT:
             self._response_format = schema_generator.generate_structured_output_schemas(
@@ -1576,6 +1595,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
             has_sub_agent_tools=any(isinstance(t, SubAgentTool) for t in self.tools),
         )
 
+        if self.response_format is not None and self.inference_mode != InferenceMode.FUNCTION_CALLING:
+            self._inject_response_format_instructions()
+
         # Only auto-wrap the entire role in a raw block if the user did not
         # provide explicit raw/endraw markers. This allows roles to mix
         # literal sections (via raw) with Jinja variables like {{ input }}
@@ -1585,6 +1607,104 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 self.system_prompt_manager.set_block("role", self.role)
             else:
                 self.system_prompt_manager.set_block("role", f"{{% raw %}}{self.role}{{% endraw %}}")
+
+    def _resolve_response_format_schema(self) -> dict[str, Any]:
+        """Return the raw JSON schema dict for the user-provided response_format."""
+        return schema_generator._unwrap_response_format(self.response_format)
+
+    def _inject_response_format_instructions(self) -> None:
+        """Append a directive requiring the final answer to match response_format's schema.
+
+        The directive is merged into the ``output_format`` prompt block so it
+        appears alongside the existing RESPONSE FORMAT section. The structural
+        ReAct schema (thought/action/action_input) is not touched; only the
+        content of the final answer is constrained.
+        """
+        schema_json = json.dumps(self._resolve_response_format_schema(), indent=2)
+        directive = (
+            "\n\n## FINAL ANSWER SCHEMA\n"
+            "Your FINAL answer (the text you provide once you decide to finish) "
+            "MUST be a valid JSON document conforming exactly to this schema:\n"
+            f"{schema_json}\n"
+            "Do not wrap it in prose, Markdown, or code fences."
+        )
+        blocks = self.system_prompt_manager._prompt_blocks
+        existing = blocks.get("output_format", "") or ""
+        blocks["output_format"] = existing + directive
+
+    def _coerce_to_response_format(self, final_answer: Any) -> Any:
+        """Convert the raw final answer into the shape requested by ``response_format``.
+
+        - If ``response_format`` is a pydantic BaseModel subclass, returns a
+          validated instance of that model.
+        - If ``response_format`` is a dict (JSON schema), returns a plain dict.
+        - FUNCTION_CALLING mode may already pass a dict (litellm parses the
+          function arguments); other modes pass a JSON string.
+        """
+        if self.response_format is None:
+            return final_answer
+
+        is_model = isinstance(self.response_format, type) and issubclass(self.response_format, BaseModel)
+
+        if is_model and isinstance(final_answer, self.response_format):
+            return final_answer
+
+        if isinstance(final_answer, (dict, list)):
+            if is_model:
+                return self.response_format.model_validate(final_answer)
+            return final_answer
+
+        if not isinstance(final_answer, str):
+            raise ParsingError(
+                f"Cannot coerce final answer of type {type(final_answer).__name__} " "to the requested response_format."
+            )
+
+        payload = self._extract_json_payload(final_answer)
+        if is_model:
+            try:
+                return self.response_format.model_validate_json(payload)
+            except Exception as e:
+                raise ParsingError(
+                    f"Final answer did not validate against response_format " f"{self.response_format.__name__}: {e}"
+                ) from e
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as e:
+            raise ParsingError(f"Final answer is not valid JSON for response_format: {e}") from e
+
+    @staticmethod
+    def _extract_json_payload(text: str) -> str:
+        """Return a JSON substring from ``text``.
+
+        Accepts raw JSON, JSON wrapped in Markdown code fences, or JSON embedded
+        in prose. Falls back to the first balanced ``{...}`` or ``[...]`` block.
+        """
+        stripped = text.strip()
+        if stripped.startswith("```"):
+            # Strip leading fence with optional language tag
+            lines = stripped.splitlines()
+            if lines and lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].startswith("```"):
+                lines = lines[:-1]
+            stripped = "\n".join(lines).strip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            return stripped
+
+        for opener, closer in (("{", "}"), ("[", "]")):
+            start = stripped.find(opener)
+            if start == -1:
+                continue
+            depth = 0
+            for idx in range(start, len(stripped)):
+                ch = stripped[idx]
+                if ch == opener:
+                    depth += 1
+                elif ch == closer:
+                    depth -= 1
+                    if depth == 0:
+                        return stripped[start : idx + 1]
+        return stripped
 
     @staticmethod
     def _build_unique_file_key(files_map: dict[str, Any], base: str) -> str:

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -124,6 +124,10 @@ class Agent(HistoryManagerMixin, BaseAgent):
     _streaming_tool_run_id: str | None = None
     _streaming_tool_run_ids: list[str] = PrivateAttr(default_factory=list)
 
+    @property
+    def to_dict_exclude_params(self):
+        return super().to_dict_exclude_params | {"response_format": True}
+
     def get_clone_attr_initializers(self) -> dict[str, Callable[[Node], Any]]:
         """
         Define attribute initializers for cloning.
@@ -1331,6 +1335,8 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 )
 
                 if final_answer is not None:
+                    if self.response_format is not None:
+                        final_answer = self._coerce_to_response_format(final_answer)
                     return final_answer
 
             except OutputFileNotFoundError as e:
@@ -1696,8 +1702,21 @@ class Agent(HistoryManagerMixin, BaseAgent):
             if start == -1:
                 continue
             depth = 0
+            in_string = False
+            escape = False
             for idx in range(start, len(stripped)):
                 ch = stripped[idx]
+                if in_string:
+                    if escape:
+                        escape = False
+                    elif ch == "\\":
+                        escape = True
+                    elif ch == '"':
+                        in_string = False
+                    continue
+                if ch == '"':
+                    in_string = True
+                    continue
                 if ch == opener:
                     depth += 1
                 elif ch == closer:

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -38,6 +38,7 @@ from dynamiq.types.streaming import (
     StreamingMode,
 )
 from dynamiq.utils import generate_uuid, serialize_files_in_value
+from dynamiq.utils.json_parser import parse_llm_json_output
 from dynamiq.utils.logger import logger
 
 
@@ -1354,6 +1355,19 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 )
                 continue
 
+            except ParsingError as e:
+                self._append_recovery_instruction(
+                    error_label=type(e).__name__,
+                    error_detail=str(e),
+                    llm_generated_output=llm_generated_output,
+                    extra_guidance=(
+                        "Your final answer must be valid JSON that conforms exactly to the declared "
+                        "response_format schema. Return only the JSON document — no prose, Markdown, "
+                        "or code fences — and provide the final answer again."
+                    ),
+                )
+                continue
+
             except ActionParsingException as e:
                 self._emit_tool_input_error(e, loop_num, config, **kwargs)
 
@@ -1587,7 +1601,17 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
         # Build the entire prompt in one call
         model_name = getattr(self.llm, "model", None)
-        self.system_prompt_manager = AgentPromptManager(model_name=model_name, tool_description=self.tool_description)
+        response_format_schema = (
+            schema_generator.unwrap_response_format(self.response_format)
+            if self.response_format is not None and self.inference_mode in (InferenceMode.DEFAULT, InferenceMode.XML)
+            else None
+        )
+        self.system_prompt_manager = AgentPromptManager(
+            model_name=model_name,
+            tool_description=self.tool_description,
+            response_format_schema=response_format_schema,
+        )
+
         self.system_prompt_manager.build_react_prompt(
             ReactPromptConfig(
                 inference_mode=self.inference_mode,
@@ -1603,30 +1627,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 instructions=self.instructions,
             )
         )
-
-    def _resolve_response_format_schema(self) -> dict[str, Any]:
-        """Return the raw JSON schema dict for the user-provided response_format."""
-        return schema_generator._unwrap_response_format(self.response_format)
-
-    def _inject_response_format_instructions(self) -> None:
-        """Append a directive requiring the final answer to match response_format's schema.
-
-        The directive is merged into the ``output_format`` prompt block so it
-        appears alongside the existing RESPONSE FORMAT section. The structural
-        ReAct schema (thought/action/action_input) is not touched; only the
-        content of the final answer is constrained.
-        """
-        schema_json = json.dumps(self._resolve_response_format_schema(), indent=2)
-        directive = (
-            "\n\n## FINAL ANSWER SCHEMA\n"
-            "Your FINAL answer (the text you provide once you decide to finish) "
-            "MUST be a valid JSON document conforming exactly to this schema:\n"
-            f"{schema_json}\n"
-            "Do not wrap it in prose, Markdown, or code fences."
-        )
-        blocks = self.system_prompt_manager._prompt_blocks
-        existing = blocks.get("output_format", "") or ""
-        blocks["output_format"] = existing + directive
 
     def _coerce_to_response_format(self, final_answer: Any) -> Any:
         """Convert the raw final answer into the shape requested by ``response_format``.
@@ -1645,75 +1645,26 @@ class Agent(HistoryManagerMixin, BaseAgent):
         if is_model and isinstance(final_answer, self.response_format):
             return final_answer
 
+        if isinstance(final_answer, str):
+            try:
+                final_answer = parse_llm_json_output(final_answer)
+            except ValueError as e:
+                raise ParsingError(f"Final answer is not valid JSON for response_format: {e}") from e
+
         if isinstance(final_answer, (dict, list)):
             if is_model:
-                return self.response_format.model_validate(final_answer)
+                try:
+                    return self.response_format.model_validate(final_answer)
+                except Exception as e:
+                    raise ParsingError(
+                        f"Final answer did not validate against response_format "
+                        f"{self.response_format.__name__}: {e}"
+                    ) from e
             return final_answer
 
-        if not isinstance(final_answer, str):
-            raise ParsingError(
-                f"Cannot coerce final answer of type {type(final_answer).__name__} " "to the requested response_format."
-            )
-
-        payload = self._extract_json_payload(final_answer)
-        if is_model:
-            try:
-                return self.response_format.model_validate_json(payload)
-            except Exception as e:
-                raise ParsingError(
-                    f"Final answer did not validate against response_format " f"{self.response_format.__name__}: {e}"
-                ) from e
-        try:
-            return json.loads(payload)
-        except json.JSONDecodeError as e:
-            raise ParsingError(f"Final answer is not valid JSON for response_format: {e}") from e
-
-    @staticmethod
-    def _extract_json_payload(text: str) -> str:
-        """Return a JSON substring from ``text``.
-
-        Accepts raw JSON, JSON wrapped in Markdown code fences, or JSON embedded
-        in prose. Falls back to the first balanced ``{...}`` or ``[...]`` block.
-        """
-        stripped = text.strip()
-        if stripped.startswith("```"):
-            # Strip leading fence with optional language tag
-            lines = stripped.splitlines()
-            if lines and lines[0].startswith("```"):
-                lines = lines[1:]
-            if lines and lines[-1].startswith("```"):
-                lines = lines[:-1]
-            stripped = "\n".join(lines).strip()
-        if stripped.startswith("{") or stripped.startswith("["):
-            return stripped
-
-        for opener, closer in (("{", "}"), ("[", "]")):
-            start = stripped.find(opener)
-            if start == -1:
-                continue
-            depth = 0
-            in_string = False
-            escape = False
-            for idx in range(start, len(stripped)):
-                ch = stripped[idx]
-                if in_string:
-                    if escape:
-                        escape = False
-                    elif ch == "\\":
-                        escape = True
-                    elif ch == '"':
-                        in_string = False
-                    continue
-                if ch == '"':
-                    in_string = True
-                    continue
-                if ch == opener:
-                    depth += 1
-                elif ch == closer:
-                    depth -= 1
-                    if depth == 0:
-                        return stripped[start : idx + 1]
-        return stripped
+        raise ParsingError(
+            f"Cannot coerce final answer of type {type(final_answer).__name__} to the requested response_format."
+        )
 
     @staticmethod
     def _build_unique_file_key(files_map: dict[str, Any], base: str) -> str:

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -129,14 +129,19 @@ class Agent(HistoryManagerMixin, BaseAgent):
     @field_validator("response_format", mode="before")
     @classmethod
     def _normalize_response_format(cls, v):
-        """Accept a pydantic BaseModel subclass as input but store it as a dict schema."""
-        if v is None or isinstance(v, dict):
-            return v
-        if isinstance(v, type) and issubclass(v, BaseModel):
-            from dynamiq.nodes.agents.components import schema_generator
+        """Normalize any accepted input to a raw JSON schema dict.
 
-            return schema_generator.unwrap_response_format(v)
-        return v
+        Routes all non-None inputs through ``unwrap_response_format`` so the
+        stored value has a single shape regardless of how it was constructed:
+        BaseModel class, litellm-wrapped dict, or raw schema dict all land as
+        the raw schema dict.
+        """
+        if v is None:
+            return v
+
+        from dynamiq.nodes.agents.components import schema_generator
+
+        return schema_generator.unwrap_response_format(v)
 
     def get_clone_attr_initializers(self) -> dict[str, Callable[[Node], Any]]:
         """

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1591,7 +1591,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 self.tools,
                 self.delegation_allowed,
                 self.sanitize_tool_name,
-                self.llm,
                 response_format=self.response_format,
             )
         elif self.inference_mode == InferenceMode.STRUCTURED_OUTPUT:
@@ -1602,9 +1601,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
         # Build the entire prompt in one call
         model_name = getattr(self.llm, "model", None)
         response_format_schema = (
-            schema_generator.unwrap_response_format(self.response_format)
-            if self.response_format is not None and self.inference_mode in (InferenceMode.DEFAULT, InferenceMode.XML)
-            else None
+            schema_generator.unwrap_response_format(self.response_format) if self.response_format is not None else None
         )
         self.system_prompt_manager = AgentPromptManager(
             model_name=model_name,

--- a/dynamiq/nodes/agents/components/schema_generator.py
+++ b/dynamiq/nodes/agents/components/schema_generator.py
@@ -44,6 +44,72 @@ FINAL_ANSWER_FUNCTION_SCHEMA = {
 }
 
 
+def _unwrap_response_format(response_format: dict | type[BaseModel]) -> dict:
+    """Return a raw JSON-schema object for use inside another schema.
+
+    Accepts either a pydantic BaseModel subclass or a dict. For dicts we
+    strip the ``{"type": "json_schema", "json_schema": {"schema": ...}}``
+    wrapper that callers may pass (matching litellm's response_format shape).
+    """
+    if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+        return _basemodel_to_schema(response_format)
+
+    if isinstance(response_format, dict):
+        if response_format.get("type") == "json_schema" and "json_schema" in response_format:
+            inner = response_format["json_schema"]
+            if isinstance(inner, dict) and "schema" in inner:
+                return inner["schema"]
+            return inner
+        return response_format
+
+    raise TypeError(f"Unsupported response_format type: {type(response_format).__name__}")
+
+
+def build_final_answer_function_schema(response_format: dict | type[BaseModel] | None) -> dict:
+    """Return ``FINAL_ANSWER_FUNCTION_SCHEMA``, optionally with the ``answer``
+    property replaced by a user-provided schema.
+
+    When ``response_format`` is ``None`` the original schema is returned
+    unchanged so default behaviour is preserved.
+    """
+    if response_format is None:
+        return FINAL_ANSWER_FUNCTION_SCHEMA
+
+    answer_schema = _unwrap_response_format(response_format)
+    strict = _is_strict_compatible(answer_schema)
+
+    parameters = {
+        "type": "object",
+        "properties": {
+            "thought": {
+                "type": "string",
+                "description": "Your reasoning about why you can answer original question.",
+            },
+            "answer": answer_schema,
+            "output_files": {
+                "type": "string",
+                "description": "Optional comma-separated file paths to return. Empty string if none.",
+            },
+        },
+        "required": ["thought", "answer", "output_files"],
+    }
+    if strict:
+        parameters["additionalProperties"] = False
+
+    return {
+        "type": "function",
+        "strict": strict,
+        "function": {
+            "name": "provide_final_answer",
+            "description": (
+                "Function should be called when if you can answer the initial request"
+                " or if there is not request at all."
+            ),
+            "parameters": parameters,
+        },
+    }
+
+
 PRIORITY_FIELDS = ("brief",)
 
 
@@ -326,7 +392,11 @@ def generate_property_schema(properties: dict, name: str, field: Any) -> None:
 
 
 def generate_function_calling_schemas(
-    tools: list[Node], delegation_allowed: bool, sanitize_tool_name: Callable[[str], str], llm: Any
+    tools: list[Node],
+    delegation_allowed: bool,
+    sanitize_tool_name: Callable[[str], str],
+    llm: Any,
+    response_format: dict | type[BaseModel] | None = None,
 ) -> list[dict]:
     """
     Generate schemas for function calling mode.
@@ -336,11 +406,15 @@ def generate_function_calling_schemas(
         delegation_allowed: Whether delegation is allowed
         sanitize_tool_name: Function to sanitize tool names
         llm: The LLM instance
+        response_format: Optional user-provided schema. When set, the
+            ``provide_final_answer`` function's ``answer`` property is
+            replaced with this schema so the LLM returns structured data
+            directly as part of the final answer function call.
 
     Returns:
         List of function calling schemas for all tools
     """
-    schemas = [FINAL_ANSWER_FUNCTION_SCHEMA]
+    schemas = [build_final_answer_function_schema(response_format)]
 
     for tool in tools:
         if isinstance(tool, SubAgentTool):

--- a/dynamiq/nodes/agents/components/schema_generator.py
+++ b/dynamiq/nodes/agents/components/schema_generator.py
@@ -394,7 +394,6 @@ def generate_function_calling_schemas(
     tools: list[Node],
     delegation_allowed: bool,
     sanitize_tool_name: Callable[[str], str],
-    llm: Any,
     response_format: dict | type[BaseModel] | None = None,
 ) -> list[dict]:
     """
@@ -404,7 +403,6 @@ def generate_function_calling_schemas(
         tools: List of tools to generate schemas for
         delegation_allowed: Whether delegation is allowed
         sanitize_tool_name: Function to sanitize tool names
-        llm: The LLM instance
         response_format: Optional user-provided schema. When set, the
             ``provide_final_answer`` function's ``answer`` property is
             replaced with this schema so the LLM returns structured data

--- a/dynamiq/nodes/agents/components/schema_generator.py
+++ b/dynamiq/nodes/agents/components/schema_generator.py
@@ -43,7 +43,7 @@ FINAL_ANSWER_FUNCTION_SCHEMA = {
 }
 
 
-def _unwrap_response_format(response_format: dict | type[BaseModel]) -> dict:
+def unwrap_response_format(response_format: dict | type[BaseModel]) -> dict:
     """Return a raw JSON-schema object for use inside another schema.
 
     Accepts either a pydantic BaseModel subclass or a dict. For dicts we
@@ -74,7 +74,7 @@ def build_final_answer_function_schema(response_format: dict | type[BaseModel] |
     if response_format is None:
         return FINAL_ANSWER_FUNCTION_SCHEMA
 
-    answer_schema = _unwrap_response_format(response_format)
+    answer_schema = unwrap_response_format(response_format)
     strict = _is_strict_compatible(answer_schema)
 
     parameters = {

--- a/dynamiq/nodes/agents/prompts/manager.py
+++ b/dynamiq/nodes/agents/prompts/manager.py
@@ -184,6 +184,15 @@ class AgentPromptManager:
         prompt = self._clean_prompt(prompt)
         return textwrap.dedent(prompt)
 
+    def render_max_loops_prompt(self) -> str:
+        """Render ``max_loops_prompt`` with the manager's current variables.
+
+        The template may reference prompt variables such as ``response_format_schema``
+        so the fallback LLM call sees any schema constraints the rest of the
+        prompt carries.
+        """
+        return Template(self.max_loops_prompt).render(self._prompt_variables)
+
     def render_block(self, block_name: str, **kwargs) -> str:
         """
         Renders a specific prompt block with variables.

--- a/dynamiq/nodes/agents/prompts/manager.py
+++ b/dynamiq/nodes/agents/prompts/manager.py
@@ -1,5 +1,6 @@
 """Helper functions and managers for model-specific prompts."""
 
+import json
 import re
 import textwrap
 from datetime import datetime
@@ -64,13 +65,21 @@ class AgentPromptManager:
         agent.prompt_manager.generate_prompt()
     """
 
-    def __init__(self, model_name: str = None, tool_description: str = ""):
+    def __init__(
+        self,
+        model_name: str = None,
+        tool_description: str = "",
+        response_format_schema: dict | None = None,
+    ):
         """
         Initialize the prompt manager.
 
         Args:
             model_name: The LLM model name for model-specific prompts
             tool_description: Description of available tools
+            response_format_schema: Optional JSON schema (as a dict) that the agent's
+                final answer must conform to. Rendered into the RESPONSE FORMAT block
+                so the LLM sees the target shape in free-text modes.
         """
         self.model_name = model_name
 
@@ -94,6 +103,8 @@ class AgentPromptManager:
             "tool_description": tool_description,
             "date": datetime.now().strftime("%d %B %Y"),
         }
+        if response_format_schema is not None:
+            self._initial_variables["response_format_schema"] = json.dumps(response_format_schema, indent=2)
         self._prompt_variables: dict[str, Any] = self._initial_variables.copy()
 
     def set_block(self, block_name: str, content: str):

--- a/dynamiq/nodes/agents/prompts/manager.py
+++ b/dynamiq/nodes/agents/prompts/manager.py
@@ -15,6 +15,7 @@ from dynamiq.nodes.agents.prompts.react import (
     REACT_BLOCK_INSTRUCTIONS_SINGLE,
     REACT_BLOCK_INSTRUCTIONS_STRUCTURED_OUTPUT,
     REACT_BLOCK_OUTPUT_FORMAT,
+    REACT_BLOCK_OUTPUT_FORMAT_FUNCTION_CALLING,
     REACT_BLOCK_TOOLS,
     REACT_BLOCK_TOOLS_BRIEF,
     REACT_BLOCK_XML_INSTRUCTIONS_NO_TOOLS,
@@ -257,7 +258,14 @@ class AgentPromptManager:
         instructions_no_tools = get_prompt_constant(
             model, "REACT_BLOCK_INSTRUCTIONS_NO_TOOLS", REACT_BLOCK_INSTRUCTIONS_NO_TOOLS
         )
-        output_format = get_prompt_constant(model, "REACT_BLOCK_OUTPUT_FORMAT", REACT_BLOCK_OUTPUT_FORMAT)
+        if config.inference_mode == InferenceMode.FUNCTION_CALLING:
+            output_format = get_prompt_constant(
+                model,
+                "REACT_BLOCK_OUTPUT_FORMAT_FUNCTION_CALLING",
+                REACT_BLOCK_OUTPUT_FORMAT_FUNCTION_CALLING,
+            )
+        else:
+            output_format = get_prompt_constant(model, "REACT_BLOCK_OUTPUT_FORMAT", REACT_BLOCK_OUTPUT_FORMAT)
 
         prompt_blocks: dict[str, str] = {
             "tools": "" if not config.has_tools else react_block_tools,

--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -329,6 +329,12 @@ Your response should be clear, concise, and professional.
 [Your final answer or explanation goes here]
 </answer>
 <output_files>[Optional: comma-separated absolute file paths to return]</output_files>
+{%- if response_format_schema %}
+
+The content inside <answer> MUST be a valid JSON document conforming exactly to this schema:
+{{response_format_schema}}
+Output only the raw JSON inside the <answer> tag — no prose, Markdown, or code fences.
+{%- endif %}
 """  # noqa: E501
 
 

--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -253,6 +253,13 @@ listing absolute file paths (comma-separated). This tag is optional — omit it 
 
 
 REACT_BLOCK_OUTPUT_FORMAT = """
+{%- if response_format_schema %}
+
+Your FINAL answer (the text you provide once you decide to finish) MUST be a valid JSON document
+ conforming exactly to this schema:
+{{response_format_schema}}
+Do not wrap it in prose, Markdown, or code fences. Output only the raw JSON.
+{%- else %}
 
 In your answers, adhere to the following formatting and stylistic guidelines:
 
@@ -275,6 +282,7 @@ IMPORTANT:
     - Avoid phrases like 'based on the information gathered or provided'.
     - Clearly mention any files that were generated during the process
     - Provide file names and brief descriptions of their contents.
+{%- endif %}
 """
 
 REACT_MAX_LOOPS_PROMPT = """

--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -252,15 +252,7 @@ listing absolute file paths (comma-separated). This tag is optional — omit it 
 """
 
 
-REACT_BLOCK_OUTPUT_FORMAT = """
-{%- if response_format_schema %}
-
-Your FINAL answer (the text you provide once you decide to finish) MUST be a valid JSON document
- conforming exactly to this schema:
-{{response_format_schema}}
-Do not wrap it in prose, Markdown, or code fences. Output only the raw JSON.
-{%- else %}
-
+_REACT_OUTPUT_FORMAT_PROSE_RULES = """
 In your answers, adhere to the following formatting and stylistic guidelines:
 
 - Use GitHub-flavored Markdown as the default format for all responses and generated documents.
@@ -282,8 +274,39 @@ IMPORTANT:
     - Avoid phrases like 'based on the information gathered or provided'.
     - Clearly mention any files that were generated during the process
     - Provide file names and brief descriptions of their contents.
+"""
+
+
+REACT_BLOCK_OUTPUT_FORMAT = (
+    """
+{%- if response_format_schema %}
+
+Your FINAL answer (the text you provide once you decide to finish) MUST be a valid JSON document
+ conforming exactly to this schema:
+{{response_format_schema}}
+Do not wrap it in prose, Markdown, or code fences. Output only the raw JSON.
+{%- else %}
+"""
+    + _REACT_OUTPUT_FORMAT_PROSE_RULES
+    + """
 {%- endif %}
 """
+)
+
+
+REACT_BLOCK_OUTPUT_FORMAT_FUNCTION_CALLING = (
+    """
+{%- if response_format_schema %}
+
+Your final answer must be delivered via the `answer` argument of `provide_final_answer`,
+matching its declared schema exactly.
+{%- else %}
+"""
+    + _REACT_OUTPUT_FORMAT_PROSE_RULES
+    + """
+{%- endif %}
+"""
+)
 
 REACT_MAX_LOOPS_PROMPT = """
 You are tasked with providing a final answer for initial user question based on information gathered during a process that has reached its maximum number of loops.

--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -84,6 +84,7 @@ For questions that don't require tools:
 
 ## Critical XML Format Rules
 - ALWAYS include <thought> tags with detailed reasoning
+- ALWAYS place <thought> BEFORE <action>/<action_input> (or before <answer>); reasoning must come first
 - Start the text immediately after each opening tag; do not add leading newlines or indentation inside the tags
 - Write thoughts in the first person (e.g., "I will...", "I should...")
 - Explain why this specific tool is the right choice
@@ -325,16 +326,20 @@ If you cannot provide a full answer based on the given context, explain that due
 Important: Do not mention specific errors in tools, exact steps, environments, code, or search results. Keep your response general and focused on the task at hand.
 Provide your final answer or explanation within <answer> tags.
 Your response should be clear, concise, and professional.
-<answer>
-[Your final answer or explanation goes here]
-</answer>
-<output_files>[Optional: comma-separated absolute file paths to return]</output_files>
 {%- if response_format_schema %}
 
 The content inside <answer> MUST be a valid JSON document conforming exactly to this schema:
 {{response_format_schema}}
 Output only the raw JSON inside the <answer> tag — no prose, Markdown, or code fences.
 {%- endif %}
+<answer>
+{%- if response_format_schema %}
+[Raw JSON matching the schema above]
+{%- else %}
+[Your final answer or explanation goes here]
+{%- endif %}
+</answer>
+<output_files>[Optional: comma-separated absolute file paths to return]</output_files>
 """  # noqa: E501
 
 

--- a/tests/integration_with_creds/agents/test_agent_response_format.py
+++ b/tests/integration_with_creds/agents/test_agent_response_format.py
@@ -1,0 +1,91 @@
+"""End-to-end tests for Agent.response_format across inference modes.
+
+Verifies that when an Agent is configured with a user-provided schema
+(pydantic BaseModel or JSON schema dict), the final content it returns
+is the parsed structured value - not a string.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from dynamiq import connections
+from dynamiq.nodes.agents import Agent
+from dynamiq.nodes.llms.openai import OpenAI
+from dynamiq.nodes.types import InferenceMode
+
+
+class Document(BaseModel):
+    title: str
+    abstract: str
+    tags: list[str]
+
+
+DICT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "abstract": {"type": "string"},
+        "tags": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["title", "abstract", "tags"],
+    "additionalProperties": False,
+}
+
+
+INPUT_MESSAGE = (
+    "Summarize this book into a document: 'Harry Potter 7' is a fantasy novel "
+    "about a young magical boy facing dark magic. It is fiction, a story, and "
+    "children's literature."
+)
+
+
+INFERENCE_MODES = [
+    InferenceMode.XML,
+    InferenceMode.STRUCTURED_OUTPUT,
+    InferenceMode.FUNCTION_CALLING,
+]
+
+
+def _make_agent(inference_mode: InferenceMode, response_format) -> Agent:
+    llm = OpenAI(model="gpt-5.4-mini", connection=connections.OpenAI(), temperature=0.1)
+    return Agent(
+        name="StructuredAgent",
+        llm=llm,
+        tools=[],
+        inference_mode=inference_mode,
+        response_format=response_format,
+        max_loops=5,
+    )
+
+
+@pytest.mark.flaky(reruns=2)
+@pytest.mark.parametrize("inference_mode", INFERENCE_MODES)
+def test_agent_response_format_dict_schema(inference_mode):
+    """A JSON-schema dict response_format returns a parsed dict in every mode."""
+    agent = _make_agent(inference_mode, response_format=DICT_SCHEMA)
+    result = agent.run(input_data={"input": INPUT_MESSAGE})
+
+    assert result.status.value == "success"
+    content = result.output["content"]
+    assert isinstance(content, dict)
+    assert {"title", "abstract", "tags"} <= content.keys()
+    assert isinstance(content["title"], str) and content["title"]
+    assert isinstance(content["abstract"], str) and content["abstract"]
+    assert isinstance(content["tags"], list)
+    assert all(isinstance(t, str) for t in content["tags"])
+
+
+@pytest.mark.flaky(reruns=2)
+@pytest.mark.parametrize("inference_mode", INFERENCE_MODES)
+def test_agent_response_format_pydantic_model(inference_mode):
+    """A pydantic BaseModel response_format returns a validated instance in every mode."""
+    agent = _make_agent(inference_mode, response_format=Document)
+    result = agent.run(input_data={"input": INPUT_MESSAGE})
+
+    assert result.status.value == "success"
+    content = result.output["content"]
+    assert isinstance(content, Document)
+    assert content.title
+    assert content.abstract
+    assert isinstance(content.tags, list)
+    assert all(isinstance(t, str) for t in content.tags)

--- a/tests/integration_with_creds/agents/test_agent_response_format.py
+++ b/tests/integration_with_creds/agents/test_agent_response_format.py
@@ -78,14 +78,23 @@ def test_agent_response_format_dict_schema(inference_mode):
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize("inference_mode", INFERENCE_MODES)
 def test_agent_response_format_pydantic_model(inference_mode):
-    """A pydantic BaseModel response_format returns a validated instance in every mode."""
+    """A pydantic BaseModel is accepted as ``response_format`` input.
+
+    The agent normalizes the class to its JSON schema dict at validation time
+    and returns the final answer as a parsed dict conforming to that schema.
+    Callers who want a typed instance pass the dict through their BaseModel.
+    """
     agent = _make_agent(inference_mode, response_format=Document)
     result = agent.run(input_data={"input": INPUT_MESSAGE})
 
     assert result.status.value == "success"
     content = result.output["content"]
-    assert isinstance(content, Document)
-    assert content.title
-    assert content.abstract
-    assert isinstance(content.tags, list)
-    assert all(isinstance(t, str) for t in content.tags)
+    assert isinstance(content, dict)
+    assert {"title", "abstract", "tags"} <= content.keys()
+
+    # Caller-side validation recovers the typed instance.
+    doc = Document.model_validate(content)
+    assert doc.title
+    assert doc.abstract
+    assert isinstance(doc.tags, list)
+    assert all(isinstance(t, str) for t in doc.tags)

--- a/tests/unit/nodes/agents/test_agent_parsing.py
+++ b/tests/unit/nodes/agents/test_agent_parsing.py
@@ -520,7 +520,8 @@ def test_agent_coerce_to_dict_schema():
 
 
 def test_agent_coerce_to_pydantic_instance():
-    """Pydantic response_format returns a validated instance."""
+    """BaseModel input is normalized to its JSON schema dict; coerce returns a parsed dict
+    that the caller can validate back into the original BaseModel."""
     from pydantic import BaseModel
 
     class Doc(BaseModel):
@@ -528,10 +529,18 @@ def test_agent_coerce_to_pydantic_instance():
         tags: list[str]
 
     agent = _make_agent(response_format=Doc)
+    # BaseModel class input is converted to dict schema on field validation.
+    assert isinstance(agent.response_format, dict)
+    assert "title" in agent.response_format["properties"]
+
     result = agent._coerce_to_response_format('{"title": "HP", "tags": ["a", "b"]}')
-    assert isinstance(result, Doc)
-    assert result.title == "HP"
-    assert result.tags == ["a", "b"]
+    assert result == {"title": "HP", "tags": ["a", "b"]}
+
+    # Callers who want a typed object keep their original BaseModel class and validate.
+    doc = Doc.model_validate(result)
+    assert isinstance(doc, Doc)
+    assert doc.title == "HP"
+    assert doc.tags == ["a", "b"]
 
 
 def test_agent_coerce_handles_markdown_fenced_json():
@@ -543,7 +552,7 @@ def test_agent_coerce_handles_markdown_fenced_json():
 
 
 def test_agent_coerce_accepts_already_parsed_dict():
-    """FUNCTION_CALLING already parses arguments to dict; coerce must accept that."""
+    """FUNCTION_CALLING already parses arguments to dict; coerce must pass it through."""
     from pydantic import BaseModel
 
     class Doc(BaseModel):
@@ -551,8 +560,7 @@ def test_agent_coerce_accepts_already_parsed_dict():
 
     agent = _make_agent(response_format=Doc)
     result = agent._coerce_to_response_format({"title": "HP"})
-    assert isinstance(result, Doc)
-    assert result.title == "HP"
+    assert result == {"title": "HP"}
 
 
 def test_agent_coerce_raises_on_invalid_json():
@@ -616,7 +624,7 @@ def test_agent_response_format_structured_output_schema_unchanged():
 
 
 def test_agent_structured_output_finish_with_json_string_action_input():
-    """STRUCTURED_OUTPUT finish emits a JSON string; coerce parses it into the model."""
+    """STRUCTURED_OUTPUT finish emits a JSON string; coerce parses it into a dict."""
     from pydantic import BaseModel
 
     from dynamiq.nodes.types import InferenceMode
@@ -630,5 +638,4 @@ def test_agent_structured_output_finish_with_json_string_action_input():
     thought, action, action_input = agent._handle_structured_output_mode(output, loop_num=1)
     assert action == "final_answer"
     coerced = agent._coerce_to_response_format(action_input)
-    assert isinstance(coerced, Doc)
-    assert coerced.title == "HP"
+    assert coerced == {"title": "HP"}

--- a/tests/unit/nodes/agents/test_agent_parsing.py
+++ b/tests/unit/nodes/agents/test_agent_parsing.py
@@ -420,3 +420,213 @@ def _mock_llm_stream(text: str):
         model_r = ModelResponse(stream=True)
         model_r.choices[0].delta = Delta(role="assistant", content=char)
         yield model_r
+
+
+def _make_agent(inference_mode=None, response_format=None):
+    """Build a minimal Agent suitable for in-process unit tests."""
+    import uuid
+
+    from dynamiq import connections, prompts
+    from dynamiq.nodes.agents import Agent
+    from dynamiq.nodes.llms import OpenAI
+    from dynamiq.nodes.types import InferenceMode
+
+    conn = connections.OpenAI(id=str(uuid.uuid4()), api_key="fake-key")
+    llm = OpenAI(
+        name="TestLLM",
+        model="gpt-4o-mini",
+        connection=conn,
+        prompt=prompts.Prompt(messages=[prompts.Message(role="user", content="{{input}}")]),
+    )
+    return Agent(
+        name="test-agent",
+        llm=llm,
+        tools=[],
+        inference_mode=inference_mode or InferenceMode.DEFAULT,
+        response_format=response_format,
+    )
+
+
+class _DocumentModel:
+    """Placeholder — real model is defined inside tests to avoid import-time side effects."""
+
+
+def test_build_final_answer_function_schema_default_unchanged():
+    """With no response_format the schema is the existing FINAL_ANSWER_FUNCTION_SCHEMA."""
+    from dynamiq.nodes.agents.components import schema_generator
+
+    assert schema_generator.build_final_answer_function_schema(None) is schema_generator.FINAL_ANSWER_FUNCTION_SCHEMA
+
+
+def test_build_final_answer_function_schema_with_pydantic_model():
+    """Pydantic classes are expanded and replace the answer property."""
+    from pydantic import BaseModel
+
+    from dynamiq.nodes.agents.components import schema_generator
+
+    class Doc(BaseModel):
+        title: str
+        tags: list[str]
+
+    schema = schema_generator.build_final_answer_function_schema(Doc)
+    props = schema["function"]["parameters"]["properties"]
+    assert props["answer"]["type"] == "object"
+    assert set(props["answer"]["properties"].keys()) == {"title", "tags"}
+    assert props["thought"]["type"] == "string"
+    assert props["output_files"]["type"] == "string"
+
+
+def test_build_final_answer_function_schema_unwraps_dict_wrapper():
+    """When a response_format dict uses litellm's json_schema wrapper it is unwrapped."""
+    from dynamiq.nodes.agents.components import schema_generator
+
+    wrapped = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "x",
+            "schema": {
+                "type": "object",
+                "properties": {"title": {"type": "string"}},
+                "required": ["title"],
+                "additionalProperties": False,
+            },
+        },
+    }
+    schema = schema_generator.build_final_answer_function_schema(wrapped)
+    answer = schema["function"]["parameters"]["properties"]["answer"]
+    assert answer["type"] == "object"
+    assert "title" in answer["properties"]
+
+
+def test_agent_default_returns_string_without_response_format():
+    """Regression: agents without response_format still return strings."""
+    agent = _make_agent()
+    assert agent.response_format is None
+    # _coerce_to_response_format is a no-op
+    assert agent._coerce_to_response_format("plain string") == "plain string"
+
+
+def test_agent_coerce_to_dict_schema():
+    """Dict response_format parses JSON string into a dict."""
+    schema = {
+        "type": "object",
+        "properties": {"title": {"type": "string"}},
+        "required": ["title"],
+        "additionalProperties": False,
+    }
+    agent = _make_agent(response_format=schema)
+    result = agent._coerce_to_response_format('{"title": "Harry Potter"}')
+    assert result == {"title": "Harry Potter"}
+
+
+def test_agent_coerce_to_pydantic_instance():
+    """Pydantic response_format returns a validated instance."""
+    from pydantic import BaseModel
+
+    class Doc(BaseModel):
+        title: str
+        tags: list[str]
+
+    agent = _make_agent(response_format=Doc)
+    result = agent._coerce_to_response_format('{"title": "HP", "tags": ["a", "b"]}')
+    assert isinstance(result, Doc)
+    assert result.title == "HP"
+    assert result.tags == ["a", "b"]
+
+
+def test_agent_coerce_handles_markdown_fenced_json():
+    """The coercion strips Markdown code fences around JSON."""
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+    agent = _make_agent(response_format=schema)
+    result = agent._coerce_to_response_format('```json\n{"x": 7}\n```')
+    assert result == {"x": 7}
+
+
+def test_agent_coerce_accepts_already_parsed_dict():
+    """FUNCTION_CALLING already parses arguments to dict; coerce must accept that."""
+    from pydantic import BaseModel
+
+    class Doc(BaseModel):
+        title: str
+
+    agent = _make_agent(response_format=Doc)
+    result = agent._coerce_to_response_format({"title": "HP"})
+    assert isinstance(result, Doc)
+    assert result.title == "HP"
+
+
+def test_agent_coerce_raises_on_invalid_json():
+    """Malformed final answer raises a ParsingError with a clear message."""
+    from dynamiq.nodes.agents.exceptions import ParsingError
+
+    schema = {"type": "object"}
+    agent = _make_agent(response_format=schema)
+    with pytest.raises(ParsingError):
+        agent._coerce_to_response_format("definitely not json")
+
+
+def test_agent_response_format_injects_prompt_instructions():
+    """Non-FUNCTION_CALLING modes get a FINAL ANSWER SCHEMA directive appended."""
+    from dynamiq.nodes.types import InferenceMode
+
+    schema = {"type": "object", "properties": {"title": {"type": "string"}}}
+    agent = _make_agent(inference_mode=InferenceMode.DEFAULT, response_format=schema)
+    output_format = agent.system_prompt_manager._prompt_blocks.get("output_format", "")
+    assert "FINAL ANSWER SCHEMA" in output_format
+    assert "title" in output_format
+
+
+def test_agent_response_format_function_calling_uses_schema_in_tools():
+    """FUNCTION_CALLING mode swaps the answer schema in the final-answer function."""
+    from pydantic import BaseModel
+
+    from dynamiq.nodes.types import InferenceMode
+
+    class Doc(BaseModel):
+        title: str
+
+    agent = _make_agent(inference_mode=InferenceMode.FUNCTION_CALLING, response_format=Doc)
+    final_answer_schema = next(s for s in agent._tools if s.get("function", {}).get("name") == "provide_final_answer")
+    answer = final_answer_schema["function"]["parameters"]["properties"]["answer"]
+    assert answer["type"] == "object"
+    assert "title" in answer["properties"]
+
+
+def test_agent_response_format_structured_output_schema_unchanged():
+    """STRUCTURED_OUTPUT keeps its simple `action_input: string` schema; the
+    user's response_format is enforced via prompt injection + coerce instead."""
+    from pydantic import BaseModel
+
+    from dynamiq.nodes.types import InferenceMode
+
+    class Doc(BaseModel):
+        title: str
+        tags: list[str]
+
+    agent = _make_agent(inference_mode=InferenceMode.STRUCTURED_OUTPUT, response_format=Doc)
+    schema = agent._response_format["json_schema"]["schema"]
+    assert schema["properties"]["action_input"] == {
+        "type": "string",
+        "description": "Input for chosen action.",
+    }
+    output_format = agent.system_prompt_manager._prompt_blocks.get("output_format", "")
+    assert "FINAL ANSWER SCHEMA" in output_format
+
+
+def test_agent_structured_output_finish_with_json_string_action_input():
+    """STRUCTURED_OUTPUT finish emits a JSON string; coerce parses it into the model."""
+    from pydantic import BaseModel
+
+    from dynamiq.nodes.types import InferenceMode
+
+    class Doc(BaseModel):
+        title: str
+
+    agent = _make_agent(inference_mode=InferenceMode.STRUCTURED_OUTPUT, response_format=Doc)
+
+    output = '{"thought": "done", "action": "finish", ' '"action_input": "{\\"title\\": \\"HP\\"}", "output_files": ""}'
+    thought, action, action_input = agent._handle_structured_output_mode(output, loop_num=1)
+    assert action == "final_answer"
+    coerced = agent._coerce_to_response_format(action_input)
+    assert isinstance(coerced, Doc)
+    assert coerced.title == "HP"

--- a/tests/unit/nodes/agents/test_agent_parsing.py
+++ b/tests/unit/nodes/agents/test_agent_parsing.py
@@ -566,14 +566,14 @@ def test_agent_coerce_raises_on_invalid_json():
 
 
 def test_agent_response_format_injects_prompt_instructions():
-    """Non-FUNCTION_CALLING modes get a FINAL ANSWER SCHEMA directive appended."""
+    """Non-FUNCTION_CALLING modes inline the response_format schema into the rendered prompt."""
     from dynamiq.nodes.types import InferenceMode
 
     schema = {"type": "object", "properties": {"title": {"type": "string"}}}
     agent = _make_agent(inference_mode=InferenceMode.DEFAULT, response_format=schema)
-    output_format = agent.system_prompt_manager._prompt_blocks.get("output_format", "")
-    assert "FINAL ANSWER SCHEMA" in output_format
-    assert "title" in output_format
+    rendered = agent.generate_prompt()
+    assert "MUST be a valid JSON document" in rendered
+    assert "title" in rendered
 
 
 def test_agent_response_format_function_calling_uses_schema_in_tools():
@@ -609,8 +609,10 @@ def test_agent_response_format_structured_output_schema_unchanged():
         "type": "string",
         "description": "Input for chosen action.",
     }
-    output_format = agent.system_prompt_manager._prompt_blocks.get("output_format", "")
-    assert "FINAL ANSWER SCHEMA" in output_format
+    rendered = agent.generate_prompt()
+    assert "MUST be a valid JSON document" in rendered
+    assert "title" in rendered
+    assert "tags" in rendered
 
 
 def test_agent_structured_output_finish_with_json_string_action_input():

--- a/tests/unit/nodes/agents/test_sub_agent_tool.py
+++ b/tests/unit/nodes/agents/test_sub_agent_tool.py
@@ -957,6 +957,49 @@ class TestYamlRoundtrip:
                 "Child agent must have been initialized via init_components"
             )
 
+    def test_agent_response_format_yaml_roundtrip(self, tmp_path):
+        """``response_format`` survives YAML roundtrip for both input forms.
+
+        - Dict input: stored and roundtripped as-is.
+        - BaseModel input: normalized to JSON schema dict at validation time,
+          then roundtripped as dict.
+        """
+        from pydantic import BaseModel
+
+        openai_conn = OpenAIConnection(id="openai-conn", api_key="test-key")
+        llm = OpenAI(id="llm", connection=openai_conn, model="gpt-4o")
+
+        schema_dict = {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+        }
+
+        class Doc(BaseModel):
+            title: str
+            tags: list[str]
+
+        agent_dict = Agent(id="dict-agent", name="Dict Agent", llm=llm, tools=[], response_format=schema_dict)
+        agent_model = Agent(id="model-agent", name="Model Agent", llm=llm, tools=[], response_format=Doc)
+
+        # BaseModel input is converted to a schema dict at field validation time.
+        assert isinstance(agent_model.response_format, dict)
+        model_schema_dict = agent_model.response_format
+
+        wf = Workflow(
+            id="rf-wf",
+            flow=Flow(id="rf-flow", name="Response Format Flow", nodes=[agent_dict, agent_model]),
+            version="1",
+        )
+
+        yaml_path = tmp_path / "response_format.yaml"
+        wf.to_yaml_file(yaml_path)
+        loaded = Workflow.from_yaml_file(str(yaml_path), init_components=True)
+
+        loaded_nodes = {n.id: n for n in loaded.flow.nodes}
+        assert loaded_nodes["dict-agent"].response_format == schema_dict
+        assert loaded_nodes["model-agent"].response_format == model_schema_dict
+
 
 # --- ToolParams resolution through SubAgentTool wrapper ---
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the agent’s public return type when `response_format` is set (string → parsed JSON dict/list) and threads schema constraints through prompting and function-calling schemas, which could affect downstream consumers and error-recovery behavior across inference modes.
> 
> **Overview**
> Adds optional `Agent.response_format` to request **structured final output**: callers can pass a JSON-schema dict (or a pydantic `BaseModel` class, normalized to schema) and the agent will return the final answer as parsed JSON (dict/list) instead of a string.
> 
> Plumbs the schema through prompt rendering (including max-loops fallback) and updates function-calling mode so `provide_final_answer.answer` uses the provided schema; adds JSON coercion + recovery messaging on `ParsingError`. Includes new unit + integration tests covering all inference modes, schema unwrapping, YAML roundtrip, and JSON fence handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 490e730bbcab1a2926e5e6a84295ff6a915ec395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->