### PR TITLE
fix: error in edit tool

### DIFF
--- a/dynamiq/nodes/tools/file_tools.py
+++ b/dynamiq/nodes/tools/file_tools.py
@@ -1303,9 +1303,8 @@ class FileWriteTool(Node):
             Dict with ``content`` (summary with counts and any warnings) and
             ``file_info``.
 
-        Raises:
-            ToolExecutionException: when one or more find strings are absent
-                from the original file content (no changes written).
+        Returns a result dict with a message when one or more find strings are absent
+        (no changes written), rather than raising — same pattern as shell command errors.
         """
         edits = input_data.edits
         encoding = input_data.encoding or "utf-8"
@@ -1315,11 +1314,12 @@ class FileWriteTool(Node):
 
         missing = [e.find for e in edits if e.find not in content]
         if missing:
-            raise ToolExecutionException(
-                f"Aborting edit: find string(s) not found in '{path}': "
-                f"{[repr(s[:80]) for s in missing]}. No changes were made.",
-                recoverable=True,
+            message = (
+                f"Edit not applied: find string(s) not found in '{path}': "
+                f"{[repr(s[:80]) for s in missing]}. No changes were made."
             )
+            logger.warning(f"Tool {self.name} - {self.id}: {message}")
+            return {"content": message}
 
         total = 0
         skipped: list[str] = []

--- a/tests/unit/nodes/tools/test_file_tools.py
+++ b/tests/unit/nodes/tools/test_file_tools.py
@@ -361,7 +361,7 @@ def test_edit_sequential_and_replace_all(file_store):
 
 
 def test_edit_find_not_found_aborts(file_store):
-    """If a find string doesn't exist in the original file, abort with no changes."""
+    """If a find string doesn't exist in the original file, return a message with no changes."""
     file_store.store("readme.md", b"# Title\n")
     tool = FileWriteTool(file_store=file_store)
 
@@ -374,7 +374,8 @@ def test_edit_find_not_found_aborts(file_store):
         }
     )
 
-    assert result.status == RunnableStatus.FAILURE
+    assert result.status == RunnableStatus.SUCCESS
+    assert "not found" in result.output["content"]
     assert file_store.retrieve("readme.md") == b"# Title\n"
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Alters error/return semantics for failed `edit` operations, which may affect downstream code that relied on a FAILURE/exception to detect unsuccessful edits.
> 
> **Overview**
> Changes `FileWriteTool` edit mode to **no longer raise `ToolExecutionException`** when any `find` string is absent in the original file; it now logs a warning and returns a success payload with an "Edit not applied" message while leaving the file untouched.
> 
> Updates the corresponding unit test to expect `RunnableStatus.SUCCESS` and assert the returned "not found" message instead of a failure status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d323c146fb564d2e5cf12be21044500f4a134a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->