### PR TITLE
fix: parse literal characters in LLM function calling arguments

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -508,7 +508,15 @@ class BaseLLM(ConnectionNode):
             tool_calls_parsed = []
             for tc in tool_calls:
                 call = tc.model_dump()
-                call["function"]["arguments"] = json.loads(call["function"]["arguments"])
+                raw_args = call["function"]["arguments"]
+                try:
+                    call["function"]["arguments"] = json.loads(raw_args, strict=False)
+                except json.JSONDecodeError as e:
+                    logger.warning(
+                        "Failed to parse tool_call arguments as JSON for function %s: %s. ",
+                        call["function"].get("name"), e,
+                    )
+                    call["function"]["arguments"] = raw_args
                 tool_calls_parsed.append(call)
             result["tool_calls"] = tool_calls_parsed
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to tool-call argument parsing that adds a warning+fallback path when JSON decoding fails, but it could slightly change downstream behavior for malformed arguments.
> 
> **Overview**
> **Improves robustness of LLM function-calling parsing.** In `BaseLLM._handle_completion_response`, tool-call `function.arguments` are now parsed with `json.loads(..., strict=False)`.
> 
> If decoding fails, the code logs a warning and leaves `arguments` as the original raw string instead of raising, preventing tool-call handling from crashing on malformed/literal-escaped argument payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03713f549a6f882024620218e1c132199aa023b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->