### PR TITLE
fix: apply custom default reasoning effort per model for OpenAI

### DIFF
--- a/dynamiq/nodes/llms/databricks.py
+++ b/dynamiq/nodes/llms/databricks.py
@@ -17,7 +17,7 @@ class Databricks(BaseLLM):
 
     connection: DatabricksConnection
     MODEL_PREFIX = "databricks/"
-    reasoning_effort: ReasoningEffort | None = ReasoningEffort.AUTO
+    reasoning_effort: ReasoningEffort | None = ReasoningEffort.MEDIUM
 
     def __init__(self, **kwargs):
         """Initialize the Databricks LLM node.

--- a/dynamiq/nodes/llms/databricks.py
+++ b/dynamiq/nodes/llms/databricks.py
@@ -17,7 +17,7 @@ class Databricks(BaseLLM):
 
     connection: DatabricksConnection
     MODEL_PREFIX = "databricks/"
-    reasoning_effort: ReasoningEffort | None = ReasoningEffort.MEDIUM
+    reasoning_effort: ReasoningEffort | None = ReasoningEffort.AUTO
 
     def __init__(self, **kwargs):
         """Initialize the Databricks LLM node.

--- a/dynamiq/nodes/llms/openai.py
+++ b/dynamiq/nodes/llms/openai.py
@@ -11,10 +11,36 @@ class ReasoningEffort(str, enum.Enum):
     The reasoning effort to use for the OpenAI LLM.
     """
 
+    AUTO = "auto"
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
     MINIMAL = "minimal"
+
+
+# OpenAI models whose native default for 'reasoning_effort' is "none"
+_MODELS_DEFAULTING_TO_NONE: frozenset[str] = frozenset(
+    {
+        "gpt-5.1",
+        "gpt-5.1-2025-11-13",
+        "gpt-5.1-chat-latest",
+        "gpt-5.2",
+        "gpt-5.2-2025-12-11",
+        "gpt-5.4",
+    }
+)
+
+
+def _resolve_default_reasoning_effort(model_lower: str) -> ReasoningEffort | None:
+    """Return the implicit default for ``model_lower``, or ``None`` to omit the param.
+
+    ``model_lower`` is the model identifier with the ``openai/`` prefix stripped
+    and lowercased. Models not on the explicit "defaults to none" list fall back
+    to the historical default of ``MEDIUM``.
+    """
+    if model_lower in _MODELS_DEFAULTING_TO_NONE:
+        return None
+    return ReasoningEffort.MEDIUM
 
 
 class Verbosity(str, enum.Enum):
@@ -36,7 +62,7 @@ class OpenAI(BaseLLM):
         connection (OpenAIConnection | None): The connection to use for the OpenAI LLM.
     """
     connection: OpenAIConnection | None = None
-    reasoning_effort: ReasoningEffort | None = ReasoningEffort.MEDIUM
+    reasoning_effort: ReasoningEffort | None = ReasoningEffort.AUTO
     verbosity: Verbosity | None = Verbosity.MEDIUM
     O_SERIES_MODEL_PREFIXES: ClassVar[tuple[str, ...]] = ("o1", "o3", "o4")
     MODEL_PREFIX = "openai/"
@@ -60,6 +86,20 @@ class OpenAI(BaseLLM):
         model_lower = self.model.lower().removeprefix(self.MODEL_PREFIX)
         return any(model_lower.startswith(prefix) for prefix in self.O_SERIES_MODEL_PREFIXES)
 
