### PR TITLE
feat: add PythonMonty node

### DIFF
--- a/dynamiq/nodes/tools/__init__.py
+++ b/dynamiq/nodes/tools/__init__.py
@@ -16,6 +16,7 @@ from .pipedream import Pipedream
 from .preprocess_tool import PreprocessTool
 from .python import Python
 from .python_code_executor import PythonCodeExecutor
+from .python_monty import PythonMonty
 from .scale_serp import ScaleSerpTool
 from .skills_tool import SkillsTool
 from .sql_executor import SQLExecutor

--- a/dynamiq/nodes/tools/python_monty.py
+++ b/dynamiq/nodes/tools/python_monty.py
@@ -1,0 +1,113 @@
+import ast
+import asyncio
+from typing import Any, ClassVar, Literal
+
+from dynamiq.nodes import Node, NodeGroup
+from dynamiq.nodes.agents.exceptions import ToolExecutionException
+from dynamiq.nodes.node import ensure_config
+from dynamiq.nodes.tools.python import PythonInputSchema
+from dynamiq.nodes.types import ActionType
+from dynamiq.runnables import RunnableConfig
+from dynamiq.utils.logger import logger
+
+_INPUTS_VAR = "__dynamiq_inputs__"
+
+
+def _run_contains_async_def(code: str) -> bool:
+    """Return True if user code defines `async def run(...)` at module scope."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return False
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "run":
+            return True
+    return False
+
+
+def _wrap_user_code(code: str, use_multiple_params: bool) -> str:
+    """Append a trailing call to `run(...)` so Monty returns its value."""
+    is_async = _run_contains_async_def(code)
+    call_prefix = "await " if is_async else ""
+    if use_multiple_params:
+        trailer = f"{call_prefix}run(**{_INPUTS_VAR})"
+    else:
+        trailer = f"{call_prefix}run({_INPUTS_VAR})"
+    return f"{code}\n\n{trailer}\n"
+
+
+class PythonMonty(Node):
+    """
+    Node for executing Python code using the Monty interpreter (a Rust-based minimal Python interpreter).
+
+    Attributes:
+        code (str): The Python code to execute. Must define a `run` function as the entry point.
+        use_multiple_params (bool): If True, the input dict will be unpacked into multiple parameters
+            when calling `run`. Otherwise, the entire input dict will be passed as a single argument.
+        type_check (bool): If True, Monty will perform type checking based on type annotations in the user code.
+            This can help catch errors but may increase execution time.
+        input_schema (type): A Pydantic model class that defines the expected input schema for the node.
+        is_files_allowed (bool): Whether to allow file inputs. Monty does not support file I/O,
+            so this should generally be False.
+    """
+
+    group: Literal[NodeGroup.TOOLS] = NodeGroup.TOOLS
+    action_type: ActionType = ActionType.CODE_EXECUTION
+    name: str = "python-tool-monty"
+    description: str = (
+        "Executes Python code inside a Rust-based minimal Python interpreter). \n"
+        "Does not support third-party libraries (pandas, numpy, requests, pydantic, "
+        "matplotlib, etc.)"
+    )
+    code: str
+    use_multiple_params: bool = False
+    type_check: bool = False
+    input_schema: ClassVar[type[PythonInputSchema]] = PythonInputSchema
+    is_files_allowed: bool = False
+
+    def execute(self, input_data: PythonInputSchema, config: RunnableConfig = None, **kwargs) -> Any:
+        return asyncio.run(self.execute_async(input_data, config, **kwargs))
+
+    async def execute_async(self, input_data: PythonInputSchema, config: RunnableConfig = None, **kwargs) -> Any:
+        logger.info(
+            f"Tool {self.name} - {self.id}: started with INPUT DATA:\n"
+            f"{input_data.model_dump() if hasattr(input_data, 'model_dump') else input_data}"
+        )
+        config = ensure_config(config)
+        self.run_on_node_execute_run(config.callbacks, **kwargs)
+
+        try:
+            import pydantic_monty
+        except ImportError as e:
+            raise ToolExecutionException(
+                "PythonMonty requires the 'pydantic-monty' package. " "Install with: poetry install --extras monty",
+                recoverable=False,
+            ) from e
+
+        inputs_dict = dict(input_data)
+        wrapped_code = _wrap_user_code(self.code, self.use_multiple_params)
+
+        try:
+            monty = pydantic_monty.Monty(
+                wrapped_code,
+                inputs=[_INPUTS_VAR],
+                script_name="python_monty.py",
+                type_check=self.type_check,
+            )
+            result = await monty.run_async(inputs={_INPUTS_VAR: inputs_dict})
+        except Exception as e:
+            error_msg = f"Code execution error: {str(e)}"
+            logger.error(error_msg)
+            raise ToolExecutionException(error_msg, recoverable=True) from e
+
+        logger.info(f"Tool {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
+        return self._format_result(result)
+
+    def _format_result(self, result: Any) -> Any:
+        if isinstance(result, dict) and "content" in result:
+            if self.is_optimized_for_agents:
+                return {**result, "content": str(result["content"])}
+            return result
+        if self.is_optimized_for_agents:
+            return {"content": str(result)}
+        return {"content": result}

--- a/dynamiq/nodes/tools/python_monty.py
+++ b/dynamiq/nodes/tools/python_monty.py
@@ -10,7 +10,8 @@ from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
 from dynamiq.utils.logger import logger
 
-_INPUTS_VAR = "__dynamiq_inputs__"
+_INPUTS_VAR = "dynamiq_monty_inputs_"
+_TYPE_CHECK_STUBS = f"{_INPUTS_VAR}: dict = {{}}\n"
 
 
 def _run_contains_async_def(code: str) -> bool:
@@ -55,7 +56,7 @@ class PythonMonty(Node):
     action_type: ActionType = ActionType.CODE_EXECUTION
     name: str = "python-tool-monty"
     description: str = (
-        "Executes Python code inside a Rust-based minimal Python interpreter). \n"
+        "Executes Python code inside a Rust-based minimal Python interpreter.\n"
         "Does not support third-party libraries (pandas, numpy, requests, pydantic, "
         "matplotlib, etc.)"
     )
@@ -66,9 +67,37 @@ class PythonMonty(Node):
     is_files_allowed: bool = False
 
     def execute(self, input_data: PythonInputSchema, config: RunnableConfig = None, **kwargs) -> Any:
+        """
+        Execute the configured Python code synchronously via the Monty interpreter.
+
+        Args:
+            input_data (PythonInputSchema): Inputs forwarded to the user-defined ``run`` function.
+            config (RunnableConfig, optional): Execution configuration, including callbacks.
+            **kwargs: Additional arguments passed to the execution context.
+
+        Returns:
+            Any: A dictionary with a ``content`` key holding the ``run`` return value.
+
+        Raises:
+            ToolExecutionException: If ``pydantic_monty`` is unavailable or the user code fails.
+        """
         return asyncio.run(self.execute_async(input_data, config, **kwargs))
 
     async def execute_async(self, input_data: PythonInputSchema, config: RunnableConfig = None, **kwargs) -> Any:
+        """
+        Execute the configured Python code asynchronously via the Monty interpreter.
+
+        Args:
+            input_data (PythonInputSchema): Inputs forwarded to the user-defined ``run`` function.
+            config (RunnableConfig, optional): Execution configuration, including callbacks.
+            **kwargs: Additional arguments passed to the execution context.
+
+        Returns:
+            Any: A dictionary with a ``content`` key holding the ``run`` return value.
+
+        Raises:
+            ToolExecutionException: If ``pydantic_monty`` is unavailable or the user code fails.
+        """
         logger.info(
             f"Tool {self.name} - {self.id}: started with INPUT DATA:\n"
             f"{input_data.model_dump() if hasattr(input_data, 'model_dump') else input_data}"
@@ -93,6 +122,7 @@ class PythonMonty(Node):
                 inputs=[_INPUTS_VAR],
                 script_name="python_monty.py",
                 type_check=self.type_check,
+                type_check_stubs=_TYPE_CHECK_STUBS if self.type_check else None,
             )
             result = await monty.run_async(inputs={_INPUTS_VAR: inputs_dict})
         except Exception as e:

--- a/poetry.lock
+++ b/poetry.lock
@@ -7232,6 +7232,79 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pydantic-monty"
+version = "0.0.16"
+description = "Python bindings for the Monty sandboxed Python interpreter"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "pydantic_monty-0.0.16-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:f1635efc128330d2b630d24d5bcb5582beb0e54ad20e186f32d4e694669bad67"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1899360dd3eb64d061f1da48f15e8470d0be7c72e6329eefc46da151cdfd6b12"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:79f32d75aef055ff96cfabaa0126b24a44075d9fe2e9b101dcc12359db63460f"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fb1fcb935beb3385cbd2ffb4729634ce8bac2159a829b3a2651dfbef6e52f8f"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aef82f3d7c612db9451d5d5b75306a8a33d97a4fc20ad154e2883993faf19180"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5f9d9c13ac3d2eb3b2f5aaf1e65da0806628159701d90c6d3b59d2a08685629"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d2ac23d8a7148a00a63e8266d3ffd7799cfabae53d37da72238e4ae66fae567"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6bbe77115afe96430c3f461fd06ca96f1295fda89e12663533c0c09cf2fc7c"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:624a752cea28bcc6e46e70c049ee5b94d1bdc8886cece7b44f44e0bd3f084cda"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b1a0e24cc45c4aebf4264e88a32e68361ecc40e549ea0882b74adc8548d382ac"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-win32.whl", hash = "sha256:2416b7336d52431fb8375b62ed53a74a1c23141db96c5e342e5aaa2ca30be07a"},
+    {file = "pydantic_monty-0.0.16-cp310-cp310-win_amd64.whl", hash = "sha256:827cad086668dd2da287da06e646bb952dbe9353b758e2dcc122207b531c5b8c"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:1eb136807127e9e7609b585ce4f13feedc1e4d670aa902a666ed6f6c1633d080"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bafb73a42bb75cc696c08c7e9866ab1344c82b7f94e2842b1211d6479d47d11"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:00090c735663c40698b887c2c92fdf181907c4eb1e0add4c95f03c23e6423174"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9267528c2b9ab3ac8ca81d9ee979e415523e3519e69095f2257f912333f30da8"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7679143b6fbfc9641de3f34ac9766171fe6e9951af70115efffa3de31ff0e104"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e3329fd392375b069c169d901b49153df3a7655174b25f0aa69a3e5dc270b452"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e659e57da79096993549b2fe687b722c766f3d27cdd56591df9102b18ff0e45"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e791a44fdd4ec14af38bedff70e363eae7323877ec04c2920874cac1a95d3206"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:25d3484cf0c7a1f77698026fa532ee5bcff4b4560d76f280ef30224a15c746e2"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:599c85757c9589682bc22f0cc9fde65461a099b5d5753d0a293f5cf33a09f733"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-win32.whl", hash = "sha256:6ac9f9bb6b4c68eef26721216822583527e63098a37d443a77443e03706b66e1"},
+    {file = "pydantic_monty-0.0.16-cp311-cp311-win_amd64.whl", hash = "sha256:a67b47a6119f4116b58481b357fb1c64d34acaa83220d989b349be1ed5c9a2ed"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f62efa2ebc1305826b646b60e1857a90b0ea8c370788a02b9d40d2ab5d505777"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4f963ea23bfb352da29dd1976821e1e47162e0e2b98065f092534dde85e41ccb"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93087d3ec044c5e929f10823fb563e809dbc7c623eb619362872403da7c406a6"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb6cd319731e404bcc190d7867cf0ea1f5bf7124114893e277693f9b8b987201"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49e58d4e00d2721560f40ae92998b5b3670166e56db678f7c16853b916d888da"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:320d4bc67e58a17a526a2361737de874cc8824c610701551e75b456b7421feb8"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a5eda5ecc4841bce0a9a9e1e059b71646a7bd5c990bc106edf717d2ec13d6cd"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa7834fdee5db13f75bfe74ab91ef4d056be643ad841b9cec5338d097c1513ed"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5df4c31ac9d5b91b39eb9cdf81e4fdf1ccfe372fea1f4133cfc02e5654c62a5d"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:6f13db1f0c1c970ad6289262273273f9d2e241e141539ad874e06ff0c736d86d"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-win32.whl", hash = "sha256:8585dd6a186a3d17d25237ea6f8ea4a8af3717c9503c08a3a582f5e5162e36a6"},
+    {file = "pydantic_monty-0.0.16-cp312-cp312-win_amd64.whl", hash = "sha256:326cddda37f0a684a5d8ca54113bd17657bf48399a0e022cdb8ae05581976bce"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9615d19bcccd7f4ad95364368cfd74d5451f1eeeb7f0363ad292c56f75bbdac5"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b9da2475d37d7614691d94b21035ad00161373592df9de2282c2929c00f2504e"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:07372b15eab8996ec6720a8ee4879f7b5fd53dd0589d818550d5244eacd68a96"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a694ea0501f2ad115ec1b169d7665b554eb9448779fce11727472a4e8378d2c3"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f00c529865554b5edaefc796c4f52ed3686f91cb9cae2b164428353c2f2a773b"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:95be0c370eeea1c185d96ff8d459e510fbce1508115bbed489f8d7b9a79e7505"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6edd9338861544e9983a3d8412f27257cb246428b0a6dab945848af0790b294"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:011ab47525340b2802e2aa32ccac92fafc4fb516a48dd07ff563f2cd40203e37"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:e5d25973f2884e0b845d2f028e1f972811c2a98708eb425bf5809747360939ad"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:944a0ab7e81e4523ff9120f45b0ca22f377ad291d2257d251db02eb25727c5ac"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-win32.whl", hash = "sha256:e6d4023ee3f0530edf57097ebc004f73d67636b39d2ebb21fca0eaed7bab9977"},
+    {file = "pydantic_monty-0.0.16-cp313-cp313-win_amd64.whl", hash = "sha256:c7c27b717ccba5a4cdd7321bc3a33fc97aede032784c41a1ce7d5906be04cf44"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d42f100eda125bded8ba38f17c9998cca2ab645c4a795aa1be4bf754075899c5"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:483ced987c4f0082cdc9980ac7b4ea5882876aa82c548d43944f96f13da9aca6"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c4c8477264e417475bcaf3ceb4044233407272cefd58356f062a3726e0a32a90"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:751ea6e8f4ae62085b43c2b891ae6e5a072e3ea26486bae2653337e8d132459e"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1f29f66645a690e96e9a1b892c0c0c0736341d32251ec5035612259ca03d2102"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ffc6730b0ed5f6f3c88f8f719df3925bfa77abb71d0259c7f175b9be79b25cfe"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d9a79337e78f3182ae029714c634c33f15dee3c75a14b0fa2c54caf041433120"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6935b421938f31f1414a10980d27f9bd62fbd7b35228253a751ac1488abcac1d"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:60c87b02e81f20fc621517bfc1359dd4f5f75e54e384456e583d9e7b8b728c88"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:dd0b67dab0fcfe1e4371b7e8e0527e4c7f1cd010d41596ba2e8a7c4aa98b476d"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-win32.whl", hash = "sha256:300bba8175bd1b92a14de19e91315e343181e3ff248990874ddb6e29a78749c5"},
+    {file = "pydantic_monty-0.0.16-cp314-cp314-win_amd64.whl", hash = "sha256:adac06c7e412504fd02d16a258d39d0e8e5a82e99158caa18f0d519ba96b393d"},
+    {file = "pydantic_monty-0.0.16.tar.gz", hash = "sha256:0c4310a3daa8edd3ea3622aed3f72f16042f0909f9b8e6880719feff23e8b10f"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.5"
+
+[[package]]
 name = "pydantic-settings"
 version = "2.13.1"
 description = "Settings management using Pydantic"
@@ -10325,8 +10398,9 @@ test = ["pytest"]
 
 [extras]
 cua = ["cua-computer"]
+monty = ["pydantic-monty"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "6b384944ad6857cfe0c8c7b8037f039b4b41e8f998d27243ea06f0b8974162d2"
+content-hash = "73872668673a5cc0b1758bea5958ad090e30d0104ea347f742db921837ebfddd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,11 @@ steel-sdk = "0.15.0"
 reportlab = "~4.3.0"
 cua-computer = { version = "0.4.19", python = ">=3.12,<3.14", optional = true }
 daytona = "^0.161.0"
+pydantic-monty = {version = "^0.0.16", optional = true}
 
 [tool.poetry.extras]
 cua = ["cua-computer"]
+monty = ["pydantic-monty"]
 
 [tool.poetry.group.dev.dependencies]
 setuptools = "~78.1.1"

--- a/tests/unit/nodes/tools/test_python_monty.py
+++ b/tests/unit/nodes/tools/test_python_monty.py
@@ -1,0 +1,149 @@
+import pytest
+
+pytest.importorskip("pydantic_monty")
+
+from dynamiq.nodes.agents.exceptions import ToolExecutionException  # noqa: E402
+from dynamiq.nodes.tools.python_monty import PythonMonty  # noqa: E402
+
+
+def test_basic_run_returns_dict():
+    code = """
+def run(inputs):
+    return {"result": inputs["a"] + inputs["b"]}
+"""
+    node = PythonMonty(code=code)
+    output = node.execute({"a": 2, "b": 3})
+    assert output == {"content": {"result": 5}}
+
+
+def test_use_multiple_params_true_unpacks_kwargs():
+    code = """
+def run(a, b):
+    return {"sum": a + b}
+"""
+    node = PythonMonty(code=code, use_multiple_params=True)
+    output = node.execute({"a": 10, "b": 32})
+    assert output == {"content": {"sum": 42}}
+
+
+def test_is_optimized_for_agents_stringifies_content():
+    code = """
+def run(inputs):
+    return {"content": {"n": 7}}
+"""
+    node = PythonMonty(code=code, is_optimized_for_agents=True)
+    output = node.execute({})
+    assert output == {"content": str({"n": 7})}
+
+
+def test_non_dict_return_wrapped_in_content():
+    code = """
+def run(inputs):
+    return 42
+"""
+    node = PythonMonty(code=code)
+    output = node.execute({})
+    assert output == {"content": 42}
+
+
+def test_dict_with_content_passthrough():
+    code = """
+def run(inputs):
+    return {"content": {"nested": True}, "meta": "ok"}
+"""
+    node = PythonMonty(code=code, is_optimized_for_agents=False)
+    output = node.execute({})
+    assert output == {"content": {"nested": True}, "meta": "ok"}
+
+
+def test_async_run_awaited():
+    code = """
+async def run(inputs):
+    return {"doubled": inputs["x"] * 2}
+"""
+    node = PythonMonty(code=code)
+    output = node.execute({"x": 21})
+    assert output == {"content": {"doubled": 42}}
+
+
+def test_missing_run_raises_tool_execution_exception():
+    code = "x = 1\n"
+    node = PythonMonty(code=code)
+    with pytest.raises(ToolExecutionException) as excinfo:
+        node.execute({})
+    assert excinfo.value.recoverable is True
+
+
+def test_disallowed_third_party_import_raises():
+    code = """
+import pandas
+def run(inputs):
+    return {"v": pandas.DataFrame().shape}
+"""
+    node = PythonMonty(code=code)
+    with pytest.raises(ToolExecutionException) as excinfo:
+        node.execute({})
+    assert excinfo.value.recoverable is True
+    assert "pandas" in str(excinfo.value)
+
+
+def test_missing_pydantic_monty_raises_unrecoverable(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pydantic_monty":
+            raise ImportError("simulated: pydantic_monty not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    node = PythonMonty(code="def run(inputs):\n    return 1\n")
+    with pytest.raises(ToolExecutionException) as excinfo:
+        node.execute({})
+    assert excinfo.value.recoverable is False
+    assert "pydantic-monty" in str(excinfo.value)
+
+
+def test_unsupported_class_definition_raises():
+    code = """
+class Foo:
+    pass
+def run(inputs):
+    return Foo()
+"""
+    node = PythonMonty(code=code)
+    with pytest.raises(ToolExecutionException) as excinfo:
+        node.execute({})
+    assert excinfo.value.recoverable is True
+    assert "class" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_async_directly():
+    code = """
+def run(inputs):
+    return {"v": inputs["x"]}
+"""
+    node = PythonMonty(code=code)
+    output = await node.execute_async({"x": 99})
+    assert output == {"content": {"v": 99}}
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Monty's type_check flag flags the injected `__dynamiq_inputs__` "
+        "reference in the wrapper trailer as unresolved. Plumbing is correct; "
+        "full interop with type_check would require reworking _wrap_user_code."
+    ),
+    strict=True,
+)
+def test_type_check_true_accepts_valid_code():
+    code = """
+def run(inputs: dict) -> dict:
+    return {"ok": True}
+"""
+    node = PythonMonty(code=code, type_check=True)
+    output = node.execute({})
+    assert output == {"content": {"ok": True}}

--- a/tests/unit/nodes/tools/test_python_monty.py
+++ b/tests/unit/nodes/tools/test_python_monty.py
@@ -2,6 +2,8 @@ import pytest
 
 pytest.importorskip("pydantic_monty")
 
+from dynamiq import Workflow  # noqa: E402
+from dynamiq.flows import Flow  # noqa: E402
 from dynamiq.nodes.agents.exceptions import ToolExecutionException  # noqa: E402
 from dynamiq.nodes.tools.python_monty import PythonMonty  # noqa: E402
 
@@ -131,14 +133,6 @@ def run(inputs):
     assert output == {"content": {"v": 99}}
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Monty's type_check flag flags the injected `__dynamiq_inputs__` "
-        "reference in the wrapper trailer as unresolved. Plumbing is correct; "
-        "full interop with type_check would require reworking _wrap_user_code."
-    ),
-    strict=True,
-)
 def test_type_check_true_accepts_valid_code():
     code = """
 def run(inputs: dict) -> dict:
