### PR TITLE
feat: add missing cancellation logic for nodes

### DIFF
--- a/dynamiq/nodes/audio/elevenlabs.py
+++ b/dynamiq/nodes/audio/elevenlabs.py
@@ -10,6 +10,7 @@ from dynamiq.connections import ElevenLabs as ElevenLabsConnection
 from dynamiq.nodes import ErrorHandling
 from dynamiq.nodes.node import ConnectionNode, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 
 
 class Voices(str, enum.Enum):
@@ -130,6 +131,7 @@ class ElevenLabsTTS(ConnectionNode):
             },
         }
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
         response = self.client.request(
             method=self.connection.method,
@@ -236,6 +238,7 @@ class ElevenLabsSTS(ConnectionNode):
         }
         audio = input_data.audio
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
         response = self.client.request(
             method=self.connection.method,

--- a/dynamiq/nodes/audio/whisper.py
+++ b/dynamiq/nodes/audio/whisper.py
@@ -9,6 +9,7 @@ from dynamiq.connections import Whisper as WhisperConnection
 from dynamiq.nodes import ErrorHandling
 from dynamiq.nodes.node import ConnectionNode, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 
 DEFAULT_FILE_NAME = "temp.wav"
 DEFAULT_CONTENT_TYPE = "audio/wav"
@@ -68,6 +69,7 @@ class WhisperSTT(ConnectionNode):
             str: A string containing the transcribe result.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         audio = input_data.audio

--- a/dynamiq/nodes/converters/csv.py
+++ b/dynamiq/nodes/converters/csv.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Iterator, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from dynamiq.nodes.node import Node, NodeGroup, RunnableConfig, ensure_config
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -123,6 +124,7 @@ class CSVConverter(Node):
 
         if input_data.file_paths:
             for path in input_data.file_paths:
+                check_cancellation(config)
                 try:
                     with open(path, encoding="utf-8") as csv_file:
                         reader = csv.DictReader(csv_file, delimiter=delimiter)
@@ -142,6 +144,7 @@ class CSVConverter(Node):
 
         if input_data.files:
             for file_obj in input_data.files:
+                check_cancellation(config)
                 source_name = getattr(file_obj, "name", "in-memory file")
                 try:
                     if isinstance(file_obj, bytes):

--- a/dynamiq/nodes/converters/multi_file_type_converter.py
+++ b/dynamiq/nodes/converters/multi_file_type_converter.py
@@ -17,6 +17,7 @@ from dynamiq.nodes.node import Node, NodeDependency, ensure_config
 from dynamiq.nodes.types import NodeGroup
 from dynamiq.runnables import RunnableConfig, RunnableStatus
 from dynamiq.types import Document
+from dynamiq.types.cancellation import check_cancellation
 
 logger = logging.getLogger(__name__)
 
@@ -274,6 +275,7 @@ class MultiFileTypeConverter(Node):
             meta_list = self._normalize_metadata(metadata, len(all_filepaths))
 
             for filepath, meta in zip(all_filepaths, meta_list):
+                check_cancellation(config)
                 try:
                     with open(filepath, "rb") as f:
                         file_content = BytesIO(f.read())
@@ -288,6 +290,7 @@ class MultiFileTypeConverter(Node):
         if files is not None:
             meta_list = self._normalize_metadata(metadata, len(files))
             for i, (file, meta) in enumerate(zip(files, meta_list)):
+                check_cancellation(config)
                 try:
                     filename = meta.get("filename", f"file_{i}")
                     documents = self._process_single_file(file, filename, meta, config, **kwargs)

--- a/dynamiq/nodes/embedders/base.py
+++ b/dynamiq/nodes/embedders/base.py
@@ -6,6 +6,7 @@ from dynamiq.components.embedders.base import BaseEmbedder
 from dynamiq.nodes.node import ConnectionNode, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.types import Document
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 from dynamiq.utils.utils import TRUNCATE_EMBEDDINGS_LIMIT
 
@@ -38,6 +39,7 @@ class DocumentEmbedder(ConnectionNode):
             The output from the document_embedder component, typically the computed embeddings.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         output = self.document_embedder.embed_documents(input_data.documents)
@@ -50,6 +52,7 @@ class DocumentEmbedder(ConnectionNode):
     ):
         """Async mirror of :meth:`execute` — uses the component's async embed path."""
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         output = await self.document_embedder.embed_documents_async(input_data.documents)
@@ -100,6 +103,7 @@ class TextEmbedder(ConnectionNode):
             dict: A dictionary containing the embedding and the original query.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
         raw_output = self.text_embedder.embed_text(input_data.query)
         logger.debug(f"{self.name}: {raw_output['meta']}")
