### PR TITLE
fix: bedrock for structured output and xml stopsequence

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -392,11 +392,10 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
                 params = get_supported_openai_params(model=model) or []
                 schema_ok = True
-                if supports_response_schema is not None:
-                    try:
-                        schema_ok = bool(supports_response_schema(model=model))
-                    except Exception:
-                        schema_ok = True
+                try:
+                    schema_ok = bool(supports_response_schema(model=model))
+                except Exception:
+                    schema_ok = True
                 if "response_format" not in params or not schema_ok:
                     logger.warning(
                         "Agent: LiteLLM reports model '%s' may not fully support json_schema "

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -2,7 +2,7 @@ import json
 from concurrent.futures import as_completed
 from typing import Any, Callable, Mapping
 
-from litellm import get_supported_openai_params, supports_function_calling
+from litellm import get_supported_openai_params, supports_function_calling, supports_response_schema
 from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
 from dynamiq.callbacks import AgentStreamingParserCallback, StreamingQueueCallbackHandler
@@ -326,16 +326,43 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
     @model_validator(mode="after")
     def validate_inference_mode(self):
-        """Validate whether specified model can be inferenced in provided mode."""
+        """Validate (and where safe, auto-correct) the inference mode for the chosen model."""
+        model = self.llm.model
         match self.inference_mode:
             case InferenceMode.FUNCTION_CALLING:
-                if not supports_function_calling(model=self.llm.model):
-                    raise ValueError(f"Model {self.llm.model} does not support function calling")
+                if not supports_function_calling(model=model):
+                    raise ValueError(
+                        f"Model {model} does not support function calling. "
+                        f"Try inference_mode=InferenceMode.XML or InferenceMode.DEFAULT."
+                    )
 
             case InferenceMode.STRUCTURED_OUTPUT:
-                params = get_supported_openai_params(model=self.llm.model)
-                if "response_format" not in params:
-                    raise ValueError(f"Model {self.llm.model} does not support structured output")
+                if self.tools and "bedrock/" in model:
+                    fallback = InferenceMode.XML
+                    logger.warning(
+                        "Agent: STRUCTURED_OUTPUT + tools is not safe on Bedrock model '%s' "
+                        "(LiteLLM emulates response_format via a forced json_tool_call that "
+                        "providers reject when other tools are present). Auto-downgrading to %s.",
+                        model,
+                        fallback.value,
+                    )
+                    self.inference_mode = fallback
+                    return self
+
+                params = get_supported_openai_params(model=model) or []
+                schema_ok = True
+                if supports_response_schema is not None:
+                    try:
+                        schema_ok = bool(supports_response_schema(model=model))
+                    except Exception:
+                        schema_ok = True
+                if "response_format" not in params or not schema_ok:
+                    logger.warning(
+                        "Agent: LiteLLM reports model '%s' may not fully support json_schema "
+                        "structured output. Proceeding anyway; if it fails at runtime, switch "
+                        "to inference_mode=InferenceMode.FUNCTION_CALLING or InferenceMode.XML.",
+                        model,
+                    )
 
         return self
 

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -325,8 +325,49 @@ class Agent(HistoryManagerMixin, BaseAgent):
         return False
 
     @model_validator(mode="after")
+    def _ensure_context_manager_tool(self):
+        """Automatically add ContextManagerTool when summarization is enabled."""
+        try:
+            if self.summarization_config.enabled:
+                has_context_tool = any(isinstance(t, ContextManagerTool) for t in self.tools)
+                if not has_context_tool:
+                    context_tool = ContextManagerTool(
+                        llm=self.llm,
+                        name="context-manager",
+                        token_budget_ratio=self.summarization_config.token_budget_ratio,
+                    )
+                    self.tools.append(context_tool)
+                    self._excluded_tool_ids.add(context_tool.id)
+        except Exception as e:
+            logger.error(f"Failed to ensure ContextManagerTool: {e}")
+        return self
+
+    @model_validator(mode="after")
+    def _ensure_todo_tools(self):
+        """Automatically add TodoWriteTool when todo is enabled in file_store config."""
+        try:
+            if self.file_store.enabled and self.file_store.todo_enabled:
+                has_todo_write = any(isinstance(t, TodoWriteTool) for t in self.tools)
+
+                if not has_todo_write:
+                    todo_tool = TodoWriteTool(
+                        name="todo-write",
+                        file_store=self.file_store.backend,
+                    )
+                    self.tools.append(todo_tool)
+                    self._excluded_tool_ids.add(todo_tool.id)
+                    logger.info("Agent: Added TodoWriteTool")
+        except Exception as e:
+            logger.error(f"Failed to ensure TodoWriteTool: {e}")
+        return self
+
+    @model_validator(mode="after")
     def validate_inference_mode(self):
-        """Validate (and where safe, auto-correct) the inference mode for the chosen model."""
+        """Validate (and where safe, auto-correct) the inference mode for the chosen model.
+
+        Runs after auto-tool validators so self.tools reflects the final set
+        (including any ContextManagerTool / TodoWriteTool appended above).
+        """
         model = self.llm.model
         match self.inference_mode:
             case InferenceMode.FUNCTION_CALLING:
@@ -364,43 +405,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
                         model,
                     )
 