@@ -147,3 +141,44 @@ def run(inputs: dict) -> dict:
     node = PythonMonty(code=code, type_check=True)
     output = node.execute({})
     assert output == {"content": {"ok": True}}
+
+
+def test_type_check_true_rejects_type_errors():
+    code = """
+def run(inputs: dict) -> int:
+    return "not-an-int"
+"""
+    node = PythonMonty(code=code, type_check=True)
+    with pytest.raises(ToolExecutionException) as excinfo:
+        node.execute({})
+    assert excinfo.value.recoverable is True
+
+
+def test_python_monty_yaml_roundtrip(tmp_path):
+    code = 'def run(inputs):\n    return {"value": inputs.get("x", 0) + 1}\n'
+    node = PythonMonty(
+        id="monty-node",
+        code=code,
+        use_multiple_params=False,
+        type_check=False,
+    )
+    workflow = Workflow(id="monty-workflow", flow=Flow(id="monty-flow", nodes=[node]))
+
+    yaml_path = tmp_path / "monty_workflow.yaml"
+    workflow.to_yaml_file(str(yaml_path))
+
+    loaded = Workflow.from_yaml_file(str(yaml_path), init_components=True)
+    assert isinstance(loaded.flow.nodes[0], PythonMonty)
+    loaded_node = loaded.flow.nodes[0]
+    assert loaded_node.id == "monty-node"
+    assert loaded_node.code == code
+    assert loaded_node.use_multiple_params is False
+    assert loaded_node.type_check is False
+
+    roundtrip_path = tmp_path / "monty_workflow_roundtrip.yaml"
+    loaded.to_yaml_file(str(roundtrip_path))
+    roundtrip = Workflow.from_yaml_file(str(roundtrip_path), init_components=True)
+    roundtrip_node = roundtrip.flow.nodes[0]
+    assert roundtrip_node.id == "monty-node"
+    assert roundtrip_node.code == code
+    assert roundtrip_node.execute({"x": 4}) == {"content": {"value": 5}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new code-execution backend and optional dependency (`pydantic-monty`), which can affect runtime behavior and error handling in tool execution paths. Risk is mitigated by being opt-in via extras and covered by new unit tests.
> 
> **Overview**
> Introduces a new `PythonMonty` tool node that executes user-provided Python by wrapping and running a required `run(...)` entrypoint inside the Monty interpreter, with support for `async def run`, optional kwargs-unpacking (`use_multiple_params`), and optional Monty type checking.
> 
> Wires the node into the tools package exports, adds an optional `pydantic-monty` dependency behind a new `monty` Poetry extra, and includes unit tests covering return formatting, async execution, type-checking, YAML roundtrips, and failure modes (missing dependency, missing `run`, unsupported imports/constructs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3606a1a5f04d886f4e1d47d60a26f2cb157fb9e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->