@@ -114,6 +118,7 @@ class TextEmbedder(ConnectionNode):
     ):
         """Async mirror of :meth:`execute` — uses the component's async embed path."""
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
         raw_output = await self.text_embedder.embed_text_async(input_data.query)
         logger.debug(f"{self.name}: {raw_output['meta']}")

--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -569,6 +569,7 @@ class BaseLLM(ConnectionNode):
         """
         chunks = []
         async for chunk in response:
+            check_cancellation(config)
             chunks.append(chunk)
             self.run_on_node_execute_stream(
                 config.callbacks,

--- a/dynamiq/nodes/parsers/mistral_ocr.py
+++ b/dynamiq/nodes/parsers/mistral_ocr.py
@@ -12,6 +12,7 @@ from dynamiq.nodes.agents.utils import is_image_file
 from dynamiq.nodes.node import ConnectionNode, ErrorHandling, ensure_config
 from dynamiq.nodes.types import NodeGroup
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 
 SUPPORTED_MIME_TYPES = [
     "application/pdf",
@@ -162,6 +163,8 @@ class MistralOCR(ConnectionNode):
         """
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
+
+        check_cancellation(config)
 
         file = input_data.file
 

--- a/dynamiq/nodes/retrievers/chroma.py
+++ b/dynamiq/nodes/retrievers/chroma.py
@@ -7,6 +7,7 @@ from dynamiq.nodes.node import ensure_config
 from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import ChromaVectorStore
+from dynamiq.types.cancellation import check_cancellation
 
 
 class ChromaDocumentRetriever(Retriever):
@@ -94,6 +95,7 @@ class ChromaDocumentRetriever(Retriever):
             dict[str, Any]: A dictionary containing the retrieved documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query_embedding = input_data.embedding

--- a/dynamiq/nodes/retrievers/elasticsearch.py
+++ b/dynamiq/nodes/retrievers/elasticsearch.py
@@ -12,6 +12,7 @@ from dynamiq.nodes.retrievers.base import Retriever
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import ElasticsearchVectorStore
 from dynamiq.storages.vector.elasticsearch.elasticsearch import ElasticsearchVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 
 
 class ElasticsearchRetrieverInputSchema(BaseModel):