+    def _effective_reasoning_effort(self, model_lower: str) -> ReasoningEffort | None:
+        """Resolve reasoning_effor parameter for the model."""
+        if self.reasoning_effort == ReasoningEffort.AUTO:
+            return _resolve_default_reasoning_effort(model_lower)
+        return self.reasoning_effort
+
+    @staticmethod
+    def _apply_reasoning_effort(params: dict[str, Any], effort: ReasoningEffort | None) -> None:
+        """Set or remove ``reasoning_effort`` on ``params`` based on ``effort``."""
+        if effort is None:
+            params.pop("reasoning_effort", None)
+        else:
+            params["reasoning_effort"] = effort
+
     def update_completion_params(self, params: dict[str, Any]) -> dict[str, Any]:
         """
         Override the base method to update the completion parameters for OpenAI.
@@ -72,7 +112,7 @@ class OpenAI(BaseLLM):
         if self.is_o_series_model:
             new_params["max_completion_tokens"] = self.max_tokens
             if model_lower.startswith("o3") or model_lower.startswith("o4"):
-                new_params["reasoning_effort"] = self.reasoning_effort
+                self._apply_reasoning_effort(new_params, self._effective_reasoning_effort(model_lower))
             if model_lower not in ["o3-mini"]:
                 new_params.pop("stop", None)
             new_params.pop("max_tokens", None)
@@ -81,9 +121,9 @@ class OpenAI(BaseLLM):
             if "chat" not in model_lower:
                 new_params["verbosity"] = self.verbosity
                 if "pro" in model_lower:
-                    new_params["reasoning_effort"] = ReasoningEffort.HIGH
+                    self._apply_reasoning_effort(new_params, ReasoningEffort.HIGH)
                 else:
-                    new_params["reasoning_effort"] = self.reasoning_effort
+                    self._apply_reasoning_effort(new_params, self._effective_reasoning_effort(model_lower))
             new_params["max_completion_tokens"] = self.max_tokens
             new_params.pop("stop", None)
             new_params.pop("max_tokens", None)

--- a/dynamiq/nodes/llms/openai.py
+++ b/dynamiq/nodes/llms/openai.py
@@ -23,7 +23,6 @@ _MODELS_DEFAULTING_TO_NONE: frozenset[str] = frozenset(
     {
         "gpt-5.1",
         "gpt-5.1-2025-11-13",
-        "gpt-5.1-chat-latest",
         "gpt-5.2",
         "gpt-5.2-2025-12-11",
         "gpt-5.4",

--- a/tests/unit/nodes/llms/test_reasoning_effort_defaults.py
+++ b/tests/unit/nodes/llms/test_reasoning_effort_defaults.py
@@ -111,7 +111,3 @@ class TestPrefixedModelIds:
     def test_openai_prefix_is_stripped_before_resolution(self):
         params = _build(_llm("openai/gpt-5.1"))
         assert "reasoning_effort" not in params
-
-    def test_uppercase_model_id_resolves(self):
-        params = _build(_llm("OpenAI/GPT-5.1"))
-        assert "reasoning_effort" not in params

--- a/tests/unit/nodes/llms/test_reasoning_effort_defaults.py
+++ b/tests/unit/nodes/llms/test_reasoning_effort_defaults.py
@@ -1,0 +1,117 @@
+import pytest
+
+from dynamiq.connections import OpenAI as OpenAIConnection
+from dynamiq.nodes.llms.openai import (
+    OpenAI,
+    ReasoningEffort,
+    _MODELS_DEFAULTING_TO_NONE,
+    _resolve_default_reasoning_effort,
+)
+
+
+def _llm(model: str, reasoning_effort: ReasoningEffort | None = ReasoningEffort.AUTO) -> OpenAI:
+    return OpenAI(
+        model=model,
+        connection=OpenAIConnection(api_key="test-key"),
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def _build(llm: OpenAI) -> dict:
+    """Run the OpenAI subclass's params-shaping logic against an empty base dict."""
+    return llm.update_completion_params({"max_tokens": None})
+
+
+class TestResolveDefaultReasoningEffort:
+    @pytest.mark.parametrize("model", sorted(_MODELS_DEFAULTING_TO_NONE))
+    def test_models_in_none_set_resolve_to_none(self, model):
+        assert _resolve_default_reasoning_effort(model) is None
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-nano",
+            "gpt-5-codex",
+            "gpt-5.1-codex",
+            "gpt-5.1-codex-max",
+            "gpt-5.1-codex-mini",
+            "gpt-5.2-pro",
+            "gpt-5.4-pro",
+            "o3",
+            "o3-mini",
+            "o4-mini",
+            "gpt-4o",
+        ],
+    )
+    def test_unknown_or_non_none_models_fall_back_to_medium(self, model):
+        assert _resolve_default_reasoning_effort(model) == ReasoningEffort.MEDIUM
+
+
+class TestAutoResolutionInCompletionParams:
+    @pytest.mark.parametrize(
+        "model",
+        ["gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.1-2025-11-13", "gpt-5.2-2025-12-11"],
+    )
+    def test_auto_omits_reasoning_effort_for_native_none_models(self, model):
+        params = _build(_llm(model))
+        assert "reasoning_effort" not in params
+
+    @pytest.mark.parametrize("model", ["gpt-5", "gpt-5-mini", "gpt-5-nano"])
+    def test_auto_falls_back_to_medium_for_other_gpt5_models(self, model):
+        params = _build(_llm(model))
+        assert params["reasoning_effort"] == ReasoningEffort.MEDIUM
+
+    @pytest.mark.parametrize("model", ["o3", "o3-mini", "o4-mini"])
+    def test_auto_falls_back_to_medium_for_o_series(self, model):
+        params = _build(_llm(model))
+        assert params["reasoning_effort"] == ReasoningEffort.MEDIUM
+
+    @pytest.mark.parametrize("model", ["gpt-5-pro", "gpt-5.2-pro", "gpt-5.4-pro"])
+    def test_pro_models_always_high_regardless_of_field(self, model):
+        # Existing opinionated override: pro family forces HIGH.
+        for effort in (ReasoningEffort.AUTO, ReasoningEffort.LOW, ReasoningEffort.MINIMAL):
+            params = _build(_llm(model, reasoning_effort=effort))
+            assert params["reasoning_effort"] == ReasoningEffort.HIGH
+
+    def test_chat_variant_never_gets_reasoning_effort(self):
+        params = _build(_llm("gpt-5-chat"))
+        assert "reasoning_effort" not in params
+
+    def test_non_reasoning_model_path_does_not_inject(self):
+        # gpt-4o is not o-series and not gpt-5*, so neither branch runs.
+        params = _build(_llm("gpt-4o"))
+        assert "reasoning_effort" not in params
+
+
+class TestExplicitOverrideRespected:
+    @pytest.mark.parametrize(
+        ("model", "explicit"),
+        [
+            ("gpt-5.1", ReasoningEffort.LOW),
+            ("gpt-5.1", ReasoningEffort.MEDIUM),
+            ("gpt-5.2", ReasoningEffort.HIGH),
+            ("gpt-5.4", ReasoningEffort.MINIMAL),
+            ("gpt-5", ReasoningEffort.LOW),
+            ("o4-mini", ReasoningEffort.HIGH),
+        ],
+    )
+    def test_explicit_value_is_sent_verbatim(self, model, explicit):
+        params = _build(_llm(model, reasoning_effort=explicit))
+        assert params["reasoning_effort"] == explicit
+
+    @pytest.mark.parametrize("model", ["gpt-5.1", "gpt-5"])
+    def test_explicit_none_omits_param(self, model):
+        params = _build(_llm(model, reasoning_effort=None))
+        assert "reasoning_effort" not in params
+
+
+class TestPrefixedModelIds:
+    def test_openai_prefix_is_stripped_before_resolution(self):
+        params = _build(_llm("openai/gpt-5.1"))
+        assert "reasoning_effort" not in params
+
+    def test_uppercase_model_id_resolves(self):
+        params = _build(_llm("OpenAI/GPT-5.1"))
+        assert "reasoning_effort" not in params


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `reasoning_effort` is defaulted/omitted for `openai/*` models, which can alter model behavior and cost characteristics for existing users. Risk is mitigated by explicit unit tests covering the key model families and override cases.
> 
> **Overview**
> Updates the OpenAI LLM node so `reasoning_effort` defaults to `AUTO` and is resolved per model: for specific `gpt-5.x` variants that natively default to *none*, the parameter is omitted; otherwise it falls back to `MEDIUM` (while keeping the existing `pro` override forcing `HIGH`).
> 
> Refactors parameter shaping via helper methods to consistently set/remove `reasoning_effort` across `o3/o4` and `gpt-5*` branches, and adds a focused unit test suite validating auto-resolution, explicit overrides (including `None`), chat variants, and `openai/`-prefixed model IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d641bd42a798a39cc9c18694e65f273152926c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->