### PR TITLE
fix: add separate async parameters for embedders

### DIFF
--- a/dynamiq/components/embedders/base.py
+++ b/dynamiq/components/embedders/base.py
@@ -135,7 +135,12 @@ class BaseEmbedder(BaseModel):
     @property
     def embed_params_async(self) -> dict:
         """Params for the async embedding call."""
-        return self.connection.conn_params
+        params = dict(self.embed_params)
+        if self.client is not None and params.get("client") is self.client:
+            del params["client"]
+            for key, value in self.connection.conn_params.items():
+                params.setdefault(key, value)
+        return params
 
     def _apply_text_truncation(self, text: str) -> str:
         """

--- a/dynamiq/components/embedders/base.py
+++ b/dynamiq/components/embedders/base.py
@@ -136,10 +136,12 @@ class BaseEmbedder(BaseModel):
     def embed_params_async(self) -> dict:
         """Params for the async embedding call."""
         params = dict(self.embed_params)
-        if self.client is not None and params.get("client") is self.client:
-            del params["client"]
-            for key, value in self.connection.conn_params.items():
-                params.setdefault(key, value)
+
+        client = params.pop("client", None)
+
+        if self.client is not None and client is self.client:
+            params.update(self.connection.conn_params)
+
         return params
 
     def _apply_text_truncation(self, text: str) -> str:

--- a/dynamiq/components/embedders/base.py
+++ b/dynamiq/components/embedders/base.py
@@ -132,6 +132,11 @@ class BaseEmbedder(BaseModel):
             params = {"client": self.client}
         return params
 
+    @property
+    def embed_params_async(self) -> dict:
+        """Params for the async embedding call."""
+        return self.connection.conn_params
+
     def _apply_text_truncation(self, text: str) -> str:
         """
         Apply text truncation if enabled and text exceeds max_input_tokens.
@@ -213,7 +218,7 @@ class BaseEmbedder(BaseModel):
         text_to_embed = text_to_embed.replace("\n", " ")
         text_to_embed = self._apply_text_truncation(text_to_embed)
 
-        response = await self._aembedding(model=self.model, input=[text_to_embed], **self.embed_params)
+        response = await self._aembedding(model=self.model, input=[text_to_embed], **self.embed_params_async)
 
         meta = {"model": response.model, "usage": dict(response.usage)}
         embedding = response.data[0]["embedding"]
@@ -282,7 +287,7 @@ class BaseEmbedder(BaseModel):
         """Async mirror of :meth:`_embed_texts_batch`."""
         all_embeddings: list[list[float]] = []
         meta: dict[str, Any] = {}
-        embed_params = self.embed_params
+        embed_params = self.embed_params_async
         for i in range(0, len(texts_to_embed), batch_size):
             batch = texts_to_embed[i : i + batch_size]
             response = await self._aembedding(model=self.model, input=batch, **embed_params)

