### PR TITLE
fix: fix response format streaming

### DIFF
--- a/dynamiq/callbacks/streaming.py
+++ b/dynamiq/callbacks/streaming.py
@@ -368,8 +368,6 @@ class AgentStreamingParserCallback(BaseStreamingCallbackHandler):
         self._tool_input_started: bool = False
         self._current_action_name: str | None = None
         self._fc_object_tool_input: bool = False
-        # True when the current FC `answer` field value is an object rather than a
-        # string (set when `response_format` maps `answer` to an object schema).
         self._fc_object_answer: bool = False
         self._brace_depth: int = 0
         self._brace_scan_index: int = 0

--- a/dynamiq/callbacks/streaming.py
+++ b/dynamiq/callbacks/streaming.py
@@ -368,6 +368,9 @@ class AgentStreamingParserCallback(BaseStreamingCallbackHandler):
         self._tool_input_started: bool = False
         self._current_action_name: str | None = None
         self._fc_object_tool_input: bool = False
+        # True when the current FC `answer` field value is an object rather than a
+        # string (set when `response_format` maps `answer` to an object schema).
+        self._fc_object_answer: bool = False
         self._brace_depth: int = 0
         self._brace_scan_index: int = 0
         self._so_action_emitted: bool = False
@@ -473,6 +476,7 @@ class AgentStreamingParserCallback(BaseStreamingCallbackHandler):
         self._answer_started = False
         self._current_action_name = None
         self._fc_object_tool_input = False
+        self._fc_object_answer = False
         self._brace_depth = 0
         self._brace_scan_index = 0
         self._state_has_emitted = {
@@ -1048,7 +1052,10 @@ class AgentStreamingParserCallback(BaseStreamingCallbackHandler):
             self._current_state = state
             self._state_start_index = field_start
             self._state_last_emit_index = max(self._state_last_emit_index, field_start)
-            self._fc_object_tool_input = True
+            if state == StreamingState.ANSWER:
+                self._fc_object_answer = True
+            else:
+                self._fc_object_tool_input = True
             self._brace_depth = 1
             self._brace_scan_index = field_start + 1
             return True
@@ -1066,7 +1073,11 @@ class AgentStreamingParserCallback(BaseStreamingCallbackHandler):
             )
 
         if self._answer_started:
-            self._initialize_json_field_state(buf, JSONStreamingField.ANSWER.value, StreamingState.ANSWER)
+            if not self._initialize_json_field_state(buf, JSONStreamingField.ANSWER.value, StreamingState.ANSWER):
+                if self._current_state is None:
+                    self._initialize_json_object_field_state(
+                        buf, JSONStreamingField.ANSWER.value, StreamingState.ANSWER
+                    )
 
         if self._tool_input_started and not self._answer_started:
             if not self._initialize_json_field_state(
@@ -1083,6 +1094,13 @@ class AgentStreamingParserCallback(BaseStreamingCallbackHandler):
             self._emit_json_object_field_content(buf, StreamingState.TOOL_INPUT)
         else:
             self._emit_json_field_content(buf, StreamingState.TOOL_INPUT)
+
+    def _emit_answer_state(self, buf: str) -> None:
+        """Emit content for the current ANSWER state."""
+        if self._fc_object_answer:
+            self._emit_json_object_field_content(buf, StreamingState.ANSWER)
+        else:
+            self._emit_json_field_content(buf, StreamingState.ANSWER)
 
     def _process_json_mode(self, final_answer_only: bool) -> None:
         """
@@ -1106,7 +1124,7 @@ class AgentStreamingParserCallback(BaseStreamingCallbackHandler):
                 # before _reset_tool_call_state clears the buffer on the next parallel call.
                 self._process_json_mode(final_answer_only)
         elif self._current_state == StreamingState.ANSWER:
-            self._emit_json_field_content(buf, StreamingState.ANSWER)
+            self._emit_answer_state(buf)
         elif self._current_state == StreamingState.TOOL_INPUT:
             self._emit_tool_input_state(buf)
 

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -326,7 +326,19 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
     @model_validator(mode="after")
     def validate_inference_mode(self):
-        """Validate whether specified model can be inferenced in provided mode."""
+        """Validate whether specified model can be inferenced in provided mode.
+
+        When ``response_format`` is set together with DEFAULT or XML inference
+        modes, auto-switch to STRUCTURED_OUTPUT — those text-shaped modes have
+        no native schema enforcement, so STRUCTURED_OUTPUT is the right default
+        for users who declared a typed response_format.
+        """
+        if self.response_format is not None and self.inference_mode in (
+            InferenceMode.DEFAULT,
+            InferenceMode.XML,
+        ):
+            self.inference_mode = InferenceMode.STRUCTURED_OUTPUT
+
         match self.inference_mode:
             case InferenceMode.FUNCTION_CALLING:
                 if not supports_function_calling(model=self.llm.model):

--- a/tests/unit/nodes/agents/test_streaming_parser.py
+++ b/tests/unit/nodes/agents/test_streaming_parser.py
@@ -150,6 +150,26 @@ def _make_fc_chunk(index=0, function_name=None, arguments=""):
     return {"choices": [{"delta": {"tool_calls": [tc]}}]}
 
 
+def test_fc_object_answer_streams_when_response_format_is_object():
+    """When response_format maps `answer` to an object schema, the FC parser should
+    detect the brace-delimited value, set `_fc_object_answer`, and emit chunks."""
+    cb = _make_fc_callback(answer_started=True)
+    cb._buffer = '{"answer": {"foo": "bar"}}'
+
+    cb._process_json_mode(final_answer_only=False)
+
+    assert cb._fc_object_answer is True
+    assert cb._fc_object_tool_input is False
+    assert cb._state_has_emitted[StreamingState.ANSWER] is True
+    cb.agent.stream_content.assert_called()
+    streamed_content = "".join(
+        call.kwargs.get("content", "") if isinstance(call.kwargs.get("content"), str) else ""
+        for call in cb.agent.stream_content.call_args_list
+        if call.kwargs.get("step") == StreamingState.ANSWER
+    )
+    assert streamed_content == '{"foo": "bar"}'
+
+
 def test_parallel_tool_calls_get_unique_ids():
     """Each parallel tool call must receive a distinct tool_run_id during streaming."""
     agent = MagicMock()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates core agent inference-mode validation and function-calling streaming parsing; could change runtime behavior for users who set `response_format` or stream final answers as JSON objects.
> 
> **Overview**
> Fixes FUNCTION_CALLING streaming when the final `answer` is an object (e.g. schema-driven `response_format`) by detecting brace-delimited `answer` values and emitting them via a dedicated ANSWER path, separate from `action_input` object streaming.
> 
> Also auto-switches agents to `STRUCTURED_OUTPUT` when `response_format` is provided alongside `DEFAULT`/`XML` modes, and adds a unit test covering object-shaped `answer` streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb3d6ef09908c0915d0566e4cb898d635db5f4fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->