### PR TITLE
chore: update models with default reasoning_effort=none

### DIFF
--- a/dynamiq/nodes/llms/openai.py
+++ b/dynamiq/nodes/llms/openai.py
@@ -25,7 +25,13 @@ _MODELS_DEFAULTING_TO_NONE: frozenset[str] = frozenset(
         "gpt-5.1-2025-11-13",
         "gpt-5.2",
         "gpt-5.2-2025-12-11",
+        "gpt-5.3-codex",
         "gpt-5.4",
+        "gpt-5.4-2026-03-05",
+        "gpt-5.4-mini",
+        "gpt-5.4-mini-2026-03-17",
+        "gpt-5.4-nano",
+        "gpt-5.4-nano-2026-03-17",
     }
 )
 

--- a/tests/integration_with_creds/agents/test_agent_escape_variables.py
+++ b/tests/integration_with_creds/agents/test_agent_escape_variables.py
@@ -49,9 +49,9 @@ def llm_instance():
     connection = OpenAIConnection()
     llm = OpenAI(
         connection=connection,
-        model="gpt-5-mini",
+        model="gpt-5.4-mini",
         max_tokens=5000,
-        temperature=0,
+        reasoning_effort="medium",
     )
     return llm
 

--- a/tests/integration_with_creds/agents/test_agent_response_format.py
+++ b/tests/integration_with_creds/agents/test_agent_response_format.py
@@ -47,7 +47,7 @@ INFERENCE_MODES = [
 
 
 def _make_agent(inference_mode: InferenceMode, response_format) -> Agent:
-    llm = OpenAI(model="gpt-5.4-mini", connection=connections.OpenAI(), temperature=0.1)
+    llm = OpenAI(model="gpt-5.4-mini", connection=connections.OpenAI(), temperature=0.1, reasoning_effort="medium")
     return Agent(
         name="StructuredAgent",
         llm=llm,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes OpenAI request parameter defaults by omitting `reasoning_effort` for additional `gpt-5.x` models, which can alter model behavior/costs if callers relied on the previous implicit `medium` default. Test updates reduce flakiness but won’t catch all production usage patterns.
> 
> **Overview**
> Updates the OpenAI LLM model allowlist so more `gpt-5.x` variants (including `gpt-5.3-codex` and multiple `gpt-5.4` mini/nano dated releases) **default to omitting** the `reasoning_effort` parameter (native default "none") when `reasoning_effort=AUTO`.
> 
> Adjusts integration agent tests to use `gpt-5.4-mini` and to **explicitly set** `reasoning_effort="medium"` to keep test behavior stable despite the new model defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7f6b2304d5e9a2aa8f1e7db86da96c69e57f20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->