### PR TITLE
fix: unescape character

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -646,6 +646,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
         try:
             if isinstance(action_input, str):
+                action_input = action_input.replace("\\'", "'")
                 action_input = json.loads(action_input, strict=False)
         except json.JSONDecodeError as e:
             raise ActionParsingException(f"Error parsing action_input string. {e}", recoverable=True)

--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -171,7 +171,7 @@ IMPORTANT RULES:
 - ALWAYS populate the "thought" field FIRST before any other field (particularly "action_input") in your response.
 - Each tool has a specific input format you must strictly follow
 - In action_input field, provide properly formatted JSON with double quotes
-# - Never escape apostrophes as \' in JSON — apostrophes do not need escaping, write them as ' directly.
+- Never escape apostrophes as \' in JSON — apostrophes do not need escaping, write them as ' directly.
 - When action_input contains multi-line content (e.g. shell commands, code), you MUST escape newlines as \\n within the JSON string — do NOT use literal line breaks inside JSON string values.
 - Json has to be parsable with json.loads() in Python.
 - Do not use markdown code blocks around your JSON

--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -171,7 +171,6 @@ IMPORTANT RULES:
 - ALWAYS populate the "thought" field FIRST before any other field (particularly "action_input") in your response.
 - Each tool has a specific input format you must strictly follow
 - In action_input field, provide properly formatted JSON with double quotes
-- Never escape apostrophes as \\' in JSON — apostrophes do not need escaping, write them as ' directly.
 - When action_input contains multi-line content (e.g. shell commands, code), you MUST escape newlines as \\n within the JSON string — do NOT use literal line breaks inside JSON string values.
 - Json has to be parsable with json.loads() in Python.
 - Do not use markdown code blocks around your JSON

--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -171,6 +171,7 @@ IMPORTANT RULES:
 - ALWAYS populate the "thought" field FIRST before any other field (particularly "action_input") in your response.
 - Each tool has a specific input format you must strictly follow
 - In action_input field, provide properly formatted JSON with double quotes
+# - Never escape apostrophes as \' in JSON — apostrophes do not need escaping, write them as ' directly.
 - When action_input contains multi-line content (e.g. shell commands, code), you MUST escape newlines as \\n within the JSON string — do NOT use literal line breaks inside JSON string values.
 - Json has to be parsable with json.loads() in Python.
 - Do not use markdown code blocks around your JSON

--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -171,7 +171,7 @@ IMPORTANT RULES:
 - ALWAYS populate the "thought" field FIRST before any other field (particularly "action_input") in your response.
 - Each tool has a specific input format you must strictly follow
 - In action_input field, provide properly formatted JSON with double quotes
-- Never escape apostrophes as \' in JSON — apostrophes do not need escaping, write them as ' directly.
+- Never escape apostrophes as \\' in JSON — apostrophes do not need escaping, write them as ' directly.
 - When action_input contains multi-line content (e.g. shell commands, code), you MUST escape newlines as \\n within the JSON string — do NOT use literal line breaks inside JSON string values.
 - Json has to be parsable with json.loads() in Python.
 - Do not use markdown code blocks around your JSON


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small, localized parsing tweak that only affects `STRUCTURED_OUTPUT` tool-call handling when `action_input` is a string with invalid escaped apostrophes.
> 
> **Overview**
> Improves `STRUCTURED_OUTPUT` parsing by **preprocessing string `action_input` values to unescape `\'` to `'`** before `json.loads`, allowing recovery from a common LLM formatting bug that previously caused JSON decode failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8059fcd92cb3f21babd0257eb0dfeee76022e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->