### PR TITLE
fix: update saving of function calling messages to memory

### DIFF
--- a/dynamiq/memory/backends/base.py
+++ b/dynamiq/memory/backends/base.py
@@ -7,6 +7,10 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 from dynamiq.prompts import Message
 from dynamiq.utils import generate_uuid
 
+TOOL_CALLS_META_KEY = "_tool_calls"
+TOOL_CALL_ID_META_KEY = "_tool_call_id"
+NAME_META_KEY = "_name"
+
 
 class MemoryBackend(ABC, BaseModel):
     """Abstract base class for memory storage backends."""

--- a/dynamiq/memory/backends/dynamiq.py
+++ b/dynamiq/memory/backends/dynamiq.py
@@ -62,10 +62,23 @@ class Dynamiq(MemoryBackend):
         if not effective_session_id:
             raise DynamiqMemoryError("Session identifier is required to create a memory item.")
 
-        data_payload = {
+        # Send function-calling fields as first-class 
+        # members of `data` instead of metadata
+        for stash_key in ("_tool_calls", "_tool_call_id", "_name"):
+            metadata.pop(stash_key, None)
+
+        data_payload: dict[str, Any] = {
             "role": message.role.value if isinstance(message.role, MessageRole) else message.role,
             "content": self._format_content_payload(message.content),
         }
+        if message.tool_calls is not None:
+            data_payload["tool_calls"] = message.tool_calls
+        if message.tool_call_id is not None:
+            data_payload["tool_call_id"] = message.tool_call_id
+        if message.name is not None:
+            data_payload["name"] = message.name
+        if metadata:
+            data_payload["metadata"] = metadata
 
         payload: dict[str, Any] = {
             "user_id": effective_user_id,
@@ -235,7 +248,16 @@ class Dynamiq(MemoryBackend):
                 metadata["timestamp"] = self._coerce_timestamp(created_at)
 
             content = self._extract_content_text(data) or item.get("content", "")
-            messages.append(Message(role=role, content=content, metadata=metadata))
+            messages.append(
+                Message(
+                    role=role,
+                    content=content,
+                    metadata=metadata,
+                    tool_calls=data.get("tool_calls"),
+                    tool_call_id=data.get("tool_call_id"),
+                    name=data.get("name"),
+                )
+            )
 
         messages.sort(key=lambda msg: (msg.metadata or {}).get("timestamp") or 0)
         return messages

--- a/dynamiq/memory/backends/dynamiq.py
+++ b/dynamiq/memory/backends/dynamiq.py
@@ -5,7 +5,7 @@ from pydantic import ConfigDict, Field, PrivateAttr
 
 from dynamiq.connections import Dynamiq as DynamiqConnection
 from dynamiq.connections import HTTPMethod
-from dynamiq.memory.backends.base import MemoryBackend
+from dynamiq.memory.backends.base import NAME_META_KEY, TOOL_CALL_ID_META_KEY, TOOL_CALLS_META_KEY, MemoryBackend
 from dynamiq.prompts import Message, MessageRole
 from dynamiq.utils.logger import logger
 
@@ -64,7 +64,7 @@ class Dynamiq(MemoryBackend):
 
         # Send function-calling fields as first-class
         # members of `data` instead of metadata
-        for stash_key in ("_tool_calls", "_tool_call_id", "_name"):
+        for stash_key in (TOOL_CALLS_META_KEY, TOOL_CALL_ID_META_KEY, NAME_META_KEY):
             metadata.pop(stash_key, None)
 
         data_payload: dict[str, Any] = {

--- a/dynamiq/memory/backends/dynamiq.py
+++ b/dynamiq/memory/backends/dynamiq.py
@@ -77,8 +77,6 @@ class Dynamiq(MemoryBackend):
             data_payload["tool_call_id"] = message.tool_call_id
         if message.name is not None:
             data_payload["name"] = message.name
-        if metadata:
-            data_payload["metadata"] = metadata
 
         payload: dict[str, Any] = {
             "user_id": effective_user_id,
@@ -86,6 +84,8 @@ class Dynamiq(MemoryBackend):
             "type": "message",
             "data": data_payload,
         }
+        if metadata:
+            payload["metadata"] = metadata
 
         logger.debug("Creating remote memory item for memory_id=%s", self.memory_id)
         self._request(

--- a/dynamiq/memory/backends/dynamiq.py
+++ b/dynamiq/memory/backends/dynamiq.py
@@ -62,7 +62,7 @@ class Dynamiq(MemoryBackend):
         if not effective_session_id:
             raise DynamiqMemoryError("Session identifier is required to create a memory item.")
 
-        # Send function-calling fields as first-class 
+        # Send function-calling fields as first-class
         # members of `data` instead of metadata
         for stash_key in ("_tool_calls", "_tool_call_id", "_name"):
             metadata.pop(stash_key, None)

--- a/dynamiq/memory/backends/sqlite.py
+++ b/dynamiq/memory/backends/sqlite.py
@@ -154,15 +154,24 @@ class SQLite(MemoryBackend):
         except sqlite3.Error as e:
             raise SQLiteError(f"Error adding message to database: {e}") from e
 
-    def get_all(self) -> list[Message]:
-        """Retrieves all messages from the SQLite database."""
+    def get_all(self, limit: int | None = None) -> list[Message]:
+        """Retrieves all messages from the SQLite database.
+
+        Args:
+            limit: Maximum number of messages to return. If provided, returns
+                the most recent ``limit`` messages, still ordered oldest-first
+                (matches the ``InMemory`` backend contract).
+        """
         try:
             query = self.SELECT_ALL_MESSAGES_QUERY.format(index_name=self.index_name)
             with sqlite3.connect(self.db_path) as conn:
                 cursor = conn.cursor()
                 cursor.execute(query)
                 rows = cursor.fetchall()
-            return [Message(role=row[1], content=row[2], metadata=json.loads(row[3] or "{}")) for row in rows]
+            messages = [Message(role=row[1], content=row[2], metadata=json.loads(row[3] or "{}")) for row in rows]
+            if limit is not None and len(messages) > limit:
+                return messages[-limit:]
+            return messages
 
         except sqlite3.Error as e:
             raise SQLiteError(f"Error retrieving messages from database: {e}") from e

--- a/dynamiq/memory/memory.py
+++ b/dynamiq/memory/memory.py
@@ -118,7 +118,7 @@ class Memory(BaseModel):
             for key, value in metadata.items():
                 sanitized_metadata[key] = "" if value is None else value
 
-            # tool_calls is JSON-encoded for compatibility with backends 
+            # tool_calls is JSON-encoded for compatibility with backends
             # that reject nested objects (e.g. Pinecone)
             if tool_calls is not None:
                 sanitized_metadata[_TOOL_CALLS_META_KEY] = json.dumps(tool_calls)
@@ -151,7 +151,7 @@ class Memory(BaseModel):
 
         Backends that only persist Message.metadata (SQL, vector stores, etc.)
         lose the first-class tool_calls/tool_call_id/name fields.
-        This method restores the fields from under reserved metadata keys 
+        This method restores the fields from under reserved metadata keys
         so the conversation can replay correctly on the next turn.
         """
         transformed: list[Message] = []

--- a/dynamiq/memory/memory.py
+++ b/dynamiq/memory/memory.py
@@ -6,15 +6,9 @@ from typing import Any, ClassVar
 from pydantic import BaseModel, ConfigDict, Field
 
 from dynamiq.memory.backends import InMemory, MemoryBackend
+from dynamiq.memory.backends.base import NAME_META_KEY, TOOL_CALL_ID_META_KEY, TOOL_CALLS_META_KEY
 from dynamiq.prompts import Message, MessageRole
 from dynamiq.utils.logger import logger
-
-# Reserved metadata keys used to round-trip function-calling fields through backends
-# that only serialize Message.metadata (SQL, vector stores, etc.). tool_calls is
-# JSON-encoded so it survives backends like Pinecone that only accept flat scalars.
-_TOOL_CALLS_META_KEY = "_tool_calls"
-_TOOL_CALL_ID_META_KEY = "_tool_call_id"
-_NAME_META_KEY = "_name"
 
 
 class FormatType(str, Enum):
@@ -121,11 +115,11 @@ class Memory(BaseModel):
             # tool_calls is JSON-encoded for compatibility with backends
             # that reject nested objects (e.g. Pinecone)
             if tool_calls is not None:
-                sanitized_metadata[_TOOL_CALLS_META_KEY] = json.dumps(tool_calls)
+                sanitized_metadata[TOOL_CALLS_META_KEY] = json.dumps(tool_calls)
             if tool_call_id is not None:
-                sanitized_metadata[_TOOL_CALL_ID_META_KEY] = tool_call_id
+                sanitized_metadata[TOOL_CALL_ID_META_KEY] = tool_call_id
             if name is not None:
-                sanitized_metadata[_NAME_META_KEY] = name
+                sanitized_metadata[NAME_META_KEY] = name
 
             message = Message(
                 role=role,
@@ -159,7 +153,7 @@ class Memory(BaseModel):
             dumped = msg.model_dump()
             meta = dict(dumped.get("metadata") or {})
 
-            raw_tool_calls = meta.pop(_TOOL_CALLS_META_KEY, None)
+            raw_tool_calls = meta.pop(TOOL_CALLS_META_KEY, None)
             tool_calls = dumped.get("tool_calls")
             if tool_calls is None and raw_tool_calls not in (None, ""):
                 if isinstance(raw_tool_calls, str):
@@ -171,12 +165,12 @@ class Memory(BaseModel):
                 else:
                     tool_calls = raw_tool_calls
 
-            stashed_tool_call_id = meta.pop(_TOOL_CALL_ID_META_KEY, None)
+            stashed_tool_call_id = meta.pop(TOOL_CALL_ID_META_KEY, None)
             tool_call_id = dumped.get("tool_call_id")
             if tool_call_id is None and stashed_tool_call_id is not None:
                 tool_call_id = stashed_tool_call_id
 
-            stashed_name = meta.pop(_NAME_META_KEY, None)
+            stashed_name = meta.pop(NAME_META_KEY, None)
             name = dumped.get("name")
             if name is None and stashed_name is not None:
                 name = stashed_name

--- a/dynamiq/memory/memory.py
+++ b/dynamiq/memory/memory.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, ClassVar
@@ -7,6 +8,13 @@ from pydantic import BaseModel, ConfigDict, Field
 from dynamiq.memory.backends import InMemory, MemoryBackend
 from dynamiq.prompts import Message, MessageRole
 from dynamiq.utils.logger import logger
+
+# Reserved metadata keys used to round-trip function-calling fields through backends
+# that only serialize Message.metadata (SQL, vector stores, etc.). tool_calls is
+# JSON-encoded so it survives backends like Pinecone that only accept flat scalars.
+_TOOL_CALLS_META_KEY = "_tool_calls"
+_TOOL_CALL_ID_META_KEY = "_tool_call_id"
+_NAME_META_KEY = "_name"
 
 
 class FormatType(str, Enum):
@@ -76,7 +84,15 @@ class Memory(BaseModel):
         )
         return data
 
-    def add(self, role: MessageRole, content: str, metadata: dict[str, Any] | None = None) -> None:
+    def add(
+        self,
+        role: MessageRole,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+        tool_calls: list[dict] | None = None,
+        tool_call_id: str | None = None,
+        name: str | None = None,
+    ) -> None:
         """
         Adds a message to the memory.
 
@@ -84,6 +100,11 @@ class Memory(BaseModel):
             role: The role of the message sender
             content: The message content
             metadata: Additional metadata for the message
+            tool_calls: Native tool_calls payload for assistant messages
+                in OpenAI function-calling protocol.
+            tool_call_id: Identifier of the tool call this message answers.
+                Required when ``role == TOOL``.
+            name: Function name a tool message is responding to.
 
         Raises:
             MemoryError: If the message cannot be added
@@ -97,7 +118,23 @@ class Memory(BaseModel):
             for key, value in metadata.items():
                 sanitized_metadata[key] = "" if value is None else value
 
-            message = Message(role=role, content=content, metadata=sanitized_metadata)
+            # tool_calls is JSON-encoded for compatibility with backends 
+            # that reject nested objects (e.g. Pinecone)
+            if tool_calls is not None:
+                sanitized_metadata[_TOOL_CALLS_META_KEY] = json.dumps(tool_calls)
+            if tool_call_id is not None:
+                sanitized_metadata[_TOOL_CALL_ID_META_KEY] = tool_call_id
+            if name is not None:
+                sanitized_metadata[_NAME_META_KEY] = name
+
+            message = Message(
+                role=role,
+                content=content,
+                metadata=sanitized_metadata,
+                tool_calls=tool_calls,
+                tool_call_id=tool_call_id,
+                name=name,
+            )
             self.backend.add(message)
 
             logger.debug(
@@ -107,6 +144,45 @@ class Memory(BaseModel):
         except Exception as e:
             logger.error(f"Unexpected error adding message: {e}")
             raise MemoryError(f"Unexpected error adding message: {e}") from e
+
+    @staticmethod
+    def _transform_function_calling_tool_fields(messages: list[Message]) -> list[Message]:
+        """Pop stashed function-calling fields from metadata and place them on Message.
+
+        Backends that only persist Message.metadata (SQL, vector stores, etc.)
+        lose the first-class tool_calls/tool_call_id/name fields.
+        This method restores the fields from under reserved metadata keys 
+        so the conversation can replay correctly on the next turn.
+        """
+        transformed: list[Message] = []
+        for msg in messages:
+            dumped = msg.model_dump()
+            meta = dict(dumped.get("metadata") or {})
+
+            raw_tool_calls = meta.pop(_TOOL_CALLS_META_KEY, None)
+            tool_calls = dumped.get("tool_calls")
+            if tool_calls is None and raw_tool_calls not in (None, ""):
+                if isinstance(raw_tool_calls, str):
+                    try:
+                        tool_calls = json.loads(raw_tool_calls)
+                    except (TypeError, ValueError) as e:
+                        logger.warning(f"Failed to decode stashed tool_calls metadata: {e}")
+                        tool_calls = None
+                else:
+                    tool_calls = raw_tool_calls
+
+            stashed_tool_call_id = meta.pop(_TOOL_CALL_ID_META_KEY, None)
+            tool_call_id = dumped.get("tool_call_id") or (stashed_tool_call_id or None)
+
+            stashed_name = meta.pop(_NAME_META_KEY, None)
+            name = dumped.get("name") or (stashed_name or None)
+
+            dumped["metadata"] = meta
+            dumped["tool_calls"] = tool_calls
+            dumped["tool_call_id"] = tool_call_id
+            dumped["name"] = name
+            transformed.append(Message(**dumped, static=True))
+        return transformed
 
     def get_all(self, limit: int | None = None) -> list[Message]:
         """
@@ -126,7 +202,7 @@ class Memory(BaseModel):
             effective_limit = limit if limit is not None else self.message_limit
 
             messages = self.backend.get_all(limit=effective_limit)
-            retrieved_messages = [Message(**msg.model_dump(), static=True) for msg in messages]
+            retrieved_messages = self._transform_function_calling_tool_fields(messages)
             logger.debug(f"Memory {self.backend.name}: Retrieved {len(retrieved_messages)} messages")
             return retrieved_messages
         except Exception as e:
@@ -175,7 +251,7 @@ class Memory(BaseModel):
 
             results = self.backend.search(query=query, filters=effective_filters, limit=effective_limit)
 
-            retrieved_messages = [Message(**msg.model_dump(), static=True) for msg in results]
+            retrieved_messages = self._transform_function_calling_tool_fields(results)
             logger.debug(
                 f"Memory {self.backend.name}: Found {len(retrieved_messages)} search results for query: {query}, "
                 f"filters: {effective_filters}"
@@ -333,7 +409,14 @@ class Memory(BaseModel):
             for seq, msg in enumerate(messages):
                 metadata = dict(msg.metadata) if msg.metadata else {}
                 metadata["sequence"] = seq
-                self.add(role=msg.role, content=msg.content, metadata=metadata)
+                self.add(
+                    role=msg.role,
+                    content=msg.content,
+                    metadata=metadata,
+                    tool_calls=msg.tool_calls,
+                    tool_call_id=msg.tool_call_id,
+                    name=msg.name,
+                )
                 written += 1
 
             logger.debug(

--- a/dynamiq/memory/memory.py
+++ b/dynamiq/memory/memory.py
@@ -172,10 +172,14 @@ class Memory(BaseModel):
                     tool_calls = raw_tool_calls
 
             stashed_tool_call_id = meta.pop(_TOOL_CALL_ID_META_KEY, None)
-            tool_call_id = dumped.get("tool_call_id") or (stashed_tool_call_id or None)
+            tool_call_id = dumped.get("tool_call_id")
+            if tool_call_id is None and stashed_tool_call_id is not None:
+                tool_call_id = stashed_tool_call_id
 
             stashed_name = meta.pop(_NAME_META_KEY, None)
-            name = dumped.get("name") or (stashed_name or None)
+            name = dumped.get("name")
+            if name is None and stashed_name is not None:
+                name = stashed_name
 
             dumped["metadata"] = meta
             dumped["tool_calls"] = tool_calls

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -949,6 +949,9 @@ class Agent(IterativeCheckpointMixin, Node):
                     role=message.role,
                     content=message.content,
                     metadata=metadata.copy(),
+                    tool_calls=getattr(message, "tool_calls", None),
+                    tool_call_id=getattr(message, "tool_call_id", None),
+                    name=getattr(message, "name", None),
                 )
             )
 
@@ -1049,7 +1052,14 @@ class Agent(IterativeCheckpointMixin, Node):
             if msg.role == MessageRole.SYSTEM:
                 continue
             raw_snapshot_messages.append(
-                Message(role=msg.role, content=extract_message_text(msg), metadata=metadata.copy())
+                Message(
+                    role=msg.role,
+                    content=extract_message_text(msg),
+                    metadata=metadata.copy(),
+                    tool_calls=getattr(msg, "tool_calls", None),
+                    tool_call_id=getattr(msg, "tool_call_id", None),
+                    name=getattr(msg, "name", None),
+                )
             )
 
         if not fully_scoped:

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -1008,7 +1008,9 @@ class Agent(IterativeCheckpointMixin, Node):
                 None,
             )
             if last_assistant is not None:
-                assistant_content = last_assistant.content
+                assistant_content = (
+                    self._extract_final_answer_from_tool_calls(last_assistant) or last_assistant.content
+                )
 
         if assistant_content is not None:
             pair.append(
@@ -1020,6 +1022,33 @@ class Agent(IterativeCheckpointMixin, Node):
             )
 
         return pair
+
+    @staticmethod
+    def _extract_final_answer_from_tool_calls(message: Message) -> str | None:
+        """Return the ``answer`` field from a ``provide_final_answer`` tool_call.
+
+        Used by the 2-message fallback so FUNCTION_CALLING runs that never
+        produced a ``final_output`` still persist the real answer text
+        instead of the placeholder ``content`` string the agent loop wrote
+        next to the tool_call.
+        """
+        if not message.tool_calls:
+            return None
+        for call in message.tool_calls:
+            fn = call.get("function") or {}
+            if fn.get("name") != "provide_final_answer":
+                continue
+            args = fn.get("arguments")
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    return None
+            if isinstance(args, dict):
+                answer = args.get("answer")
+                if isinstance(answer, str) and answer.strip():
+                    return answer
+        return None
 
     def _save_history_to_memory(
         self,

--- a/tests/unit/memory/test_dynamiq_backend_fc_wire.py
+++ b/tests/unit/memory/test_dynamiq_backend_fc_wire.py
@@ -1,0 +1,125 @@
+"""Verify the Dynamiq memory backend sends and receives function-calling fields
+as first-class members of the ``data`` payload (not buried in metadata)."""
+
+from dynamiq.connections import Dynamiq as DynamiqConnection
+from dynamiq.memory.backends.dynamiq import Dynamiq
+from dynamiq.prompts import Message, MessageRole
+
+
+def _make_backend(mocker) -> Dynamiq:
+    """Create a Dynamiq backend with HTTP calls patched out."""
+    connection = DynamiqConnection(url="https://api.example/v1", api_key="test")
+    mocker.patch.object(DynamiqConnection, "connect", return_value=mocker.MagicMock())
+    return Dynamiq(connection=connection, memory_id="mem-1", user_id="u1", session_id="s1")
+
+
+def test_add_sends_tool_calls_as_first_class_data_field(mocker):
+    backend = _make_backend(mocker)
+    request = mocker.patch.object(backend, "_request", return_value=None)
+
+    tool_calls = [
+        {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+    ]
+    msg = Message(
+        role=MessageRole.ASSISTANT,
+        content="Calling: get_weather",
+        metadata={"user_id": "u1", "session_id": "s1", "timestamp": 1.0},
+        tool_calls=tool_calls,
+    )
+    backend.add(msg)
+
+    sent_payload = request.call_args.kwargs["json"]
+    data = sent_payload["data"]
+
+    assert data["role"] == "assistant"
+    assert data["tool_calls"] == tool_calls
+    assert "_tool_calls" not in data.get("metadata", {})
+
+
+def test_add_sends_tool_call_id_and_name_as_first_class_data_fields(mocker):
+    backend = _make_backend(mocker)
+    request = mocker.patch.object(backend, "_request", return_value=None)
+
+    msg = Message(
+        role=MessageRole.TOOL,
+        content="ok",
+        metadata={"user_id": "u1", "session_id": "s1", "timestamp": 1.0},
+        tool_call_id="call_1",
+        name="get_weather",
+    )
+    backend.add(msg)
+
+    data = request.call_args.kwargs["json"]["data"]
+    assert data["tool_call_id"] == "call_1"
+    assert data["name"] == "get_weather"
+    md = data.get("metadata", {})
+    assert "_tool_call_id" not in md
+    assert "_name" not in md
+
+
+def test_add_strips_memory_layer_stash_from_metadata(mocker):
+    """Even if the Memory layer added stash keys, the Dynamiq backend must not
+    forward them — it owns its own wire shape."""
+    backend = _make_backend(mocker)
+    request = mocker.patch.object(backend, "_request", return_value=None)
+
+    msg = Message(
+        role=MessageRole.ASSISTANT,
+        content="...",
+        metadata={
+            "user_id": "u1",
+            "session_id": "s1",
+            "timestamp": 1.0,
+            "_tool_calls": '[{"id":"x"}]',
+            "_tool_call_id": "x",
+            "_name": "f",
+        },
+        tool_calls=[{"id": "x", "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+    )
+    backend.add(msg)
+
+    sent_metadata = request.call_args.kwargs["json"]["data"].get("metadata", {})
+    assert "_tool_calls" not in sent_metadata
+    assert "_tool_call_id" not in sent_metadata
+    assert "_name" not in sent_metadata
+
+
+def test_items_to_messages_reads_tool_calls_from_first_class_data(mocker):
+    backend = _make_backend(mocker)
+
+    tool_calls = [
+        {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+    ]
+    api_items = [
+        {
+            "user_id": "u1",
+            "session_id": "s1",
+            "type": "message",
+            "created_at": "2026-01-01T00:00:00Z",
+            "data": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Calling: f"}],
+                "tool_calls": tool_calls,
+            },
+        },
+        {
+            "user_id": "u1",
+            "session_id": "s1",
+            "type": "message",
+            "created_at": "2026-01-01T00:00:01Z",
+            "data": {
+                "role": "tool",
+                "content": [{"type": "text", "text": "ok"}],
+                "tool_call_id": "call_1",
+                "name": "f",
+            },
+        },
+    ]
+
+    messages = backend._items_to_messages(api_items)
+
+    assert messages[0].role == MessageRole.ASSISTANT
+    assert messages[0].tool_calls == tool_calls
+    assert messages[1].role == MessageRole.TOOL
+    assert messages[1].tool_call_id == "call_1"
+    assert messages[1].name == "f"

--- a/tests/unit/memory/test_dynamiq_backend_fc_wire.py
+++ b/tests/unit/memory/test_dynamiq_backend_fc_wire.py
@@ -1,6 +1,3 @@
-"""Verify the Dynamiq memory backend sends and receives function-calling fields
-as first-class members of the ``data`` payload (not buried in metadata)."""
-
 from dynamiq.connections import Dynamiq as DynamiqConnection
 from dynamiq.memory.backends.dynamiq import Dynamiq
 from dynamiq.prompts import Message, MessageRole

--- a/tests/unit/memory/test_dynamiq_backend_fc_wire.py
+++ b/tests/unit/memory/test_dynamiq_backend_fc_wire.py
@@ -81,6 +81,24 @@ def test_add_strips_memory_layer_stash_from_metadata(mocker):
     assert "_name" not in sent_metadata
 
 
+def test_add_sends_metadata_at_top_level_not_inside_data(mocker):
+    """Metadata rides as a sibling of `data`, not inside it — the API stores it separately."""
+    backend = _make_backend(mocker)
+    request = mocker.patch.object(backend, "_request", return_value=None)
+
+    msg = Message(
+        role=MessageRole.USER,
+        content="hi",
+        metadata={"user_id": "u1", "session_id": "s1", "timestamp": 1.0, "custom": "v"},
+    )
+    backend.add(msg)
+
+    sent_payload = request.call_args.kwargs["json"]
+    assert sent_payload["metadata"]["custom"] == "v"
+    assert sent_payload["metadata"]["timestamp"] == 1.0
+    assert "metadata" not in sent_payload["data"]
+
+
 def test_items_to_messages_reads_tool_calls_from_first_class_data(mocker):
     backend = _make_backend(mocker)
 

--- a/tests/unit/memory/test_tool_call_round_trip.py
+++ b/tests/unit/memory/test_tool_call_round_trip.py
@@ -1,12 +1,3 @@
-"""Regression tests for function-calling field round-trip through Memory.
-
-The agent constructs assistant messages with ``tool_calls`` and tool messages
-with ``tool_call_id``/``name``. When the conversation is persisted to memory
-and later replayed, these fields must survive the round-trip — otherwise the
-next LLM call fails with provider-specific errors (e.g. Anthropic rejects a
-TOOL message that has no ``tool_call_id``).
-"""
-
 import json
 
 from dynamiq.memory import Memory

--- a/tests/unit/memory/test_tool_call_round_trip.py
+++ b/tests/unit/memory/test_tool_call_round_trip.py
@@ -109,6 +109,25 @@ def test_replace_messages_round_trips_fc_fields():
     assert restored[2].name == "f"
 
 
+def test_transform_does_not_discard_falsy_but_present_tool_call_id_or_name():
+    """Regression: the prior ``or``-based fallback collapsed an empty-string
+    tool_call_id/name to None and silently fell through to the stash. The
+    serializer only strips ``None``; a present-but-falsy value must round-trip
+    unchanged, matching how tool_calls already handles ``[]``."""
+    msg = Message(
+        role=MessageRole.TOOL,
+        content="ok",
+        metadata={"timestamp": 1.0},
+        tool_call_id="",
+        name="",
+    )
+
+    [restored] = Memory._transform_function_calling_tool_fields([msg])
+
+    assert restored.tool_call_id == ""
+    assert restored.name == ""
+
+
 def test_add_without_fc_fields_does_not_inject_stash_keys():
     """Plain user/assistant messages must not accumulate reserved metadata keys."""
     memory = Memory(backend=InMemory())

--- a/tests/unit/memory/test_tool_call_round_trip.py
+++ b/tests/unit/memory/test_tool_call_round_trip.py
@@ -1,0 +1,133 @@
+"""Regression tests for function-calling field round-trip through Memory.
+
+The agent constructs assistant messages with ``tool_calls`` and tool messages
+with ``tool_call_id``/``name``. When the conversation is persisted to memory
+and later replayed, these fields must survive the round-trip — otherwise the
+next LLM call fails with provider-specific errors (e.g. Anthropic rejects a
+TOOL message that has no ``tool_call_id``).
+"""
+
+import json
+
+from dynamiq.memory import Memory
+from dynamiq.memory.backends import InMemory
+from dynamiq.prompts import Message, MessageRole
+
+
+USER_ID = "u1"
+SESSION_ID = "s1"
+
+
+def _scope_metadata() -> dict:
+    return {"user_id": USER_ID, "session_id": SESSION_ID}
+
+
+def test_add_preserves_tool_calls_on_assistant_message():
+    memory = Memory(backend=InMemory())
+    tool_calls = [
+        {
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city":"NYC"}'},
+        }
+    ]
+
+    memory.add(
+        role=MessageRole.ASSISTANT,
+        content="Calling: get_weather",
+        metadata=_scope_metadata(),
+        tool_calls=tool_calls,
+    )
+
+    [restored] = memory.get_all()
+    assert restored.role == MessageRole.ASSISTANT
+    assert restored.content == "Calling: get_weather"
+    assert restored.tool_calls == tool_calls
+    # Stash keys must not leak into user-visible metadata after hydration.
+    assert "_tool_calls" not in restored.metadata
+
+
+def test_add_preserves_tool_call_id_and_name_on_tool_message():
+    memory = Memory(backend=InMemory())
+
+    memory.add(
+        role=MessageRole.TOOL,
+        content="Acknowledged.",
+        metadata=_scope_metadata(),
+        tool_call_id="call_abc",
+        name="provide_final_answer",
+    )
+
+    [restored] = memory.get_all()
+    assert restored.role == MessageRole.TOOL
+    assert restored.tool_call_id == "call_abc"
+    assert restored.name == "provide_final_answer"
+    assert "_tool_call_id" not in restored.metadata
+    assert "_name" not in restored.metadata
+
+
+def test_stash_is_json_string_for_flat_metadata_backends():
+    """The tool_calls stash is JSON-encoded as a string so backends that only
+    accept flat scalars in metadata (e.g. Pinecone) can still persist it."""
+    memory = Memory(backend=InMemory())
+    tool_calls = [{"id": "x", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
+
+    memory.add(
+        role=MessageRole.ASSISTANT,
+        content="...",
+        metadata=_scope_metadata(),
+        tool_calls=tool_calls,
+    )
+
+    [stored] = memory.backend.messages
+    raw = stored.metadata.get("_tool_calls")
+    assert isinstance(raw, str)
+    assert json.loads(raw) == tool_calls
+
+
+def test_replace_messages_round_trips_fc_fields():
+    """replace_messages must thread tool_calls/tool_call_id/name to add(),
+    so a snapshot save in FULL mode preserves the FC trace."""
+    memory = Memory(backend=InMemory())
+    tool_calls = [
+        {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+    ]
+    snapshot = [
+        Message(role=MessageRole.USER, content="hi", metadata=_scope_metadata()),
+        Message(
+            role=MessageRole.ASSISTANT,
+            content="Calling: f",
+            metadata=_scope_metadata(),
+            tool_calls=tool_calls,
+        ),
+        Message(
+            role=MessageRole.TOOL,
+            content="ok",
+            metadata=_scope_metadata(),
+            tool_call_id="call_1",
+            name="f",
+        ),
+    ]
+
+    memory.replace_messages(filters=_scope_metadata(), messages=snapshot)
+    restored = memory.get_all()
+
+    assert [m.role for m in restored] == [MessageRole.USER, MessageRole.ASSISTANT, MessageRole.TOOL]
+    assert restored[1].tool_calls == tool_calls
+    assert restored[2].tool_call_id == "call_1"
+    assert restored[2].name == "f"
+
+
+def test_add_without_fc_fields_does_not_inject_stash_keys():
+    """Plain user/assistant messages must not accumulate reserved metadata keys."""
+    memory = Memory(backend=InMemory())
+
+    memory.add(role=MessageRole.USER, content="hello", metadata=_scope_metadata())
+
+    [restored] = memory.get_all()
+    assert restored.tool_calls is None
+    assert restored.tool_call_id is None
+    assert restored.name is None
+    assert "_tool_calls" not in restored.metadata
+    assert "_tool_call_id" not in restored.metadata
+    assert "_name" not in restored.metadata


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how function-calling fields are persisted/hydrated across memory backends and how agents derive fallback assistant output, which can affect stored conversation history and replay fidelity.
> 
> **Overview**
> Ensures OpenAI function-calling fields (`tool_calls`, `tool_call_id`, `name`) survive memory persistence and can be rehydrated correctly on retrieval/search/replace.
> 
> `Memory.add()` now accepts these fields, stashes them under reserved metadata keys (JSON-encoding `tool_calls` for flat-metadata stores), and `Memory.get_all()`/`search()` restore them while removing the stash keys from user-visible metadata.
> 
> Updates the Dynamiq backend wire format to send/read function-calling fields as first-class members of `data` (and keep metadata at the top level), and updates agent snapshot saving/fallback logic to carry FC fields and to extract a final answer from a `provide_final_answer` tool call when `final_output` is missing.
> 
> Adds unit tests covering Dynamiq API payload shape and FC round-trip behavior, plus a `SQLite.get_all(limit=...)` implementation to match other backends’ limiting semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200a2e592d4aa0e62bde518c719fdef67e596824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->