### PR TITLE
feat: add checkpoints on input timeout

### DIFF
--- a/dynamiq/checkpoints/checkpoint.py
+++ b/dynamiq/checkpoints/checkpoint.py
@@ -351,33 +351,65 @@ class CheckpointFlowMixin(BaseModel):
                     self._save_checkpoint_unlocked()
                     logger.debug(f"Flow {self.id}: cleared pending input for node {node_id}")
 
+        def _snapshot_node_state_unlocked(node_id: str) -> bool:
+            """Snapshot a node's internal state into the checkpoint and persist.
+
+            Caller must hold ``self._checkpoint_lock``. Returns ``True`` if the snapshot
+            was written, ``False`` if there's no live checkpoint, the node is unknown,
+            or the node doesn't implement ``CheckpointNodeMixin``.
+            """
+            if not self._checkpoint:
+                return False
+            node = self._node_by_id.get(node_id)
+            if not node or not isinstance(node, CheckpointNodeMixin):
+                return False
+            checkpoint_state = node.to_checkpoint_state()
+            internal_state = (
+                checkpoint_state.model_dump() if hasattr(checkpoint_state, "model_dump") else checkpoint_state
+            )
+            if node_id in self._checkpoint.node_states:
+                self._checkpoint.node_states[node_id].internal_state = internal_state
+            else:
+                self._checkpoint.node_states[node_id] = NodeCheckpointState(
+                    node_id=node_id,
+                    node_type=node.type,
+                    status=CheckpointStatus.ACTIVE.value,
+                    internal_state=internal_state,
+                )
+            self._save_checkpoint_unlocked()
+            return True
+
         def on_save_mid_run(node_id: str) -> None:
             with self._checkpoint_lock:
                 cfg = self._effective_checkpoint_config or self.checkpoint
-                if self._checkpoint and cfg.checkpoint_mid_agent_loop_enabled:
-                    node = self._node_by_id.get(node_id)
-                    if not node or not isinstance(node, CheckpointNodeMixin):
-                        return
-                    checkpoint_state = node.to_checkpoint_state()
-                    internal_state = (
-                        checkpoint_state.model_dump() if hasattr(checkpoint_state, "model_dump") else checkpoint_state
-                    )
-                    if node_id in self._checkpoint.node_states:
-                        self._checkpoint.node_states[node_id].internal_state = internal_state
-                    else:
-                        self._checkpoint.node_states[node_id] = NodeCheckpointState(
-                            node_id=node_id,
-                            node_type=node.type,
-                            status=CheckpointStatus.ACTIVE.value,
-                            internal_state=internal_state,
-                        )
-                    self._save_checkpoint_unlocked()
+                if not cfg.checkpoint_mid_agent_loop_enabled:
+                    return
+                if _snapshot_node_state_unlocked(node_id):
                     logger.debug(f"Flow {self.id}: mid-run checkpoint saved for node {node_id}")
+                else:
+                    logger.debug(
+                        f"Flow {self.id}: mid-run save requested for node {node_id} - "
+                        f"no checkpoint state captured (no live checkpoint or unknown node)"
+                    )
+
+        def on_input_timeout(node_id: str) -> None:
+            with self._checkpoint_lock:
+                cfg = self._effective_checkpoint_config or self.checkpoint
+                if not cfg.checkpoint_on_input_timeout_enabled:
+                    return
+                if _snapshot_node_state_unlocked(node_id):
+                    logger.info(f"Flow {self.id}: checkpoint saved on input streaming timeout for node {node_id}")
+                else:
+                    logger.debug(
+                        f"Flow {self.id}: input streaming timeout for node {node_id} - "
+                        f"no checkpoint state captured (no live checkpoint or unknown node)"
+                    )
 
         checkpoint_context = CheckpointContext(
             on_pending_input=on_pending_input,
             on_input_received=on_input_received,
             on_save_mid_run=on_save_mid_run,
+            on_input_timeout=on_input_timeout,
         )
 
         if config is None:

--- a/dynamiq/checkpoints/checkpoint.py
+++ b/dynamiq/checkpoints/checkpoint.py
@@ -392,12 +392,34 @@ class CheckpointFlowMixin(BaseModel):
                         f"no checkpoint state captured (no live checkpoint or unknown node)"
                     )
 
+        def _resolve_top_level_owner(node_id: str) -> str:
+            """Map a node id to the top-level flow node id that owns it.
+
+            ``_node_by_id`` only holds top-level flow nodes, so when an agent's
+            tool times out we need to find the enclosing agent to snapshot its
+            state. Falls back to the original id if no owner is found (helper
+            will then no-op cleanly).
+            """
+            if node_id in self._node_by_id:
+                return node_id
+            for top_id, top in self._node_by_id.items():
+                tools = getattr(top, "tools", None) or []
+                if any(getattr(t, "id", None) == node_id for t in tools):
+                    return top_id
+            return node_id
+
         def on_input_timeout(node_id: str) -> None:
             with self._checkpoint_lock:
                 cfg = self._effective_checkpoint_config or self.checkpoint
                 if not cfg.checkpoint_on_input_timeout_enabled:
                     return