@@ -127,6 +128,7 @@ class ElasticsearchDocumentRetriever(Retriever, ElasticsearchVectorStoreParams):
             dict[str, Any]: A dictionary containing the retrieved documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         output = self.document_retriever.run(

--- a/dynamiq/nodes/retrievers/milvus.py
+++ b/dynamiq/nodes/retrievers/milvus.py
@@ -8,6 +8,7 @@ from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import MilvusVectorStore
 from dynamiq.storages.vector.milvus.milvus import MilvusVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 
 
 class MilvusDocumentRetriever(Retriever, MilvusVectorStoreParams):
@@ -95,6 +96,7 @@ class MilvusDocumentRetriever(Retriever, MilvusVectorStoreParams):
             dict[str, Any]: A dictionary containing the retrieved documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query_embedding = input_data.embedding

--- a/dynamiq/nodes/retrievers/opensearch.py
+++ b/dynamiq/nodes/retrievers/opensearch.py
@@ -10,6 +10,7 @@ from dynamiq.nodes.retrievers.base import Retriever
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import OpenSearchVectorStore
 from dynamiq.storages.vector.opensearch.opensearch import OpenSearchVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 
 
 class OpenSearchRetrieverInputSchema(BaseModel):
@@ -125,6 +126,7 @@ class OpenSearchDocumentRetriever(Retriever, OpenSearchVectorStoreParams):
             dict[str, Any]: A dictionary containing the retrieved documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         output = self.document_retriever.run(

--- a/dynamiq/nodes/retrievers/pgvector.py
+++ b/dynamiq/nodes/retrievers/pgvector.py
@@ -8,6 +8,7 @@ from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import PGVectorStore
 from dynamiq.storages.vector.pgvector.pgvector import PGVectorStoreParams, PGVectorStoreRetrieverParams
+from dynamiq.types.cancellation import check_cancellation
 
 
 class PGVectorDocumentRetriever(Retriever, PGVectorStoreRetrieverParams):
@@ -98,6 +99,7 @@ class PGVectorDocumentRetriever(Retriever, PGVectorStoreRetrieverParams):
             dict[str, Any]: A dictionary containing the retrieved documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query_embedding = input_data.embedding

--- a/dynamiq/nodes/retrievers/pinecone.py
+++ b/dynamiq/nodes/retrievers/pinecone.py
@@ -6,6 +6,7 @@ from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import PineconeVectorStore
 from dynamiq.storages.vector.pinecone.pinecone import PineconeVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 
 
 class PineconeDocumentRetriever(Retriever, PineconeVectorStoreParams):
@@ -89,6 +90,7 @@ class PineconeDocumentRetriever(Retriever, PineconeVectorStoreParams):
             dict: A dictionary containing the retrieved documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query_embedding = input_data.embedding

--- a/dynamiq/nodes/retrievers/qdrant.py
+++ b/dynamiq/nodes/retrievers/qdrant.py
@@ -7,6 +7,7 @@ from dynamiq.nodes.node import ensure_config
 from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import QdrantVectorStore
+from dynamiq.types.cancellation import check_cancellation
 
 
 class QdrantDocumentRetriever(Retriever):
@@ -87,6 +88,7 @@ class QdrantDocumentRetriever(Retriever):
             dict[str, Any]: A dictionary containing the retrieved documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query_embedding = input_data.embedding

--- a/dynamiq/nodes/retrievers/weaviate.py
+++ b/dynamiq/nodes/retrievers/weaviate.py
@@ -8,6 +8,7 @@ from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import WeaviateVectorStore
 from dynamiq.storages.vector.weaviate import WeaviateRetrieverVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 
 
 class WeaviateDocumentRetriever(Retriever, WeaviateRetrieverVectorStoreParams):
@@ -99,6 +100,7 @@ class WeaviateDocumentRetriever(Retriever, WeaviateRetrieverVectorStoreParams):
             dict[str, Any]: A dictionary containing the retrieved documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query_embedding = input_data.embedding

--- a/dynamiq/nodes/tools/code_interpreter.py
+++ b/dynamiq/nodes/tools/code_interpreter.py
@@ -16,6 +16,7 @@ from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.file.base import FileInfo
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 _DESCRIPTION_TEMPLATE = """Executes Python code and shell commands in a secure cloud sandbox environment.
@@ -683,6 +684,7 @@ class BaseCodeInterpreterTool(ConnectionNode, abc.ABC):
         """
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n" f"{str(input_data.model_dump())[:300]}")
         config = ensure_config(config)
+        check_cancellation(config)
 
         if self.persistent_sandbox and self._sandbox:
             sandbox = self._sandbox

--- a/dynamiq/nodes/tools/cua_desktop/cua_desktop.py
+++ b/dynamiq/nodes/tools/cua_desktop/cua_desktop.py
@@ -43,6 +43,7 @@ from dynamiq.nodes.tools.cua_desktop.types import (
 )
 from dynamiq.nodes.tools.utils import sanitize_filename
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 ACTION_SCHEMA_MAP: dict[CuaAction, type] = {
@@ -464,6 +465,7 @@ class CuaDesktopTool(ConnectionNode):
             ToolExecutionException: If the input is invalid or execution fails.
         """
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
+        check_cancellation(config)
 
         await self._init_client()
 

--- a/dynamiq/nodes/tools/cypher_executor.py
+++ b/dynamiq/nodes/tools/cypher_executor.py
@@ -15,6 +15,7 @@ from dynamiq.storages.graph.age import ApacheAgeGraphStore
 from dynamiq.storages.graph.base import BaseGraphStore
 from dynamiq.storages.graph.neo4j import Neo4jGraphStore
 from dynamiq.storages.graph.neptune import NeptuneGraphStore
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 BASE_CYPHER_DESCRIPTION = """Executes parameterized Cypher
@@ -236,6 +237,7 @@ class CypherExecutor(ConnectionNode):
         """
         logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         if not self._graph_store:
@@ -266,6 +268,7 @@ class CypherExecutor(ConnectionNode):
                     routing=routing,
                     graph_return_enabled=input_data.graph_return_enabled,
                     writes_allowed=input_data.writes_allowed,
+                    config=config,
                 )
                 result_payload = {
                     "mode": input_data.mode,
@@ -302,6 +305,7 @@ class CypherExecutor(ConnectionNode):
         routing: str | None,
         graph_return_enabled: bool,
         writes_allowed: bool,
+        config: RunnableConfig | None = None,
     ) -> list[dict[str, Any]]:
         if isinstance(parameters, list):
             params_list = parameters
@@ -309,6 +313,7 @@ class CypherExecutor(ConnectionNode):
             params_list = [parameters for _ in queries]
         results: list[dict[str, Any]] = []
         for query, query_params in zip(queries, params_list, strict=True):
+            check_cancellation(config)
             results.append(
                 self._execute_single(
                     query=query,

--- a/dynamiq/nodes/tools/e2b_desktop/e2b_desktop.py
+++ b/dynamiq/nodes/tools/e2b_desktop/e2b_desktop.py
@@ -26,6 +26,7 @@ from dynamiq.nodes.tools.e2b_desktop.types import (
 )
 from dynamiq.nodes.tools.utils import sanitize_filename
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 ACTION_SCHEMA_MAP: dict[E2BAction, type] = {
@@ -375,6 +376,7 @@ class E2BDesktopTool(ConnectionNode):
             ToolExecutionException: If the input is invalid or execution fails.
         """
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
+        check_cancellation(config)
 
         await self._init_client()
 

--- a/dynamiq/nodes/tools/exa_search.py
+++ b/dynamiq/nodes/tools/exa_search.py
@@ -10,6 +10,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_EXA = """Searches the web with semantic understanding and advanced filtering.
@@ -603,6 +604,7 @@ class ExaTool(ConnectionNode):
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         payload, connection_url = self._build_search_payload(input_data)

--- a/dynamiq/nodes/tools/firecrawl.py
+++ b/dynamiq/nodes/tools/firecrawl.py
@@ -10,6 +10,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_FIRECRAWL = """Scrapes web content from a URL and returns cleaned content.
@@ -357,6 +358,7 @@ class FirecrawlTool(ConnectionNode):
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         url, scrape_data, connection_url = self._resolve_scrape_request(input_data)

--- a/dynamiq/nodes/tools/firecrawl_search.py
+++ b/dynamiq/nodes/tools/firecrawl_search.py
@@ -10,6 +10,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_FIRECRAWL_SEARCH = """Search the internet and returns SERP results.
@@ -261,6 +262,7 @@ class FirecrawlSearchTool(ConnectionNode):
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query, search_payload, connection_url = self._resolve_search_request(input_data)

--- a/dynamiq/nodes/tools/function_tool.py
+++ b/dynamiq/nodes/tools/function_tool.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, create_model
 from dynamiq.nodes import ErrorHandling, NodeGroup
 from dynamiq.nodes.node import Node, ensure_config
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 T = TypeVar("T")
@@ -68,6 +69,7 @@ Examples:
         """
         logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         result = self.run_func(input_data, config=config, **kwargs)

--- a/dynamiq/nodes/tools/http_api_call.py
+++ b/dynamiq/nodes/tools/http_api_call.py
@@ -13,6 +13,7 @@ from dynamiq.nodes.agents.utils import FileMappedInput
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.file.base import FileInfo
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_HTTP = """Makes HTTP API requests with support for all methods and configurable parameters.
@@ -256,6 +257,7 @@ class HttpApiCall(ConnectionNode):
                 - "status_code" (int): The status code of the request.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
         logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n" f"{input_data.model_dump()}")
 

--- a/dynamiq/nodes/tools/jina.py
+++ b/dynamiq/nodes/tools/jina.py
@@ -9,6 +9,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_SCRAPE = """Scrapes web content from URLs with CSS selector targeting and content filtering.
@@ -252,6 +253,7 @@ class JinaScrapeTool(ConnectionNode):
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         headers = self._build_headers(input_data)

--- a/dynamiq/nodes/tools/pipedream.py
+++ b/dynamiq/nodes/tools/pipedream.py
@@ -9,6 +9,7 @@ from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.tools.mcp import rename_keys_recursive
 from dynamiq.nodes.tools.utils import create_file_from_url
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 FIELD_TYPES_MAPPING = {
@@ -229,6 +230,7 @@ class Pipedream(ConnectionNode):
         logger.debug(f"Tool {self.name} - Starting execution with input data: {input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         try:

--- a/dynamiq/nodes/tools/preprocess_tool.py
+++ b/dynamiq/nodes/tools/preprocess_tool.py
@@ -7,6 +7,7 @@ from dynamiq.components.splitters.document import DocumentSplitter as DocumentSp
 from dynamiq.nodes.node import Node, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.types import Document
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 PREPROCESS_TOOL_DESCRIPTION = """Preprocesses text by splitting it into smaller parts.
@@ -71,6 +72,7 @@ class PreprocessTool(Node):
             dict[str, Any]: A dictionary containing the split documents under the key "documents".
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         documents = input_data.documents

--- a/dynamiq/nodes/tools/python.py
+++ b/dynamiq/nodes/tools/python.py
@@ -15,6 +15,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils import format_value
 from dynamiq.utils.logger import logger
 
@@ -298,6 +299,7 @@ class Python(Node):
         """
         logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n" f"{input_data.model_dump()}")
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
         stdout = io.StringIO()
         safe_print = make_safe_print(lambda *args, **print_kwargs: print(*args, file=stdout, **print_kwargs))

--- a/dynamiq/nodes/tools/python_code_executor.py
+++ b/dynamiq/nodes/tools/python_code_executor.py
@@ -26,6 +26,7 @@ from dynamiq.nodes.tools.python import (
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.file.base import FileInfo, FileStore
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils import format_value
 from dynamiq.utils.logger import logger
 
@@ -309,6 +310,7 @@ class PythonCodeExecutor(Node):
             f"preview='{code_preview}{'...' if len(input_data.code) > 200 else ''}'"
         )
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         if not self.file_store:

--- a/dynamiq/nodes/tools/python_monty.py
+++ b/dynamiq/nodes/tools/python_monty.py
@@ -8,6 +8,7 @@ from dynamiq.nodes.node import ensure_config
 from dynamiq.nodes.tools.python import PythonInputSchema
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 _INPUTS_VAR = "dynamiq_monty_inputs_"
@@ -103,6 +104,7 @@ class PythonMonty(Node):
             f"{input_data.model_dump() if hasattr(input_data, 'model_dump') else input_data}"
         )
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         try:

--- a/dynamiq/nodes/tools/scale_serp.py
+++ b/dynamiq/nodes/tools/scale_serp.py
@@ -10,6 +10,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_SERP = """Performs web search with support for web, news, images, and video results.
@@ -220,6 +221,7 @@ class ScaleSerpTool(ConnectionNode):
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         request_kwargs, search_type, query, url = self._build_request_kwargs(input_data)

--- a/dynamiq/nodes/tools/skills_tool.py
+++ b/dynamiq/nodes/tools/skills_tool.py
@@ -8,6 +8,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.runnables import RunnableConfig
 from dynamiq.skills import BaseSkillRegistry
 from dynamiq.skills.utils import normalize_sandbox_skills_base_path
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -71,6 +72,7 @@ class SkillsTool(Node):
     def execute(
         self, input_data: SkillsToolInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
+        check_cancellation(config)
         action = input_data.action
         logger.info("SkillsTool - action=%s", action.value)
 

--- a/dynamiq/nodes/tools/sql_executor.py
+++ b/dynamiq/nodes/tools/sql_executor.py
@@ -8,6 +8,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_SQL = """Executes SQL queries on multiple database systems including PostgreSQL,
@@ -94,6 +95,7 @@ class SQLExecutor(ConnectionNode):
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         query = input_data.query or self.query

--- a/dynamiq/nodes/tools/stagehand.py
+++ b/dynamiq/nodes/tools/stagehand.py
@@ -20,6 +20,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.tools.utils import guess_mime_type_from_bytes, sanitize_filename
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_STAGEHAND = """## Stagehand Tool
@@ -462,7 +463,12 @@ class Stagehand(ConnectionNode):
         """
         return self._run_async(self.execute_async(input_data, config, **kwargs))
 
-    async def get_downloads_via_sdk(self, session_id: str, max_retry_sec: int = 20) -> bytes:
+    async def get_downloads_via_sdk(
+        self,
+        session_id: str,
+        max_retry_sec: int = 20,
+        config: RunnableConfig | None = None,
+    ) -> bytes:
         """
         Retrieve the downloads archive for the given session.
         Retries until content is non-empty or timeout.
@@ -478,6 +484,7 @@ class Stagehand(ConnectionNode):
         interval = 2
 
         while elapsed < max_retry_sec:
+            check_cancellation(config)
             response = await self._browserbase_client.sessions.downloads.list(session_id)
             data = await response.read()
 
@@ -522,6 +529,7 @@ class Stagehand(ConnectionNode):
         """
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
         config = ensure_config(config)
+        check_cancellation(config)
         await self._init_client(input_data.files)
 
         tool_data = {"tool_session_id": self.client.session_id}
@@ -543,7 +551,7 @@ class Stagehand(ConnectionNode):
             elif input_data.action_type == StagehandActionType.ACT:
                 result = await self.client.page.act(input_data.instruction, **payload)
                 result = result.model_dump()
-                zip_data = await self.get_downloads_via_sdk(self.client.session_id)
+                zip_data = await self.get_downloads_via_sdk(self.client.session_id, config=config)
                 files = self.extract_files_from_zip(zip_data) if zip_data else []
             elif input_data.action_type == StagehandActionType.GOTO:
                 if input_data.url is None:

--- a/dynamiq/nodes/tools/tavily.py
+++ b/dynamiq/nodes/tools/tavily.py
@@ -11,6 +11,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_TAVILY = """Search the web with structured filters and enriched responses.
@@ -274,6 +275,7 @@ class TavilyTool(ConnectionNode):
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         request_payload, connection_url = self._build_search_payload(input_data)
@@ -298,6 +300,7 @@ class TavilyTool(ConnectionNode):
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         request_payload, connection_url = self._build_search_payload(input_data)

--- a/dynamiq/nodes/tools/todo_tools.py
+++ b/dynamiq/nodes/tools/todo_tools.py
@@ -16,6 +16,7 @@ from dynamiq.nodes.tools.file_tools import RESERVED_AGENT_PATH_PREFIX
 from dynamiq.runnables import RunnableConfig
 from dynamiq.sandboxes.base import Sandbox
 from dynamiq.storages.file.base import FileStore
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -162,6 +163,7 @@ RULES:
         self, input_data: TodoWriteInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         config = ensure_config(config)
+        check_cancellation(config)
         self.reset_run_state()
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 

--- a/dynamiq/nodes/tools/zenrows.py
+++ b/dynamiq/nodes/tools/zenrows.py
@@ -8,6 +8,7 @@ from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.nodes.types import ActionType
 from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 DESCRIPTION_ZENROWS = """Scrapes web content from URLs with advanced anti-bot protection and JavaScript rendering. Handles complex websites with proxy rotation, CAPTCHA solving, and browser automation for reliable data extraction.
@@ -104,6 +105,7 @@ class ZenRowsTool(ConnectionNode):
         """
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         try:
@@ -120,6 +122,7 @@ class ZenRowsTool(ConnectionNode):
         """Native async execution path mirroring ``execute``."""
         logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         client = await self.get_async_client()

--- a/dynamiq/nodes/writers/chroma.py
+++ b/dynamiq/nodes/writers/chroma.py
@@ -4,6 +4,7 @@ from dynamiq.nodes.writers.base import Writer, WriterInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import ChromaVectorStore
 from dynamiq.storages.vector.base import BaseWriterVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 
 
 class ChromaDocumentWriter(Writer, BaseWriterVectorStoreParams):
@@ -63,6 +64,7 @@ class ChromaDocumentWriter(Writer, BaseWriterVectorStoreParams):
             dict: A dictionary containing the count of upserted documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         documents = input_data.documents

--- a/dynamiq/nodes/writers/elasticsearch.py
+++ b/dynamiq/nodes/writers/elasticsearch.py
@@ -5,6 +5,7 @@ from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import ElasticsearchVectorStore
 from dynamiq.storages.vector.elasticsearch.elasticsearch import ElasticsearchVectorStoreWriterParams
 from dynamiq.storages.vector.policies import DuplicatePolicy
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -78,6 +79,7 @@ class ElasticsearchDocumentWriter(Writer, ElasticsearchVectorStoreWriterParams):
             dict[str, int]: A dictionary containing the count of written documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         upserted_count = self.vector_store.write_documents(

--- a/dynamiq/nodes/writers/milvus.py
+++ b/dynamiq/nodes/writers/milvus.py
@@ -4,6 +4,7 @@ from dynamiq.nodes.writers.base import Writer, WriterInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import MilvusVectorStore
 from dynamiq.storages.vector.milvus.milvus import MilvusWriterVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -67,6 +68,7 @@ class MilvusDocumentWriter(Writer, MilvusWriterVectorStoreParams):
             Any exceptions raised by the vector store's write_documents method.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         documents = input_data.documents

--- a/dynamiq/nodes/writers/opensearch.py
+++ b/dynamiq/nodes/writers/opensearch.py
@@ -5,6 +5,7 @@ from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import OpenSearchVectorStore
 from dynamiq.storages.vector.opensearch.opensearch import OpenSearchVectorStoreWriterParams
 from dynamiq.storages.vector.policies import DuplicatePolicy
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -78,6 +79,7 @@ class OpenSearchDocumentWriter(Writer, OpenSearchVectorStoreWriterParams):
             dict[str, int]: A dictionary containing the count of written documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         upserted_count = self.vector_store.write_documents(

--- a/dynamiq/nodes/writers/pgvector.py
+++ b/dynamiq/nodes/writers/pgvector.py
@@ -4,6 +4,7 @@ from dynamiq.nodes.writers.base import Writer, WriterInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import PGVectorStore
 from dynamiq.storages.vector.pgvector.pgvector import PGVectorStoreWriterParams
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -63,6 +64,7 @@ class PGVectorDocumentWriter(Writer, PGVectorStoreWriterParams):
             dict: A dictionary containing the count of upserted documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         documents = input_data.documents

--- a/dynamiq/nodes/writers/pinecone.py
+++ b/dynamiq/nodes/writers/pinecone.py
@@ -6,6 +6,7 @@ from dynamiq.nodes.writers.base import Writer, WriterInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import PineconeVectorStore
 from dynamiq.storages.vector.pinecone.pinecone import PineconeIndexType, PineconeWriterVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -89,6 +90,7 @@ class PineconeDocumentWriter(Writer, PineconeWriterVectorStoreParams):
             Any exceptions raised by the vector store's write_documents method.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         documents = input_data.documents

--- a/dynamiq/nodes/writers/qdrant.py
+++ b/dynamiq/nodes/writers/qdrant.py
@@ -3,6 +3,7 @@ from dynamiq.nodes.node import ensure_config
 from dynamiq.nodes.writers.base import Writer, WriterInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector.qdrant.qdrant import QdrantVectorStore, QdrantWriterVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -62,6 +63,7 @@ class QdrantDocumentWriter(Writer, QdrantWriterVectorStoreParams):
             dict: A dictionary containing the count of upserted documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         documents = input_data.documents

--- a/dynamiq/nodes/writers/weaviate.py
+++ b/dynamiq/nodes/writers/weaviate.py
@@ -4,6 +4,7 @@ from dynamiq.nodes.writers.base import Writer, WriterInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import WeaviateVectorStore
 from dynamiq.storages.vector.weaviate import WeaviateWriterVectorStoreParams
+from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
 
 
@@ -63,6 +64,7 @@ class WeaviateDocumentWriter(Writer, WeaviateWriterVectorStoreParams):
             dict: A dictionary containing the count of upserted documents.
         """
         config = ensure_config(config)
+        check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         documents = input_data.documents


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many execution paths (tools, retrievers, writers, streaming, and batch loops) to raise `CanceledException` earlier, which could change runtime behavior for long-running workflows if callers weren’t expecting mid-run cancellation.
> 
> **Overview**
> Adds `check_cancellation(config)` calls across a wide set of nodes to make cancellation consistently enforced before long-running work (API calls, embedding, retrieval/writes, file conversions) and inside streaming/batch loops.
> 
> Also threads `config` into internal loops where needed (e.g. `CypherExecutor._execute_batch`, `Stagehand.get_downloads_via_sdk`) so cancellation can interrupt multi-step operations promptly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2e32fc7c092f0988fbc3a1480550f9daba400f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->