### PR TITLE
fix: update calculation of cached tokens

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -456,17 +456,19 @@ class BaseLLM(ConnectionNode):
             cls._usage_value(usage, "total_tokens", prompt_tokens + completion_tokens)
             or prompt_tokens + completion_tokens
         )
-        cache_read_input_tokens = cls._usage_value(usage, "cache_read_input_tokens")
-        cache_creation_input_tokens = cls._usage_value(usage, "cache_creation_input_tokens")
+        cached_tokens = getattr(getattr(usage, "prompt_tokens_details", None), "cached_tokens", 0) or 0
+        cache_read_input_tokens = cls._usage_value(usage, "cache_read_input_tokens", cached_tokens)
+        cache_creation_input_tokens = cls._usage_value(usage, "cache_creation_input_tokens", None)
+
+        cache_read_input_tokens = min(cache_read_input_tokens or 0, prompt_tokens)
 
         try:
             cost_kwargs: dict[str, Any] = {
                 "model": model,
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
+                "cache_read_input_tokens": cache_read_input_tokens,
             }
-            if cache_read_input_tokens is not None:
-                cost_kwargs["cache_read_input_tokens"] = cache_read_input_tokens
             if cache_creation_input_tokens is not None:
                 cost_kwargs["cache_creation_input_tokens"] = cache_creation_input_tokens
 

--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -456,8 +456,11 @@ class BaseLLM(ConnectionNode):
             cls._usage_value(usage, "total_tokens", prompt_tokens + completion_tokens)
             or prompt_tokens + completion_tokens
         )
-        cached_tokens = getattr(getattr(usage, "prompt_tokens_details", None), "cached_tokens", 0) or 0
-        cache_read_input_tokens = cls._usage_value(usage, "cache_read_input_tokens", cached_tokens)
+        prompt_tokens_details = cls._usage_value(usage, "prompt_tokens_details", None)
+        cached_tokens = cls._usage_value(prompt_tokens_details, "cached_tokens", 0) or 0
+        cache_read_input_tokens = cls._usage_value(usage, "cache_read_input_tokens", None)
+        if cache_read_input_tokens is None:
+            cache_read_input_tokens = cached_tokens
         cache_creation_input_tokens = cls._usage_value(usage, "cache_creation_input_tokens", None)
 
         cache_read_input_tokens = min(cache_read_input_tokens or 0, prompt_tokens)

--- a/tests/unit/nodes/llms/test_llm_async.py
+++ b/tests/unit/nodes/llms/test_llm_async.py
@@ -16,6 +16,15 @@ def make_mock_response(content="test response"):
     choice.message.tool_calls = None
     response = MagicMock()
     response.choices = [choice]
+    response.model_extra = {}
+    usage = MagicMock()
+    usage.prompt_tokens = 0
+    usage.completion_tokens = 0
+    usage.total_tokens = 0
+    usage.prompt_tokens_details = None
+    usage.cache_read_input_tokens = None
+    usage.cache_creation_input_tokens = None
+    response.usage = usage
     return response
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts token usage/cost computation for cached prompts, which can impact billing/usage reporting across providers. Logic is small but touches accounting-related fields and may change observed costs in production.
> 
> **Overview**
> Fixes how `BaseLLM.get_usage_data` derives cached prompt usage by falling back to `prompt_tokens_details.cached_tokens` when `cache_read_input_tokens` is absent, and clamps cached-read tokens to not exceed `prompt_tokens`.
> 
> Cost calculation now always passes `cache_read_input_tokens` into `litellm.cost_per_token`, and async LLM unit tests update their mock `ModelResponse` usage fields to reflect the new usage shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359bb526384ab44c593b2f88c1cabeb7496af356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->