### PR TITLE
fix: fix structured output

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -669,7 +669,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
         thought = llm_generated_output_json["thought"]
         action = llm_generated_output_json["action"]
-        action_input = llm_generated_output_json["action_input"]
+        action_input = llm_generated_output_json.get("action_input")
 
         if action == "finish":
             self._requested_output_files = self._parse_output_files_csv(
@@ -678,12 +678,23 @@ class Agent(HistoryManagerMixin, BaseAgent):
             self.log_final_output(thought, action_input, loop_num)
             return thought, "final_answer", action_input
 
-        try:
-            if isinstance(action_input, str):
-                action_input = action_input.replace("\\'", "'")
-                action_input = json.loads(action_input, strict=False)
-        except json.JSONDecodeError as e:
-            raise ActionParsingException(f"Error parsing action_input string. {e}", recoverable=True)
+        if action_input is None:
+            action_input = {}
+        elif isinstance(action_input, list):
+            parsed = {}
+            for item in action_input:
+                key = item.get("key", "")
+                raw = item.get("value", "")
+                try:
+                    parsed[key] = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    parsed[key] = raw
+            action_input = parsed
+        elif not isinstance(action_input, dict):
+            raise ActionParsingException(
+                f"Expected action_input to be an array or object, got {type(action_input).__name__}.",
+                recoverable=True,
+            )
 
         self.log_reasoning(thought, action, action_input, loop_num)
         return thought, action, action_input

--- a/dynamiq/nodes/agents/components/schema_generator.py
+++ b/dynamiq/nodes/agents/components/schema_generator.py
@@ -198,8 +198,21 @@ def generate_structured_output_schemas(
                         "description": f"Next action to make (choose from [{tool_names}, finish]).",
                     },
                     "action_input": {
-                        "type": "string",
-                        "description": action_input_description,
+                        "type": "array",
+                        "description": (
+                            action_input_description
+                            + " Required when action is a tool name. Omit when action is 'finish'."
+                            " Each item is a {key, value} pair representing one tool parameter."
+                        ),
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "key": {"type": "string"},
+                                "value": {"type": "string"},
+                            },
+                            "required": ["key", "value"],
+                            "additionalProperties": False,
+                        },
                     },
                     "output_files": {
                         "type": "string",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the structured-output contract for `action_input` and the agent’s parsing logic, which could break tool invocation if any callers or prompts still emit the old string/dict format. Risk is contained to `InferenceMode.STRUCTURED_OUTPUT` but affects all tool calls in that mode.
> 
> **Overview**
> Fixes structured-output tool calling by changing `action_input` from a JSON string to a **typed list of `{key, value}` pairs** in the generated structured-output schema.
> 
> Updates structured-output parsing to accept missing `action_input` (defaults to `{}`), convert the `{key, value}` array into a dict (attempting JSON-decode per value), and raise a recoverable parse error when `action_input` is neither an array nor an object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28899d0069eb47fa4dd7f81c15454abfa7d0d8c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->