-        return self
-
-    @model_validator(mode="after")
-    def _ensure_context_manager_tool(self):
-        """Automatically add ContextManagerTool when summarization is enabled."""
-        try:
-            if self.summarization_config.enabled:
-                has_context_tool = any(isinstance(t, ContextManagerTool) for t in self.tools)
-                if not has_context_tool:
-                    context_tool = ContextManagerTool(
-                        llm=self.llm,
-                        name="context-manager",
-                        token_budget_ratio=self.summarization_config.token_budget_ratio,
-                    )
-                    self.tools.append(context_tool)
-                    self._excluded_tool_ids.add(context_tool.id)
-        except Exception as e:
-            logger.error(f"Failed to ensure ContextManagerTool: {e}")
-        return self
-
-    @model_validator(mode="after")
-    def _ensure_todo_tools(self):
-        """Automatically add TodoWriteTool when todo is enabled in file_store config."""
-        try:
-            if self.file_store.enabled and self.file_store.todo_enabled:
-                has_todo_write = any(isinstance(t, TodoWriteTool) for t in self.tools)
-
-                if not has_todo_write:
-                    todo_tool = TodoWriteTool(
-                        name="todo-write",
-                        file_store=self.file_store.backend,
-                    )
-                    self.tools.append(todo_tool)
-                    self._excluded_tool_ids.add(todo_tool.id)
-                    logger.info("Agent: Added TodoWriteTool")
-        except Exception as e:
-            logger.error(f"Failed to ensure TodoWriteTool: {e}")
         return self
 
     def _append_recovery_instruction(

--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -708,6 +708,17 @@ class BaseLLM(ConnectionNode):
 
         return self.update_completion_params(common_params)
 
+    def _recover_completion_params(self, exc: BaseException, common_params: dict) -> dict | None:
+        """Provider-specific recovery hook for known-bad completion params.
+
+        Called once after a completion call raises. Subclasses may inspect the exception
+        and return a modified `common_params` dict to retry with, or return ``None`` to
+        re-raise the original error.
+
+        Default implementation: no recovery (return ``None``).
+        """
+        return None
+
     def execute(
         self,
         input_data: BaseLLMInputSchema,
@@ -754,7 +765,13 @@ class BaseLLM(ConnectionNode):
             include_sync_client=True,
         )
 
-        response = self._completion(**common_params)
+        try:
+            response = self._completion(**common_params)
+        except Exception as e:
+            recovered = self._recover_completion_params(e, common_params)
+            if recovered is None:
+                raise
+            response = self._completion(**recovered)
         handle_completion = (
             self._handle_streaming_completion_response
             if common_params.get("stream")
@@ -811,7 +828,13 @@ class BaseLLM(ConnectionNode):
             include_sync_client=False,
         )
 
-        response = await self._acompletion(**common_params)
+        try:
+            response = await self._acompletion(**common_params)
+        except Exception as e:
+            recovered = self._recover_completion_params(e, common_params)
+            if recovered is None:
+                raise
+            response = await self._acompletion(**recovered)
 
         if common_params.get("stream"):
             return await self._handle_streaming_completion_response_async(

--- a/dynamiq/nodes/llms/bedrock.py
+++ b/dynamiq/nodes/llms/bedrock.py
@@ -1,5 +1,11 @@
 from dynamiq.connections import AWS as AWSConnection
 from dynamiq.nodes.llms.base import BaseLLM
+from dynamiq.utils.logger import logger
+
+_BEDROCK_STOP_UNSUPPORTED_INDICATORS = (
+    "doesn't support the stopSequences field",
+    "does not support the stopSequences field",
+)
 
 
 class Bedrock(BaseLLM):
@@ -23,3 +29,24 @@ class Bedrock(BaseLLM):
         if kwargs.get("client") is None and kwargs.get("connection") is None:
             kwargs["connection"] = AWSConnection()
         super().__init__(**kwargs)
+
+    def _recover_completion_params(self, exc: BaseException, common_params: dict) -> dict | None:
+        """Bedrock-specific recovery for known-bad completion params.
+
+        Currently handles: hosted models (e.g. openai.gpt-oss-*, moonshotai.kimi-k2.5)
+        that reject the `stopSequences` field even though LiteLLM's per-model registry
+        claims they support it. We strip `stop` and signal a one-shot retry.
+        """
+        msg = str(exc)
+        if any(ind in msg for ind in _BEDROCK_STOP_UNSUPPORTED_INDICATORS) and common_params.get("stop"):
+            logger.warning(
+                "LLM '%s': Bedrock rejected stopSequences for model '%s'; "
+                "retrying without `stop` (LiteLLM registry may be stale).",
+                self.name,
+                self.model,
+            )
+            recovered = dict(common_params)
+            recovered.pop("stop", None)
+            self.stop = None
+            return recovered
+        return None

--- a/dynamiq/nodes/llms/bedrock.py
+++ b/dynamiq/nodes/llms/bedrock.py
@@ -47,6 +47,5 @@ class Bedrock(BaseLLM):
             )
             recovered = dict(common_params)
             recovered.pop("stop", None)
-            self.stop = None
             return recovered
         return None

--- a/dynamiq/nodes/llms/bedrock.py
+++ b/dynamiq/nodes/llms/bedrock.py
@@ -35,7 +35,8 @@ class Bedrock(BaseLLM):
 
         Currently handles: hosted models (e.g. openai.gpt-oss-*, moonshotai.kimi-k2.5)
         that reject the `stopSequences` field even though LiteLLM's per-model registry
-        claims they support it. We strip `stop` and signal a one-shot retry.
+        claims they support it. We strip `stop` and persist that recovery on the
+        instance so later calls do not repeat the same failing first attempt.
         """
         msg = str(exc)
         if any(ind in msg for ind in _BEDROCK_STOP_UNSUPPORTED_INDICATORS) and common_params.get("stop"):
@@ -45,6 +46,7 @@ class Bedrock(BaseLLM):
                 self.name,
                 self.model,
             )
+            self.stop = None
             recovered = dict(common_params)
             recovered.pop("stop", None)
             return recovered

--- a/tests/unit/nodes/llms/test_llm_async.py
+++ b/tests/unit/nodes/llms/test_llm_async.py
@@ -2,8 +2,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from dynamiq.connections import AWS as AWSConnection
 from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.nodes.llms.base import FallbackConfig
+from dynamiq.nodes.llms.bedrock import Bedrock
 from dynamiq.nodes.llms.openai import OpenAI
 from dynamiq.prompts import Prompt
 from dynamiq.runnables import RunnableConfig, RunnableStatus
@@ -145,6 +147,44 @@ class TestBuildCompletionParams:
             )
 
             assert "client" not in params
+
+    def test_bedrock_stop_recovery_persists_for_future_calls(self):
+        """Bedrock stop recovery should clear instance-level stop for later calls."""
+        with patch("litellm.completion"), patch("litellm.stream_chunk_builder"):
+            node = Bedrock(
+                model="openai.gpt-oss-20b-1:0",
+                connection=AWSConnection(),
+                prompt=Prompt(messages=[{"role": "user", "content": "Hello"}]),
+                stop=["DONE"],
+            )
+            input_data = MagicMock(messages=None, files=None)
+            config = RunnableConfig(callbacks=[])
+            prompt = node.prompt or Prompt(messages=[], tools=None, response_format=None)
+            messages = node.get_messages(prompt, input_data)
+            initial_params = node._build_completion_params(
+                messages=messages,
+                config=config,
+                prompt=prompt,
+                include_sync_client=True,
+            )
+
+            recovered = node._recover_completion_params(
+                Exception("Model does not support the stopSequences field"),
+                initial_params,
+            )
+
+            assert recovered is not None
+            assert recovered.get("stop") is None
+            assert node.stop is None
+
+            next_params = node._build_completion_params(
+                messages=messages,
+                config=config,
+                prompt=prompt,
+                include_sync_client=True,
+            )
+
+            assert next_params.get("stop") is None
 
 
 class TestBaseLLMAsyncFallback:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes alter how LLM calls are retried after provider errors and can auto-downgrade `Agent` inference modes on Bedrock, which may change response formatting/behavior across runs. Risk is moderate because it affects core LLM execution parameters but is narrowly scoped and includes a unit test for the Bedrock recovery path.
> 
> **Overview**
> Improves robustness of Bedrock-backed runs by adding a provider-specific retry path that strips unsupported `stop`/`stopSequences` params after a failure and persists that setting for future calls.
> 
> Updates `Agent.validate_inference_mode` to run after auto-tool injection and to *avoid* `STRUCTURED_OUTPUT` when tools are present on Bedrock (auto-falling back to `XML`), while softening structured-output support checks to warnings based on LiteLLM capability signals.
> 
> Adds a unit test asserting the Bedrock stop-sequence recovery both retries without `stop` and clears the instance-level `stop` for subsequent requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7258c5597e7980b6e34e41ee0327d1925a8959e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->