-                if _snapshot_node_state_unlocked(node_id):
+                effective_id = _resolve_top_level_owner(node_id)
+                if effective_id != node_id:
+                    logger.debug(
+                        f"Flow {self.id}: input timeout from nested node {node_id} - "
+                        f"snapshotting enclosing top-level node {effective_id}"
+                    )
+                if _snapshot_node_state_unlocked(effective_id):
                     logger.info(f"Flow {self.id}: checkpoint saved on input streaming timeout for node {node_id}")
                 else:
                     logger.debug(

--- a/dynamiq/checkpoints/checkpoint.py
+++ b/dynamiq/checkpoints/checkpoint.py
@@ -352,11 +352,12 @@ class CheckpointFlowMixin(BaseModel):
                     logger.debug(f"Flow {self.id}: cleared pending input for node {node_id}")
 
         def _snapshot_node_state_unlocked(node_id: str) -> bool:
-            """Snapshot a node's internal state into the checkpoint and persist.
+            """Snapshot a node's internal state into the checkpoint (mutation only, no save).
 
-            Caller must hold ``self._checkpoint_lock``. Returns ``True`` if the snapshot
-            was written, ``False`` if there's no live checkpoint, the node is unknown,
-            or the node doesn't implement ``CheckpointNodeMixin``.
+            Caller must hold ``self._checkpoint_lock`` and is responsible for calling
+            ``self._save_checkpoint_unlocked()`` afterwards. Returns ``True`` if the
+            snapshot mutation was written, ``False`` if there's no live checkpoint, the
+            node is unknown, or the node doesn't implement ``CheckpointNodeMixin``.
             """
             if not self._checkpoint:
                 return False
@@ -376,7 +377,6 @@ class CheckpointFlowMixin(BaseModel):
                     status=CheckpointStatus.ACTIVE.value,
                     internal_state=internal_state,
                 )
-            self._save_checkpoint_unlocked()
             return True
 
         def on_save_mid_run(node_id: str) -> None:
@@ -385,6 +385,7 @@ class CheckpointFlowMixin(BaseModel):
                 if not cfg.checkpoint_mid_agent_loop_enabled:
                     return
                 if _snapshot_node_state_unlocked(node_id):
+                    self._save_checkpoint_unlocked()
                     logger.debug(f"Flow {self.id}: mid-run checkpoint saved for node {node_id}")
                 else:
                     logger.debug(
@@ -420,7 +421,18 @@ class CheckpointFlowMixin(BaseModel):
                         f"snapshotting enclosing top-level node {effective_id}"
                     )
                 if _snapshot_node_state_unlocked(effective_id):
-                    logger.info(f"Flow {self.id}: checkpoint saved on input streaming timeout for node {node_id}")
+                    self._checkpoint.mark_pending_input(
+                        node_id=effective_id,
+                        prompt="",
+                        metadata={
+                            "reason": "input_streaming_timeout",
+                            "source_node_id": node_id,
+                        },
+                    )
+                    self._save_checkpoint_unlocked()
+                    logger.info(
+                        f"Flow {self.id}: checkpoint marked PENDING_INPUT on input streaming timeout for node {node_id}"
+                    )
                 else:
                     logger.debug(
                         f"Flow {self.id}: input streaming timeout for node {node_id} - "

--- a/dynamiq/checkpoints/config.py
+++ b/dynamiq/checkpoints/config.py
@@ -27,10 +27,12 @@ class CheckpointContext:
         on_pending_input: Callable[[str, str, dict | None], None] | None = None,
         on_input_received: Callable[[str], None] | None = None,
         on_save_mid_run: Callable[[str], None] | None = None,
+        on_input_timeout: Callable[[str], None] | None = None,
     ):
         self._on_pending_input = on_pending_input
         self._on_input_received = on_input_received
         self._on_save_mid_run = on_save_mid_run
+        self._on_input_timeout = on_input_timeout
 
     def mark_pending_input(self, node_id: str, prompt: str, metadata: dict | None = None) -> None:
         """Notify that a node is waiting for human input."""
@@ -46,6 +48,11 @@ class CheckpointContext:
         """Request a checkpoint save during a long-running node (e.g., agent loop iteration)."""
         if self._on_save_mid_run:
             self._on_save_mid_run(node_id)
+
+    def save_on_input_timeout(self, node_id: str) -> None:
+        """Request a checkpoint save when StreamingConfig input wait times out."""
+        if self._on_input_timeout:
+            self._on_input_timeout(node_id)
 
 
 class CheckpointConfig(BaseModel):
@@ -72,6 +79,10 @@ class CheckpointConfig(BaseModel):
     checkpoint_on_failure_enabled: bool = Field(default=True, description="Create checkpoint when workflow fails")
     checkpoint_on_cancel_enabled: bool = Field(default=True, description="Create checkpoint when workflow is canceled")
     checkpoint_mid_agent_loop_enabled: bool = Field(default=False, description="Checkpoint during long agent loops")
+    checkpoint_on_input_timeout_enabled: bool = Field(
+        default=True,
+        description="Create checkpoint when StreamingConfig input wait times out",
+    )
 
     max_checkpoints: int = Field(
         default=50,

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -295,6 +295,18 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             return False
         return type(self).execute_async is not Node.execute_async
 
+    @model_validator(mode="after")
+    def validate_streaming_vs_error_handling_timeout(self):
+        streaming_timeout = self.streaming.timeout
+        node_timeout = self.error_handling.timeout_seconds
+        if streaming_timeout is not None and node_timeout is not None and streaming_timeout >= node_timeout:
+            raise ValueError(
+                f"Node {self.name or self.id}: streaming.timeout ({streaming_timeout}s) must be smaller than "
+                f"error_handling.timeout_seconds ({node_timeout}s) so the input-streaming timeout can fire "
+                f"before the generic execution timeout."
+            )
+        return self
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
     input_schema: type[BaseModel] | None = None
     callbacks: list[NodeCallbackHandler] = []
@@ -1508,6 +1520,9 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         while not is_done():
             check_cancellation(config)
             if streaming.timeout is not None and elapsed >= streaming.timeout:
+                checkpoint_ctx = config.checkpoint.context if config and config.checkpoint else None
+                if checkpoint_ctx:
+                    checkpoint_ctx.save_on_input_timeout(self.id)
                 raise ValueError(f"Input streaming timeout: {streaming.timeout} seconds exceeded.")
 
             remaining = streaming.timeout - elapsed if streaming.timeout is not None else poll_interval

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -47,7 +47,13 @@ from dynamiq.types.feedback import (
     ApprovalStreamingOutputEventMessage,
     FeedbackMethod,
 )
-from dynamiq.types.streaming import STREAMING_EVENT, StreamingConfig, StreamingEntitySource, StreamingEventMessage
+from dynamiq.types.streaming import (
+    STREAMING_EVENT,
+    InputStreamingTimeoutError,
+    StreamingConfig,
+    StreamingEntitySource,
+    StreamingEventMessage,
+)
 from dynamiq.utils import format_value, generate_uuid, merge
 from dynamiq.utils.duration import format_duration
 from dynamiq.utils.jsonpath import filter as jsonpath_filter
@@ -1528,7 +1534,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                         checkpoint_ctx.save_on_input_timeout(self.id)
                     except Exception as e:
                         logger.warning(f"Node {self.id}: checkpoint save on input-streaming timeout failed: {e}")
-                raise ValueError(f"Input streaming timeout: {streaming.timeout} seconds exceeded.")
+                raise InputStreamingTimeoutError(node_id=self.id, timeout=streaming.timeout)
 
             remaining = streaming.timeout - elapsed if streaming.timeout is not None else poll_interval
             wait_time = min(poll_interval, remaining)

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -297,6 +297,8 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
 
     @model_validator(mode="after")
     def validate_streaming_vs_error_handling_timeout(self):
+        if not self.streaming.input_streaming_enabled:
+            return self
         streaming_timeout = self.streaming.timeout
         node_timeout = self.error_handling.timeout_seconds
         if streaming_timeout is not None and node_timeout is not None and streaming_timeout >= node_timeout:

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -301,6 +301,12 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             return False
         return type(self).execute_async is not Node.execute_async
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    input_schema: type[BaseModel] | None = None
+    callbacks: list[NodeCallbackHandler] = []
+    _json_schema_fields: ClassVar[list[str]] = []
+    _clone_init_methods_names: ClassVar[list[str]] = ["reset_run_state"]
+
     @model_validator(mode="after")
     def validate_streaming_vs_error_handling_timeout(self):
         if not self.streaming.input_streaming_enabled:
@@ -314,12 +320,6 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                 f"before the generic execution timeout."
             )
         return self
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-    input_schema: type[BaseModel] | None = None
-    callbacks: list[NodeCallbackHandler] = []
-    _json_schema_fields: ClassVar[list[str]] = []
-    _clone_init_methods_names: ClassVar[list[str]] = ["reset_run_state"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -1524,7 +1524,10 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             if streaming.timeout is not None and elapsed >= streaming.timeout:
                 checkpoint_ctx = config.checkpoint.context if config and config.checkpoint else None
                 if checkpoint_ctx:
-                    checkpoint_ctx.save_on_input_timeout(self.id)
+                    try:
+                        checkpoint_ctx.save_on_input_timeout(self.id)
+                    except Exception as e:
+                        logger.warning(f"Node {self.id}: checkpoint save on input-streaming timeout failed: {e}")
                 raise ValueError(f"Input streaming timeout: {streaming.timeout} seconds exceeded.")
 
             remaining = streaming.timeout - elapsed if streaming.timeout is not None else poll_interval

--- a/dynamiq/types/streaming.py
+++ b/dynamiq/types/streaming.py
@@ -20,6 +20,21 @@ class StreamingMode(str, Enum):
 STREAMING_EVENT = "streaming"
 
 
+class InputStreamingTimeoutError(TimeoutError):
+    """Raised when a node's input-streaming wait exceeds ``StreamingConfig.timeout``.
+
+    Subclasses the built-in ``TimeoutError`` so generic ``except TimeoutError``
+    handlers catch it idiomatically. Callers that need to distinguish a
+    streaming-input timeout specifically should isinstance-check or, after
+    serialization, match ``error["type"] == "InputStreamingTimeoutError"``.
+    """
+
+    def __init__(self, node_id: str, timeout: float):
+        self.node_id = node_id
+        self.timeout = timeout
+        super().__init__(f"Input streaming timeout: {timeout} seconds exceeded.")
+
+
 class StreamingEntitySource(BaseModel):
     id: str | None = None
     name: str | None = None

--- a/dynamiq/types/streaming.py
+++ b/dynamiq/types/streaming.py
@@ -20,11 +20,12 @@ class StreamingMode(str, Enum):
 STREAMING_EVENT = "streaming"
 
 
-class InputStreamingTimeoutError(TimeoutError):
+class InputStreamingTimeoutError(TimeoutError, ValueError):
     """Raised when a node's input-streaming wait exceeds ``StreamingConfig.timeout``.
 
-    Subclasses the built-in ``TimeoutError`` so generic ``except TimeoutError``
-    handlers catch it idiomatically. Callers that need to distinguish a
+    Inherits from both ``TimeoutError`` (idiomatic for timeouts) and ``ValueError``
+    (the original raised type, preserved for backward compatibility with callers
+    and tests that catch ``ValueError``). Callers that need to distinguish a
     streaming-input timeout specifically should isinstance-check or, after
     serialization, match ``error["type"] == "InputStreamingTimeoutError"``.
     """

--- a/tests/integration/checkpoints/test_agent_checkpoints.py
+++ b/tests/integration/checkpoints/test_agent_checkpoints.py
@@ -1,3 +1,5 @@
+from queue import Queue
+
 import pytest
 from litellm import ModelResponse
 
@@ -5,14 +7,27 @@ from dynamiq import connections, flows
 from dynamiq.checkpoints.backends.filesystem import FileSystem
 from dynamiq.checkpoints.backends.in_memory import InMemory
 from dynamiq.checkpoints.checkpoint import CheckpointStatus
-from dynamiq.checkpoints.config import CheckpointBehavior, CheckpointConfig
+from dynamiq.checkpoints.config import CheckpointBehavior, CheckpointConfig, CheckpointContext
 from dynamiq.nodes import llms
 from dynamiq.nodes.agents import Agent
 from dynamiq.nodes.node import NodeDependency
 from dynamiq.nodes.tools import Python
+from dynamiq.nodes.tools.human_feedback import (
+    HFStreamingInputEventMessage,
+    HFStreamingInputEventMessageData,
+    HumanFeedbackAction,
+    HumanFeedbackTool,
+)
 from dynamiq.nodes.utils import Input, Output
 from dynamiq.runnables import RunnableConfig, RunnableStatus
-from dynamiq.types.feedback import ApprovalConfig, ApprovalInputData, FeedbackMethod
+from dynamiq.types.feedback import (
+    APPROVAL_EVENT,
+    ApprovalConfig,
+    ApprovalInputData,
+    ApprovalStreamingInputEventMessage,
+    FeedbackMethod,
+)
+from dynamiq.types.streaming import StreamingConfig
 
 TEST_API_KEY = "test-api-key"
 LLM_MODEL = "gpt-4o-mini"
@@ -371,6 +386,147 @@ class TestHITLApprovalCheckpoint:
 
         assert len(pending_notifications) >= 1
         assert pending_notifications[0]["node_id"] == "hitl-python"
+
+
+def _input_timeout_only_config(backend) -> CheckpointConfig:
+    """CheckpointConfig with all save triggers off except input-timeout, so any
+    save_on_input_timeout invocation can be uniquely attributed to this feature."""
+    return CheckpointConfig(
+        enabled=True,
+        backend=backend,
+        checkpoint_after_node_enabled=False,
+        checkpoint_on_failure_enabled=False,
+        checkpoint_on_cancel_enabled=False,
+        checkpoint_mid_agent_loop_enabled=False,
+        checkpoint_on_input_timeout_enabled=True,
+    )
+
+
+class TestInputStreamingTimeoutInAgent:
+    """Streaming-input timeout inside an Agent's tool also fires save_on_input_timeout.
+
+    Mirrors TestInputStreamingTimeoutCheckpoint in test_flow_checkpoints.py — verifies
+    the same callback wiring works when the timing-out node is a tool invoked from an
+    agent's ReAct loop rather than a standalone node in a flow.
+    """
+
+    HF_TOOL_ID = "hitl-input-tool"
+    PY_TOOL_ID = "approval-gated-python"
+    SHORT_STREAMING_TIMEOUT = 0.3
+
+    def _patch_llm_tool_call_then_final(self, mocker, tool_name: str, final_answer: str = "approved"):
+        """LLM emits the tool call on calls #1 and #2, then Final Answer thereafter.
+
+        - First run: call #1 → tool call → tool times out → agent fails.
+        - Resume: call #2 → tool call → tool must actually consume the queued
+          response to succeed → call #3 → Final Answer → agent terminates.
+
+        Returning Final Answer on call #2 would let the agent bypass the tool on
+        resume; emitting the tool call twice forces the queue to be consumed for
+        the resume to succeed.
+        """
+        call_count = {"value": 0}
+
+        def side_effect(stream: bool, *args, **kwargs):
+            call_count["value"] += 1
+            r = ModelResponse()
+            if call_count["value"] <= 2:
+                r["choices"][0]["message"][
+                    "content"
+                ] = f'Thought: I need to ask.\nAction: {tool_name}\nAction Input: {{"input": "approve?"}}'
+            else:
+                r["choices"][0]["message"]["content"] = f"Thought: Done.\nFinal Answer: {final_answer}"
+            return r
+
+        mocker.patch("dynamiq.nodes.llms.base.BaseLLM._completion", side_effect=side_effect)
+
+    def test_human_feedback_tool_timeout_checkpoint_recoverable_in_agent(self, mocker):
+        """End-to-end: agent's HumanFeedbackTool times out → on_input_timeout fires
+        with the tool's id → walk-up snapshots agent state → resume completes."""
+        spy = mocker.spy(CheckpointContext, "save_on_input_timeout")
+        queue = Queue()
+        tool = HumanFeedbackTool(
+            id=self.HF_TOOL_ID,
+            name="human-input",
+            action=HumanFeedbackAction.ASK,
+            input_method=FeedbackMethod.STREAM,
+            output_method=FeedbackMethod.STREAM,
+            streaming=StreamingConfig(enabled=True, input_queue=queue, timeout=self.SHORT_STREAMING_TIMEOUT),
+        )
+        agent = Agent(
+            id=AGENT_ID,
+            name="ReAct Agent",
+            llm=make_agent_llm(),
+            tools=[tool],
+            role="Assistant",
+            max_loops=2,
+        )
+        self._patch_llm_tool_call_then_final(mocker, tool_name="human-input")
+
+        backend = InMemory()
+        flow = flows.Flow(id=FLOW_ID, nodes=[agent], checkpoint=_input_timeout_only_config(backend))
+
+        first = flow.run_sync(input_data={"input": "do something"})
+        assert first.status == RunnableStatus.FAILURE
+        assert any(
+            call.args[1] == self.HF_TOOL_ID for call in spy.call_args_list
+        ), "expected save_on_input_timeout to be invoked with the tool's id"
+        saved = backend.get_latest_by_flow(FLOW_ID)
+        assert saved is not None
+        assert AGENT_ID in saved.node_states, "agent state must be snapshotted via walk-up"
+
+        queue.put(
+            HFStreamingInputEventMessage(
+                entity_id=self.HF_TOOL_ID,
+                data=HFStreamingInputEventMessageData(content="approved"),
+            ).model_dump_json()
+        )
+        second = flow.run_sync(input_data={"input": "do something"}, resume_from=saved.id)
+        assert second.status == RunnableStatus.SUCCESS
+
+    def test_streaming_approval_tool_timeout_checkpoint_recoverable_in_agent(self, mocker):
+        """End-to-end: agent's Python tool with ApprovalConfig(STREAM) times out →
+        on_input_timeout fires → walk-up snapshots agent state → resume completes."""
+        spy = mocker.spy(CheckpointContext, "save_on_input_timeout")
+        queue = Queue()
+        tool = Python(
+            id=self.PY_TOOL_ID,
+            name="approval-python",
+            code='def run(input_data): return {"result": "ran"}',
+            approval=ApprovalConfig(enabled=True, feedback_method=FeedbackMethod.STREAM),
+            streaming=StreamingConfig(enabled=True, input_queue=queue, timeout=self.SHORT_STREAMING_TIMEOUT),
+        )
+        agent = Agent(
+            id=AGENT_ID,
+            name="ReAct Agent",
+            llm=make_agent_llm(),
+            tools=[tool],
+            role="Assistant",
+            max_loops=2,
+        )
+        self._patch_llm_tool_call_then_final(mocker, tool_name="approval-python")
+
+        backend = InMemory()
+        flow = flows.Flow(id=FLOW_ID, nodes=[agent], checkpoint=_input_timeout_only_config(backend))
+
+        first = flow.run_sync(input_data={"input": "do something"})
+        assert first.status == RunnableStatus.FAILURE
+        assert any(
+            call.args[1] == self.PY_TOOL_ID for call in spy.call_args_list
+        ), "expected save_on_input_timeout to be invoked with the tool's id"
+        saved = backend.get_latest_by_flow(FLOW_ID)
+        assert saved is not None
+        assert AGENT_ID in saved.node_states, "agent state must be snapshotted via walk-up"
+
+        queue.put(
+            ApprovalStreamingInputEventMessage(
+                entity_id=self.PY_TOOL_ID,
+                event=APPROVAL_EVENT,
+                data=ApprovalInputData(is_approved=True, feedback=""),
+            ).model_dump_json()
+        )
+        second = flow.run_sync(input_data={"input": "do something"}, resume_from=saved.id)
+        assert second.status == RunnableStatus.SUCCESS
 
 
 class TestAgentFlowRunIsolation:

--- a/tests/integration/checkpoints/test_flow_checkpoints.py
+++ b/tests/integration/checkpoints/test_flow_checkpoints.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from queue import Queue
 from unittest.mock import AsyncMock
 
 import pytest
@@ -7,15 +8,16 @@ from litellm import ModelResponse
 from dynamiq import Workflow, connections, flows
 from dynamiq.checkpoints.backends.filesystem import FileSystem
 from dynamiq.checkpoints.backends.in_memory import InMemory
-from dynamiq.checkpoints.checkpoint import CheckpointStatus
+from dynamiq.checkpoints.checkpoint import CheckpointStatus, FlowCheckpoint
 from dynamiq.checkpoints.config import CheckpointBehavior, CheckpointConfig
 from dynamiq.nodes import llms
 from dynamiq.nodes.agents import Agent
-from dynamiq.nodes.node import NodeDependency
+from dynamiq.nodes.node import Node, NodeDependency, NodeGroup
 from dynamiq.nodes.tools import Python
 from dynamiq.nodes.utils import Input, Output
 from dynamiq.prompts import Message, Prompt
 from dynamiq.runnables import RunnableConfig, RunnableStatus
+from dynamiq.types.streaming import StreamingConfig
 
 TEST_API_KEY = "test-api-key"
 LLM_MODEL = "gpt-4o-mini"
@@ -685,6 +687,115 @@ class TestCheckpointStatusLifecycle:
         all_checkpoints = backend.get_list_by_flow(flow.id, limit=50)
         children = [cp for cp in all_checkpoints if cp.parent_checkpoint_id == original_id]
         assert len(children) >= 1, "No APPEND snapshot linked to the original checkpoint was created"
+
+
+INPUT_TIMEOUT_NODE_ID = "blocking-input-node"
+INPUT_TIMEOUT_FLOW_ID = "input-timeout-flow"
+SHORT_STREAMING_TIMEOUT = 0.3
+
+
+class _BlockingInputNode(Node):
+    """Test node that blocks on streaming input so the timeout fires."""
+
+    group: NodeGroup = NodeGroup.UTILS
+    name: str = "BlockingInputNode"
+
+    def execute(self, input_data: dict, config: RunnableConfig = None, **kwargs) -> dict:
+        event_msg = self.get_input_streaming_event(config=config)
+        return {"result": event_msg.data}
+
+
+def _make_blocking_node() -> _BlockingInputNode:
+    return _BlockingInputNode(
+        id=INPUT_TIMEOUT_NODE_ID,
+        streaming=StreamingConfig(enabled=True, input_queue=Queue(), timeout=SHORT_STREAMING_TIMEOUT),
+    )
+
+
+def _has_active_node_state(checkpoints: list[FlowCheckpoint]) -> bool:
+    """True if any checkpoint contains an ACTIVE node_state for the blocking node.
+
+    The on_input_timeout save writes node_states[NODE_ID].status = "active".
+    The per-node-completion path writes status = "failure" once the node returns FAILURE,
+    so "active" is the unique signature of the on_input_timeout save.
+    """
+    return any(
+        INPUT_TIMEOUT_NODE_ID in cp.node_states
+        and cp.node_states[INPUT_TIMEOUT_NODE_ID].status == CheckpointStatus.ACTIVE.value
+        for cp in checkpoints
+    )
+
+
+class TestInputStreamingTimeoutCheckpoint:
+    """Checkpoint creation when StreamingConfig.timeout fires waiting for input."""
+
+    def test_checkpoint_saved_on_input_timeout(self):
+        backend = InMemory()
+        flow = flows.Flow(
+            id=INPUT_TIMEOUT_FLOW_ID,
+            nodes=[_make_blocking_node()],
+            checkpoint=CheckpointConfig(enabled=True, backend=backend),
+        )
+
+        result = flow.run_sync(input_data={})
+
+        assert result.status == RunnableStatus.FAILURE
+        assert "timeout" in str(result.error.message).lower()
+        assert _has_active_node_state(
+            backend.get_list_by_flow(INPUT_TIMEOUT_FLOW_ID)
+        ), "expected an on_input_timeout checkpoint with node_states[NODE_ID].status == 'active'"
+
+    def test_no_input_timeout_snapshot_when_flag_disabled(self):
+        backend = InMemory()
+        flow = flows.Flow(
+            id=INPUT_TIMEOUT_FLOW_ID,
+            nodes=[_make_blocking_node()],
+            checkpoint=CheckpointConfig(
+                enabled=True,
+                backend=backend,
+                checkpoint_on_input_timeout_enabled=False,
+            ),
+        )
+
+        result = flow.run_sync(input_data={})
+
+        assert result.status == RunnableStatus.FAILURE
+        assert not _has_active_node_state(
+            backend.get_list_by_flow(INPUT_TIMEOUT_FLOW_ID)
+        ), "did not expect an ACTIVE node_state snapshot when checkpoint_on_input_timeout_enabled is False"
+
+    def test_no_checkpoint_when_checkpoints_disabled(self):
+        backend = InMemory()
+        flow = flows.Flow(
+            id=INPUT_TIMEOUT_FLOW_ID,
+            nodes=[_make_blocking_node()],
+            checkpoint=CheckpointConfig(enabled=False, backend=backend),
+        )
+
+        result = flow.run_sync(input_data={})
+
+        assert result.status == RunnableStatus.FAILURE
+        assert backend.get_list_by_flow(INPUT_TIMEOUT_FLOW_ID) == []
+
+    def test_input_timeout_enabled_via_runnable_config_override(self):
+        backend = InMemory()
+        flow = flows.Flow(
+            id=INPUT_TIMEOUT_FLOW_ID,
+            nodes=[_make_blocking_node()],
+            checkpoint=CheckpointConfig(
+                enabled=True,
+                backend=backend,
+                checkpoint_on_input_timeout_enabled=False,
+            ),
+        )
+
+        config = RunnableConfig(checkpoint=CheckpointConfig(checkpoint_on_input_timeout_enabled=True))
+        result = flow.run_sync(input_data={}, config=config)
+
+        assert result.status == RunnableStatus.FAILURE
+        assert _has_active_node_state(
+            backend.get_list_by_flow(INPUT_TIMEOUT_FLOW_ID)
+        ), "per-run override should have re-enabled the on_input_timeout save"
 
 
 class TestBinaryDataCheckpoint:

--- a/tests/integration/checkpoints/test_flow_checkpoints.py
+++ b/tests/integration/checkpoints/test_flow_checkpoints.py
@@ -8,15 +8,28 @@ from litellm import ModelResponse
 from dynamiq import Workflow, connections, flows
 from dynamiq.checkpoints.backends.filesystem import FileSystem
 from dynamiq.checkpoints.backends.in_memory import InMemory
-from dynamiq.checkpoints.checkpoint import CheckpointStatus, FlowCheckpoint
-from dynamiq.checkpoints.config import CheckpointBehavior, CheckpointConfig
+from dynamiq.checkpoints.checkpoint import CheckpointStatus
+from dynamiq.checkpoints.config import CheckpointBehavior, CheckpointConfig, CheckpointContext
 from dynamiq.nodes import llms
 from dynamiq.nodes.agents import Agent
-from dynamiq.nodes.node import Node, NodeDependency, NodeGroup
+from dynamiq.nodes.node import NodeDependency
 from dynamiq.nodes.tools import Python
+from dynamiq.nodes.tools.human_feedback import (
+    HFStreamingInputEventMessage,
+    HFStreamingInputEventMessageData,
+    HumanFeedbackAction,
+    HumanFeedbackTool,
+)
 from dynamiq.nodes.utils import Input, Output
 from dynamiq.prompts import Message, Prompt
 from dynamiq.runnables import RunnableConfig, RunnableStatus
+from dynamiq.types.feedback import (
+    APPROVAL_EVENT,
+    ApprovalConfig,
+    ApprovalInputData,
+    ApprovalStreamingInputEventMessage,
+    FeedbackMethod,
+)
 from dynamiq.types.streaming import StreamingConfig
 
 TEST_API_KEY = "test-api-key"
@@ -689,113 +702,102 @@ class TestCheckpointStatusLifecycle:
         assert len(children) >= 1, "No APPEND snapshot linked to the original checkpoint was created"
 
 
-INPUT_TIMEOUT_NODE_ID = "blocking-input-node"
+INPUT_TIMEOUT_NODE_ID = "human-feedback-node"
 INPUT_TIMEOUT_FLOW_ID = "input-timeout-flow"
 SHORT_STREAMING_TIMEOUT = 0.3
 
 
-class _BlockingInputNode(Node):
-    """Test node that blocks on streaming input so the timeout fires."""
-
-    group: NodeGroup = NodeGroup.UTILS
-    name: str = "BlockingInputNode"
-
-    def execute(self, input_data: dict, config: RunnableConfig = None, **kwargs) -> dict:
-        event_msg = self.get_input_streaming_event(config=config)
-        return {"result": event_msg.data}
-
-
-def _make_blocking_node() -> _BlockingInputNode:
-    return _BlockingInputNode(
-        id=INPUT_TIMEOUT_NODE_ID,
-        streaming=StreamingConfig(enabled=True, input_queue=Queue(), timeout=SHORT_STREAMING_TIMEOUT),
-    )
-
-
-def _has_active_node_state(checkpoints: list[FlowCheckpoint]) -> bool:
-    """True if any checkpoint contains an ACTIVE node_state for the blocking node.
-
-    The on_input_timeout save writes node_states[NODE_ID].status = "active".
-    The per-node-completion path writes status = "failure" once the node returns FAILURE,
-    so "active" is the unique signature of the on_input_timeout save.
-    """
-    return any(
-        INPUT_TIMEOUT_NODE_ID in cp.node_states
-        and cp.node_states[INPUT_TIMEOUT_NODE_ID].status == CheckpointStatus.ACTIVE.value
-        for cp in checkpoints
+def _input_timeout_only_config(backend) -> CheckpointConfig:
+    """CheckpointConfig with all save triggers off except input-timeout, so any
+    save_on_input_timeout invocation can be uniquely attributed to this feature."""
+    return CheckpointConfig(
+        enabled=True,
+        backend=backend,
+        checkpoint_after_node_enabled=False,
+        checkpoint_on_failure_enabled=False,
+        checkpoint_on_cancel_enabled=False,
+        checkpoint_mid_agent_loop_enabled=False,
+        checkpoint_on_input_timeout_enabled=True,
     )
 
 
 class TestInputStreamingTimeoutCheckpoint:
-    """Checkpoint creation when StreamingConfig.timeout fires waiting for input."""
+    """End-to-end: streaming-input timeout saves a recoverable checkpoint."""
 
-    def test_checkpoint_saved_on_input_timeout(self):
+    def test_human_feedback_tool_timeout_checkpoint_recoverable(self, mocker):
+        """HumanFeedbackTool times out → on_input_timeout fires → checkpoint
+        saved → resume with input now available → flow completes."""
+        spy = mocker.spy(CheckpointContext, "save_on_input_timeout")
+        queue = Queue()
+        node = HumanFeedbackTool(
+            id=INPUT_TIMEOUT_NODE_ID,
+            action=HumanFeedbackAction.ASK,
+            input_method=FeedbackMethod.STREAM,
+            output_method=FeedbackMethod.STREAM,
+            streaming=StreamingConfig(enabled=True, input_queue=queue, timeout=SHORT_STREAMING_TIMEOUT),
+        )
         backend = InMemory()
         flow = flows.Flow(
             id=INPUT_TIMEOUT_FLOW_ID,
-            nodes=[_make_blocking_node()],
-            checkpoint=CheckpointConfig(enabled=True, backend=backend),
+            nodes=[node],
+            checkpoint=_input_timeout_only_config(backend),
         )
 
-        result = flow.run_sync(input_data={})
+        first = flow.run_sync(input_data={"input": "approve?"})
+        assert first.status == RunnableStatus.FAILURE
+        assert any(
+            call.args[1] == INPUT_TIMEOUT_NODE_ID for call in spy.call_args_list
+        ), "expected save_on_input_timeout to be invoked with the node's id"
+        saved = backend.get_latest_by_flow(INPUT_TIMEOUT_FLOW_ID)
+        assert saved is not None
+        assert INPUT_TIMEOUT_NODE_ID in saved.node_states
 
-        assert result.status == RunnableStatus.FAILURE
-        assert "timeout" in str(result.error.message).lower()
-        assert _has_active_node_state(
-            backend.get_list_by_flow(INPUT_TIMEOUT_FLOW_ID)
-        ), "expected an on_input_timeout checkpoint with node_states[NODE_ID].status == 'active'"
+        queue.put(
+            HFStreamingInputEventMessage(
+                entity_id=INPUT_TIMEOUT_NODE_ID,
+                data=HFStreamingInputEventMessageData(content="approved"),
+            ).model_dump_json()
+        )
+        second = flow.run_sync(input_data={"input": "approve?"}, resume_from=saved.id)
+        assert second.status == RunnableStatus.SUCCESS
 
-    def test_no_input_timeout_snapshot_when_flag_disabled(self):
+    def test_streaming_approval_timeout_checkpoint_recoverable(self, mocker):
+        """A Python node opens a stream wait only because of ApprovalConfig(STREAM);
+        on timeout, on_input_timeout fires, the checkpoint is saved, and resume completes."""
+        spy = mocker.spy(CheckpointContext, "save_on_input_timeout")
+        queue = Queue()
+        node = Python(
+            id=INPUT_TIMEOUT_NODE_ID,
+            name="approval-gated-python",
+            code='def run(input_data): return {"result": "ran"}',
+            approval=ApprovalConfig(enabled=True, feedback_method=FeedbackMethod.STREAM),
+            streaming=StreamingConfig(enabled=True, input_queue=queue, timeout=SHORT_STREAMING_TIMEOUT),
+        )
         backend = InMemory()
         flow = flows.Flow(
             id=INPUT_TIMEOUT_FLOW_ID,
-            nodes=[_make_blocking_node()],
-            checkpoint=CheckpointConfig(
-                enabled=True,
-                backend=backend,
-                checkpoint_on_input_timeout_enabled=False,
-            ),
+            nodes=[node],
+            checkpoint=_input_timeout_only_config(backend),
         )
 
-        result = flow.run_sync(input_data={})
+        first = flow.run_sync(input_data={})
+        assert first.status == RunnableStatus.FAILURE
+        assert any(
+            call.args[1] == INPUT_TIMEOUT_NODE_ID for call in spy.call_args_list
+        ), "expected save_on_input_timeout to be invoked with the node's id"
+        saved = backend.get_latest_by_flow(INPUT_TIMEOUT_FLOW_ID)
+        assert saved is not None
+        assert INPUT_TIMEOUT_NODE_ID in saved.node_states
 
-        assert result.status == RunnableStatus.FAILURE
-        assert not _has_active_node_state(
-            backend.get_list_by_flow(INPUT_TIMEOUT_FLOW_ID)
-        ), "did not expect an ACTIVE node_state snapshot when checkpoint_on_input_timeout_enabled is False"
-
-    def test_no_checkpoint_when_checkpoints_disabled(self):
-        backend = InMemory()
-        flow = flows.Flow(
-            id=INPUT_TIMEOUT_FLOW_ID,
-            nodes=[_make_blocking_node()],
-            checkpoint=CheckpointConfig(enabled=False, backend=backend),
+        queue.put(
+            ApprovalStreamingInputEventMessage(
+                entity_id=INPUT_TIMEOUT_NODE_ID,
+                event=APPROVAL_EVENT,
+                data=ApprovalInputData(is_approved=True, feedback=""),
+            ).model_dump_json()
         )
-
-        result = flow.run_sync(input_data={})
-
-        assert result.status == RunnableStatus.FAILURE
-        assert backend.get_list_by_flow(INPUT_TIMEOUT_FLOW_ID) == []
-
-    def test_input_timeout_enabled_via_runnable_config_override(self):
-        backend = InMemory()
-        flow = flows.Flow(
-            id=INPUT_TIMEOUT_FLOW_ID,
-            nodes=[_make_blocking_node()],
-            checkpoint=CheckpointConfig(
-                enabled=True,
-                backend=backend,
-                checkpoint_on_input_timeout_enabled=False,
-            ),
-        )
-
-        config = RunnableConfig(checkpoint=CheckpointConfig(checkpoint_on_input_timeout_enabled=True))
-        result = flow.run_sync(input_data={}, config=config)
-
-        assert result.status == RunnableStatus.FAILURE
-        assert _has_active_node_state(
-            backend.get_list_by_flow(INPUT_TIMEOUT_FLOW_ID)
-        ), "per-run override should have re-enabled the on_input_timeout save"
+        second = flow.run_sync(input_data={}, resume_from=saved.id)
+        assert second.status == RunnableStatus.SUCCESS
 
 
 class TestBinaryDataCheckpoint:

--- a/tests/integration/nodes/tools/test_context_manager.py
+++ b/tests/integration/nodes/tools/test_context_manager.py
@@ -3,9 +3,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from dynamiq.nodes.llms.base import BaseLLM
+from dynamiq.nodes.node import ErrorHandling
 from dynamiq.nodes.tools.context_manager import ContextManagerTool
 from dynamiq.prompts import Message, MessageRole
 from dynamiq.runnables import RunnableStatus
+from dynamiq.types.streaming import StreamingConfig
 
 
 def _mock_tool(outputs):
@@ -17,6 +19,8 @@ def _mock_tool(outputs):
     llm.get_token_limit.return_value = 128_000
     llm.is_postponed_component_init = False
     llm.to_dict.return_value = {}
+    llm.streaming = StreamingConfig()
+    llm.error_handling = ErrorHandling()
     llm.run.side_effect = [MagicMock(status=RunnableStatus.SUCCESS, output=out) for out in outputs]
     return ContextManagerTool(llm=llm, max_retries=3), llm
 

--- a/tests/unit/checkpoints/test_states.py
+++ b/tests/unit/checkpoints/test_states.py
@@ -323,6 +323,27 @@ class TestHITLCheckpointContext:
         ctx = CheckpointContext()
         ctx.save_mid_run("agent-1")
 
+    def test_save_on_input_timeout_callback(self):
+        timeout_calls = []
+        ctx = CheckpointContext(on_input_timeout=lambda nid: timeout_calls.append(nid))
+
+        ctx.save_on_input_timeout("node-1")
+        ctx.save_on_input_timeout("node-2")
+
+        assert timeout_calls == ["node-1", "node-2"]
+
+    def test_save_on_input_timeout_noop_when_no_callback(self):
+        ctx = CheckpointContext()
+        ctx.save_on_input_timeout("node-1")
+
+    def test_checkpoint_on_input_timeout_enabled_default(self):
+        cfg = CheckpointConfig()
+        assert cfg.checkpoint_on_input_timeout_enabled is True
+
+    def test_checkpoint_on_input_timeout_can_be_disabled(self):
+        cfg = CheckpointConfig(checkpoint_on_input_timeout_enabled=False)
+        assert cfg.checkpoint_on_input_timeout_enabled is False
+
 
 class TestNodeApprovalCheckpoint:
     """Tests for Node approval response checkpoint persistence."""

--- a/tests/unit/nodes/test_node.py
+++ b/tests/unit/nodes/test_node.py
@@ -6,11 +6,11 @@ from threading import Event
 from typing import ClassVar
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.nodes.llms.openai import OpenAI
-from dynamiq.nodes.node import Node, NodeGroup
+from dynamiq.nodes.node import ErrorHandling, Node, NodeGroup
 from dynamiq.runnables import RunnableConfig, RunnableResult, RunnableStatus
 from dynamiq.types.cancellation import check_cancellation
 from dynamiq.types.streaming import StreamingConfig, StreamingEventMessage
@@ -287,6 +287,46 @@ def test_get_input_streaming_event_skips_invalid_messages():
 
     assert result.entity_id == TEST_ENTITY_ID
     assert result.data == {"content": "valid"}
+
+
+def test_streaming_timeout_must_be_smaller_than_error_handling_timeout():
+    with pytest.raises(ValidationError, match="streaming.timeout"):
+        BlockingQueueNode(
+            streaming=StreamingConfig(enabled=True, input_queue=Queue(), timeout=5.0),
+            error_handling=ErrorHandling(timeout_seconds=5.0),
+        )
+
+    with pytest.raises(ValidationError, match="streaming.timeout"):
+        BlockingQueueNode(
+            streaming=StreamingConfig(enabled=True, input_queue=Queue(), timeout=10.0),
+            error_handling=ErrorHandling(timeout_seconds=5.0),
+        )
+
+
+def test_streaming_timeout_smaller_than_error_handling_timeout_is_allowed():
+    node = BlockingQueueNode(
+        streaming=StreamingConfig(enabled=True, input_queue=Queue(), timeout=1.0),
+        error_handling=ErrorHandling(timeout_seconds=5.0),
+    )
+    assert node.streaming.timeout == 1.0
+    assert node.error_handling.timeout_seconds == 5.0
+
+
+def test_streaming_timeout_with_no_error_handling_timeout_is_allowed():
+    node = BlockingQueueNode(
+        streaming=StreamingConfig(enabled=True, input_queue=Queue(), timeout=5.0),
+    )
+    assert node.streaming.timeout == 5.0
+    assert node.error_handling.timeout_seconds is None
+
+
+def test_no_streaming_timeout_with_error_handling_timeout_is_allowed():
+    node = BlockingQueueNode(
+        streaming=StreamingConfig(enabled=True, input_queue=Queue(), timeout=None),
+        error_handling=ErrorHandling(timeout_seconds=1.0),
+    )
+    assert node.streaming.timeout is None
+    assert node.error_handling.timeout_seconds == 1.0
 
 
 def test_blocking_queue_node_with_streaming_timeout_does_not_hang():

--- a/tests/unit/nodes/test_node.py
+++ b/tests/unit/nodes/test_node.py
@@ -329,6 +329,21 @@ def test_no_streaming_timeout_with_error_handling_timeout_is_allowed():
     assert node.error_handling.timeout_seconds == 1.0
 
 
+def test_validator_skipped_when_input_streaming_not_enabled():
+    """Default StreamingConfig.timeout (600s) must not collide with low error_handling timeouts
+    when input streaming is not actually active (e.g., audio/image nodes with streaming disabled
+    or output-only streaming without an input_queue)."""
+    BlockingQueueNode(
+        streaming=StreamingConfig(enabled=False),
+        error_handling=ErrorHandling(timeout_seconds=0.5),
+    )
+
+    BlockingQueueNode(
+        streaming=StreamingConfig(enabled=True),
+        error_handling=ErrorHandling(timeout_seconds=0.5),
+    )
+
+
 def test_blocking_queue_node_with_streaming_timeout_does_not_hang():
     node = BlockingQueueNode()
     input_queue = Queue()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new checkpoint trigger on input-streaming timeouts and changes the thrown exception type, which can affect error handling/resume behavior and any callers relying on previous timeout semantics. Also introduces a new validation constraint between `streaming.timeout` and `error_handling.timeout_seconds` that can reject previously-valid node configs.
> 
> **Overview**
> When a node’s input-streaming wait exceeds `StreamingConfig.timeout`, the node now invokes a new `CheckpointContext.save_on_input_timeout()` callback and raises `InputStreamingTimeoutError` (a `TimeoutError`/`ValueError` hybrid) instead of a plain `ValueError`.
> 
> Flows can now be configured to checkpoint on this event via `CheckpointConfig.checkpoint_on_input_timeout_enabled` (default **true**). The flow checkpoint context snapshots the timing-out node’s internal state and marks the checkpoint `PENDING_INPUT`; if the timeout originates from an agent tool, it “walks up” to snapshot the enclosing top-level agent node.
> 
> Adds a Pydantic validator on `Node` requiring `streaming.timeout < error_handling.timeout_seconds` when input streaming is enabled, and extends integration/unit tests to cover timeout-triggered checkpointing and resume for both standalone nodes and agent tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f835239a19312ce38ebaf009518041f36a6b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->