### PR TITLE
fix: fix memory function calling

### DIFF
--- a/dynamiq/memory/memory.py
+++ b/dynamiq/memory/memory.py
@@ -76,7 +76,15 @@ class Memory(BaseModel):
         )
         return data
 
-    def add(self, role: MessageRole, content: str, metadata: dict[str, Any] | None = None) -> None:
+    def add(
+        self,
+        role: MessageRole,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+        tool_calls: list[dict] | None = None,
+        tool_call_id: str | None = None,
+        name: str | None = None,
+    ) -> None:
         """
         Adds a message to the memory.
 
@@ -84,6 +92,14 @@ class Memory(BaseModel):
             role: The role of the message sender
             content: The message content
             metadata: Additional metadata for the message
+            tool_calls: Native tool_calls payload for assistant messages in the
+                OpenAI/Anthropic function-calling protocol. Must be persisted so
+                a saved conversation round-trips through providers that require
+                each TOOL message to reference a prior assistant tool_use.
+            tool_call_id: Identifier of the tool call this message answers.
+                Required when ``role == TOOL`` for the message to remain valid
+                on replay.
+            name: Function name a tool message is responding to.
 
         Raises:
             MemoryError: If the message cannot be added
@@ -97,7 +113,14 @@ class Memory(BaseModel):
             for key, value in metadata.items():
                 sanitized_metadata[key] = "" if value is None else value
 
-            message = Message(role=role, content=content, metadata=sanitized_metadata)
+            message = Message(
+                role=role,
+                content=content,
+                metadata=sanitized_metadata,
+                tool_calls=tool_calls,
+                tool_call_id=tool_call_id,
+                name=name,
+            )
             self.backend.add(message)
 
             logger.debug(
@@ -333,7 +356,14 @@ class Memory(BaseModel):
             for seq, msg in enumerate(messages):
                 metadata = dict(msg.metadata) if msg.metadata else {}
                 metadata["sequence"] = seq
-                self.add(role=msg.role, content=msg.content, metadata=metadata)
+                self.add(
+                    role=msg.role,
+                    content=msg.content,
+                    metadata=metadata,
+                    tool_calls=msg.tool_calls,
+                    tool_call_id=msg.tool_call_id,
+                    name=msg.name,
+                )
                 written += 1
 
             logger.debug(

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -1049,7 +1049,14 @@ class Agent(IterativeCheckpointMixin, Node):
             if msg.role == MessageRole.SYSTEM:
                 continue
             raw_snapshot_messages.append(
-                Message(role=msg.role, content=extract_message_text(msg), metadata=metadata.copy())
+                Message(
+                    role=msg.role,
+                    content=extract_message_text(msg),
+                    metadata=metadata.copy(),
+                    tool_calls=msg.tool_calls,
+                    tool_call_id=msg.tool_call_id,
+                    name=msg.name,
+                )
             )
 
         if not fully_scoped:
@@ -1101,7 +1108,14 @@ class Agent(IterativeCheckpointMixin, Node):
         """Append only the user input and last assistant response to memory (safe fallback)."""
         pair = self._fallback_input_output_pair(metadata, snapshot_messages, final_output=final_output)
         for m in pair:
-            self.memory.add(role=m.role, content=m.content, metadata=m.metadata)
+            self.memory.add(
+                role=m.role,
+                content=m.content,
+                metadata=m.metadata,
+                tool_calls=m.tool_calls,
+                tool_call_id=m.tool_call_id,
+                name=m.name,
+            )
         logger.info(f"Agent {self.name} - {self.id}: saved {len(pair)} message(s) to memory (fallback)")
 
     def _run_llm(

--- a/tests/integration/nodes/agents/test_agent_memory_snapshot.py
+++ b/tests/integration/nodes/agents/test_agent_memory_snapshot.py
@@ -445,3 +445,96 @@ def test_fallback_append_preserves_react_assistant_response_in_full_mode(llm):
         "Where does Alex work?",
         "Alex works at TechCorp.",
     ]
+
+
+_FA_TOOL_CALL_ID = "toolu_fa_abc"
+_FA_TOOL_CALLS = [
+    {
+        "id": _FA_TOOL_CALL_ID,
+        "type": "function",
+        "function": {
+            "name": "provide_final_answer",
+            "arguments": '{"thought":"done","answer":"Hi","output_files":""}',
+        },
+    }
+]
+
+
+def test_memory_add_preserves_tool_call_fields():
+    """Memory.add must forward tool_calls / tool_call_id / name to the backend."""
+    mem = Memory(backend=InMemory())
+
+    mem.add(
+        role=MessageRole.ASSISTANT,
+        content="Calling: provide_final_answer",
+        metadata={"user_id": USER_ID, "session_id": SESSION_ID},
+        tool_calls=_FA_TOOL_CALLS,
+    )
+    mem.add(
+        role=MessageRole.TOOL,
+        content="Acknowledged.",
+        metadata={"user_id": USER_ID, "session_id": SESSION_ID},
+        tool_call_id=_FA_TOOL_CALL_ID,
+        name="provide_final_answer",
+    )
+
+    stored = mem.backend.messages
+    assistant_msg = next(m for m in stored if m.role == MessageRole.ASSISTANT)
+    tool_msg = next(m for m in stored if m.role == MessageRole.TOOL)
+
+    assert assistant_msg.tool_calls == _FA_TOOL_CALLS
+    assert tool_msg.tool_call_id == _FA_TOOL_CALL_ID
+    assert tool_msg.name == "provide_final_answer"
+
+
+def test_save_history_preserves_function_calling_pair(llm):
+    """End-to-end: agent snapshot save must keep the assistant tool_use ↔ TOOL
+    tool_call_id linkage intact so the conversation replays cleanly on the
+    next turn.
+    """
+    memory = Memory(backend=InMemory(), save_mode=MemorySaveMode.FULL)
+    agent = Agent(
+        name="FCMemoryAgent",
+        llm=llm,
+        tools=[],
+        inference_mode=InferenceMode.FUNCTION_CALLING,
+        memory=memory,
+    )
+
+    agent._pinned_input = Message(role=MessageRole.USER, content="Hi")
+    agent._prompt = Prompt(
+        messages=[
+            Message(role=MessageRole.SYSTEM, content="system"),
+            Message(role=MessageRole.USER, content="Hi"),
+            Message(
+                role=MessageRole.ASSISTANT,
+                content="Calling: provide_final_answer",
+                tool_calls=_FA_TOOL_CALLS,
+            ),
+            Message(
+                role=MessageRole.TOOL,
+                content="Acknowledged.",
+                tool_call_id=_FA_TOOL_CALL_ID,
+                name="provide_final_answer",
+            ),
+        ]
+    )
+
+    agent._save_history_to_memory(
+        {"user_id": USER_ID, "session_id": SESSION_ID},
+        final_output="Hi",
+    )
+
+    stored = memory.get_agent_conversation(filters={"user_id": USER_ID, "session_id": SESSION_ID})
+
+    assistant_msg = next(m for m in stored if m.role == MessageRole.ASSISTANT)
+    tool_msg = next(m for m in stored if m.role == MessageRole.TOOL)
+
+    assert assistant_msg.tool_calls == _FA_TOOL_CALLS, (
+        "Assistant tool_calls dropped during snapshot save — " "Anthropic will reject the conversation on replay."
+    )
+    assert tool_msg.tool_call_id == _FA_TOOL_CALL_ID, (
+        "TOOL message lost tool_call_id — synthetic provide_final_answer pair "
+        "is now orphaned and the API will reject it."
+    )
+    assert tool_msg.name == "provide_final_answer"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core agent memory persistence by adding tool-call fields to stored messages; regressions could break conversation replay for function-calling providers or affect backward compatibility of stored history.
> 
> **Overview**
> Fixes memory snapshotting for function-calling chats by **persisting tool-call linkage fields** across saves.
> 
> `Memory.add` and `replace_messages` now carry `tool_calls`, `tool_call_id`, and `name` into stored `Message`s, and agent history snapshot/fallback saves forward these fields so assistant tool_use messages remain correctly paired with subsequent `TOOL` messages. Integration tests were added to assert these fields round-trip through `Memory.add` and `_save_history_to_memory` in `InferenceMode.FUNCTION_CALLING`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12bac20febba8280521e2ddc6b815679fe015323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->