--- a/tests/integration/nodes/embedders/test_openai_embedders.py
+++ b/tests/integration/nodes/embedders/test_openai_embedders.py
@@ -302,11 +302,18 @@ async def test_workflow_with_openai_text_embedder_async(
     result = await openai_text_embedder.run_async(input_data=query_input)
 
     assert result.status == RunnableStatus.SUCCESS
+    # Async path must NOT pass the sync ``client`` (which is a ``openai.OpenAI``
+    # instance) — litellm would invoke its sync ``.create`` and the resulting
+    # ``LegacyAPIResponse`` cannot be ``await``-ed. Instead, we pass the auth
+    # params from the connection and let litellm build its own AsyncOpenAI.
     mock_aembedding_executor.assert_awaited_once_with(
         input=[query_input["query"]],
         model=openai_model,
-        client=ANY,
+        api_key=ANY,
+        api_base=ANY,
     )
+    call_kwargs = mock_aembedding_executor.await_args.kwargs
+    assert "client" not in call_kwargs
 
 
 @pytest.mark.asyncio
@@ -319,5 +326,8 @@ async def test_workflow_with_openai_document_embedder_async(
     mock_aembedding_executor.assert_awaited_once_with(
         input=[document_input["documents"][0].content],
         model=openai_model,
-        client=ANY,
+        api_key=ANY,
+        api_base=ANY,
     )
+    call_kwargs = mock_aembedding_executor.await_args.kwargs
+    assert "client" not in call_kwargs

--- a/tests/integration_with_creds/nodes/embedders/conftest.py
+++ b/tests/integration_with_creds/nodes/embedders/conftest.py
@@ -1,0 +1,14 @@
+import asyncio
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def cancel_pending_tasks_after_test():
+    yield
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)

--- a/tests/integration_with_creds/nodes/embedders/test_openai_embedders_async.py
+++ b/tests/integration_with_creds/nodes/embedders/test_openai_embedders_async.py
@@ -11,8 +11,6 @@ from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.runnables import RunnableStatus
 from dynamiq.types.document import Document
 
-load_dotenv()
-
 @pytest.mark.asyncio
 async def test_openai_text_embedder_run_async():
     """Single async embed call must return a real embedding vector."""

--- a/tests/integration_with_creds/nodes/embedders/test_openai_embedders_async.py
+++ b/tests/integration_with_creds/nodes/embedders/test_openai_embedders_async.py
@@ -93,3 +93,35 @@ def test_openai_embedder_async_params_omit_sync_client():
     params = node.text_embedder.embed_params_async
     assert "client" not in params, "async embed params must not pass the sync client"
     assert "api_key" in params and "api_base" in params
+
+
+def test_openai_embedder_async_params_preserve_dimensions():
+    """``embed_params_async`` must preserve subclass-specific params like ``dimensions``.
+
+    OpenAIEmbedderComponent overrides ``embed_params`` to add ``dimensions`` when set.
+    A naive async params builder that only returned ``conn_params`` would silently drop
+    this and produce embeddings of the model's default size instead of the requested one.
+    """
+    node = OpenAITextEmbedder(connection=OpenAIConnection(), dimensions=512)
+
+    sync_params = node.text_embedder.embed_params
+    async_params = node.text_embedder.embed_params_async
+
+    assert sync_params.get("dimensions") == 512
+    assert async_params.get("dimensions") == 512
+    assert "client" not in async_params
+    assert "api_key" in async_params and "api_base" in async_params
+
+
+@pytest.mark.asyncio
+async def test_openai_text_embedder_dimensions_round_trip_async():
+    """End-to-end: setting ``dimensions`` on the async path must produce vectors of that size."""
+    node = OpenAITextEmbedder(connection=OpenAIConnection(), dimensions=512)
+    result = await node.run_async(input_data={"query": "hello world"})
+
+    assert result.status == RunnableStatus.SUCCESS, f"failed: {result.output}"
+    embedding = result.output["embedding"]
+    assert len(embedding) == 512, (
+        f"expected 512-d vector via async path; got {len(embedding)}. "
+        f"Subclass-specific dimensions param was likely dropped from embed_params_async."
+    )

--- a/tests/integration_with_creds/nodes/embedders/test_openai_embedders_async.py
+++ b/tests/integration_with_creds/nodes/embedders/test_openai_embedders_async.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 
 import pytest
-from dotenv import load_dotenv
 
 from dynamiq import Workflow
 from dynamiq.flows import Flow
@@ -10,6 +9,7 @@ from dynamiq.nodes.embedders import OpenAIDocumentEmbedder, OpenAITextEmbedder
 from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.runnables import RunnableStatus
 from dynamiq.types.document import Document
+
 
 @pytest.mark.asyncio
 async def test_openai_text_embedder_run_async():

--- a/tests/integration_with_creds/nodes/embedders/test_openai_embedders_async.py
+++ b/tests/integration_with_creds/nodes/embedders/test_openai_embedders_async.py
@@ -1,0 +1,97 @@
+import asyncio
+import time
+
+import pytest
+from dotenv import load_dotenv
+
+from dynamiq import Workflow
+from dynamiq.flows import Flow
+from dynamiq.nodes.embedders import OpenAIDocumentEmbedder, OpenAITextEmbedder
+from dynamiq.connections import OpenAI as OpenAIConnection
+from dynamiq.runnables import RunnableStatus
+from dynamiq.types.document import Document
+
+load_dotenv()
+
+@pytest.mark.asyncio
+async def test_openai_text_embedder_run_async():
+    """Single async embed call must return a real embedding vector."""
+    node = OpenAITextEmbedder(connection=OpenAIConnection())
+    result = await node.run_async(input_data={"query": "hello world"})
+
+    assert result.status == RunnableStatus.SUCCESS, f"failed: {result.output}"
+    embedding = result.output["embedding"]
+    assert isinstance(embedding, list) and len(embedding) > 0
+    assert all(isinstance(x, float) for x in embedding)
+
+
+@pytest.mark.asyncio
+async def test_openai_document_embedder_run_async():
+    """Async embed across multiple documents."""
+    node = OpenAIDocumentEmbedder(connection=OpenAIConnection())
+    docs = [Document(content="alpha"), Document(content="beta"), Document(content="gamma")]
+    result = await node.run_async(input_data={"documents": docs})
+
+    assert result.status == RunnableStatus.SUCCESS, f"failed: {result.output}"
+    embedded = result.output["documents"]
+    assert len(embedded) == 3
+    for d in embedded:
+        assert d.embedding is not None
+        assert len(d.embedding) > 0
+
+
+@pytest.mark.asyncio
+async def test_openai_text_embedder_workflow_run_async():
+    """Full Workflow.run_async lifecycle."""
+    node = OpenAITextEmbedder(connection=OpenAIConnection())
+    workflow = Workflow(flow=Flow(nodes=[node]))
+
+    result = await workflow.run_async(input_data={"query": "the quick brown fox"})
+    assert result.status == RunnableStatus.SUCCESS, f"workflow failed: {result.output}"
+
+    node_output = result.output[node.id]
+    assert node_output["status"] == "success"
+    assert len(node_output["output"]["embedding"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_openai_text_embedder_concurrent_calls_overlap():
+    """Three parallel embed calls via ``asyncio.gather`` must overlap on the wire."""
+    queries = ["alpha is the first", "beta is the second", "gamma is the third"]
+    node = OpenAITextEmbedder(connection=OpenAIConnection())
+
+    start = time.perf_counter()
+    baseline = await node.run_async(input_data={"query": queries[0]})
+    single_call_s = time.perf_counter() - start
+    assert baseline.status == RunnableStatus.SUCCESS
+
+    start = time.perf_counter()
+    results = await asyncio.gather(*(node.run_async(input_data={"query": q}) for q in queries))
+    parallel_s = time.perf_counter() - start
+
+    for r, q in zip(results, queries):
+        assert r.status == RunnableStatus.SUCCESS, f"failed for {q!r}: {r.output}"
+
+    ceiling = (single_call_s * 2.0) + 1.0
+    assert parallel_s < ceiling, (
+        f"async embed calls did not overlap: parallel={parallel_s:.2f}s, "
+        f"single_call_baseline={single_call_s:.2f}s, ceiling={ceiling:.2f}s"
+    )
+
+
+def test_openai_embedder_async_params_omit_sync_client():
+    """``embed_params_async`` on the underlying component must NOT
+    include the sync OpenAI client cached by ``ConnectionNode.init_components``.
+    """
+    from openai import OpenAI as OpenAIClient
+
+    node = OpenAITextEmbedder(connection=OpenAIConnection())
+    # init_components caches a sync OpenAI client on the underlying component
+    assert isinstance(node.text_embedder.client, OpenAIClient)
+    # and the sync params correctly include it
+    assert node.text_embedder.embed_params.get("client") is node.text_embedder.client
+
+    # but the async params must drop it and fall back to api_key/api_base only
+    params = node.text_embedder.embed_params_async
+    assert "client" not in params, "async embed params must not pass the sync client"
+    assert "api_key" in params and "api_base" in params


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how async embedding requests are parameterized, which can affect runtime behavior for OpenAI (and any subclass overriding `embed_params`) and may surface integration issues if connection params are incomplete.
> 
> **Overview**
> Fixes async embedding calls to avoid passing a cached synchronous OpenAI `client` into `litellm.aembedding` by introducing `BaseEmbedder.embed_params_async` and using it in async embed paths.
> 
> Updates integration tests to assert async calls use connection auth params (`api_key`/`api_base`) and never include `client`, and adds new credentialed async integration tests covering end-to-end async runs, concurrency overlap, and preserving subclass params like `dimensions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48bec7318fc65a17618147355f0e546da824370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->