### PR TITLE
feat: upd mcp handler

### DIFF
--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -33,6 +33,11 @@ def rename_keys_recursive(data: dict[str, Any] | list[str], key_map: dict[str, s
     return data
 
 
+def extract_text_from_mcp_content(content: list[Any]) -> str:
+    """Join the text of the TextContent blocks in an MCP result's content list."""
+    return "\n".join(block.text for block in content if getattr(block, "type", None) == "text")
+
+
 class ServerMetadata(BaseModel):
     id: str | None = None
     name: str | None = None
@@ -174,8 +179,25 @@ class MCPTool(ConnectionNode):
                 recoverable=True,
             )
 
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
-        return {"content": result}
+        if result.isError:
+            error_text = extract_text_from_mcp_content(result.content)
+            raise ToolExecutionException(
+                f"Tool '{self.name}' returned an error from the MCP server: "
+                f"{error_text or 'unknown error'}. Please analyze the error and take appropriate action.",
+                recoverable=True,
+            )
+
+        # Optimized for agents: the structured payload (or text) the server returned.
+        # Otherwise: the full result dump, for debugging.
+        if not self.is_optimized_for_agents:
+            content = result.model_dump(exclude_none=True)
+        elif result.structuredContent is not None:
+            content = result.structuredContent
+        else:
+            content = extract_text_from_mcp_content(result.content)
+
+        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(content)[:200]}...")
+        return {"content": content}
 
 
 class MCPServer(ConnectionNode):
@@ -235,6 +257,7 @@ Usage Strategy:
                             json_input_schema=tool.inputSchema,
                             connection=self.connection,
                             server_metadata=ServerMetadata(id=self.id, name=self.name, description=self.description),
+                            is_optimized_for_agents=self.is_optimized_for_agents,
                         )
 
             logger.info(f"Tool {self.name}: {len(self._mcp_tools)} MCP tools initialized from a server.")

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -187,8 +187,6 @@ class MCPTool(ConnectionNode):
                 recoverable=True,
             )
 
-        # Optimized for agents: the structured payload (or text) the server returned.
-        # Otherwise: the full result dump, for debugging.
         if not self.is_optimized_for_agents:
             content = result.model_dump(exclude_none=True)
         elif result.structuredContent is not None:

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -187,15 +187,20 @@ class MCPTool(ConnectionNode):
                 recoverable=True,
             )
 
+        raw_response = result.model_dump(exclude_none=True)
+
         if not self.is_optimized_for_agents:
-            content = result.model_dump(exclude_none=True)
+            content = raw_response
         elif result.structuredContent is not None:
             content = result.structuredContent
         else:
             content = extract_text_from_mcp_content(result.content)
 
         logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(content)[:200]}...")
-        return {"content": content}
+        output = {"content": content}
+        if self.is_optimized_for_agents:
+            output["raw_response"] = raw_response
+        return output
 
 
 class MCPServer(ConnectionNode):

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -1,15 +1,18 @@
+import contextlib
 import uuid
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from mcp.types import CallToolResult, ImageContent, TextContent
 from pydantic import Field, create_model
 
 from dynamiq import connections
 from dynamiq.nodes.agents import Agent
+from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.llms import OpenAI
 from dynamiq.nodes.tools import FileListTool, FileReadTool
-from dynamiq.nodes.tools.mcp import MCPServer, MCPSse, MCPTool
+from dynamiq.nodes.tools.mcp import MCPServer, MCPSse, MCPTool, extract_text_from_mcp_content
 
 
 def assert_tool_matches(tool, expected, connection):
@@ -222,3 +225,102 @@ def test_agent_integration_with_mcp_tools(sse_server_connection, mock_mcp_tools,
     assert dict_tools[0]["name"] == "subtract"
     assert dict_tools[0]["type"] == "dynamiq.nodes.tools.MCPTool"
     assert dict_tools[1]["type"] == "dynamiq.nodes.tools.MCPServer"
+
+
+def test_extract_text_from_mcp_content():
+    content = [
+        TextContent(type="text", text="line one"),
+        ImageContent(type="image", data="aGk=", mimeType="image/png"),
+        TextContent(type="text", text="line two"),
+    ]
+    assert extract_text_from_mcp_content(content) == "line one\nline two"
+    assert extract_text_from_mcp_content([]) == ""
+
+
+def _patch_session_with_result(result: CallToolResult):
+    """Patch the connection + ClientSession so call_tool yields `result`."""
+
+    @contextlib.asynccontextmanager
+    async def fake_connect(self):
+        yield (object(), object())
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, args):
+            return result
+
+    return (
+        patch.object(MCPSse, "connect", new=fake_connect),
+        patch("dynamiq.nodes.tools.mcp.ClientSession", return_value=FakeSession()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_async_optimized_returns_structured_content(mcp_server_tool):
+    tool = mcp_server_tool._mcp_tools["add"]
+    tool.is_optimized_for_agents = True  # the agent sets this on its tools at init
+    payload = {"data": {"result": 42}, "meta": {"mode": "sandbox"}}
+    result = CallToolResult(
+        content=[TextContent(type="text", text="{...}")],
+        structuredContent=payload,
+    )
+
+    conn_patch, session_patch = _patch_session_with_result(result)
+    with conn_patch, session_patch:
+        output = await tool.execute_async(tool.input_schema(a=20, b=22))
+
+    assert output == {"content": payload}
+
+
+@pytest.mark.asyncio
+async def test_execute_async_optimized_falls_back_to_text(mcp_server_tool):
+    tool = mcp_server_tool._mcp_tools["add"]
+    tool.is_optimized_for_agents = True
+    result = CallToolResult(content=[TextContent(type="text", text="plain text result")])
+
+    conn_patch, session_patch = _patch_session_with_result(result)
+    with conn_patch, session_patch:
+        output = await tool.execute_async(tool.input_schema(a=20, b=22))
+
+    assert output == {"content": "plain text result"}
+
+
+@pytest.mark.asyncio
+async def test_execute_async_not_optimized_returns_full_dump(mcp_server_tool):
+    tool = mcp_server_tool._mcp_tools["add"]
+    tool.is_optimized_for_agents = False
+    payload = {"data": {"result": 42}}
+    result = CallToolResult(
+        content=[TextContent(type="text", text="{...}")],
+        structuredContent=payload,
+    )
+
+    conn_patch, session_patch = _patch_session_with_result(result)
+    with conn_patch, session_patch:
+        output = await tool.execute_async(tool.input_schema(a=20, b=22))
+
+    assert output["content"]["structuredContent"] == payload
+    assert output["content"]["isError"] is False
+    assert "content" in output["content"]
+
+
+@pytest.mark.asyncio
+async def test_execute_async_raises_on_is_error(mcp_server_tool):
+    tool = mcp_server_tool._mcp_tools["add"]
+    result = CallToolResult(
+        content=[TextContent(type="text", text="API rate limit exceeded")],
+        isError=True,
+    )
+
+    conn_patch, session_patch = _patch_session_with_result(result)
+    with conn_patch, session_patch:
+        with pytest.raises(ToolExecutionException, match="API rate limit exceeded"):
+            await tool.execute_async(tool.input_schema(a=20, b=22))

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -277,7 +277,10 @@ async def test_execute_async_optimized_returns_structured_content(mcp_server_too
     with conn_patch, session_patch:
         output = await tool.execute_async(tool.input_schema(a=20, b=22))
 
-    assert output == {"content": payload}
+    assert output["content"] == payload
+    assert output["raw_response"]["structuredContent"] == payload
+    assert output["raw_response"]["content"] == [{"type": "text", "text": "{...}"}]
+    assert output["raw_response"]["isError"] is False
 
 
 @pytest.mark.asyncio
@@ -290,7 +293,9 @@ async def test_execute_async_optimized_falls_back_to_text(mcp_server_tool):
     with conn_patch, session_patch:
         output = await tool.execute_async(tool.input_schema(a=20, b=22))
 
-    assert output == {"content": "plain text result"}
+    assert output["content"] == "plain text result"
+    assert output["raw_response"]["content"] == [{"type": "text", "text": "plain text result"}]
+    assert output["raw_response"]["isError"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the MCP tool output contract agents and callers see (structured vs full dump) and error handling; risk is mainly integration breakage for code expecting the old raw result shape.
> 
> **Overview**
> **MCP tool execution** now treats `CallToolResult` from the MCP SDK explicitly instead of returning the raw call result under `content`.
> 
> When the server sets **`isError`**, execution raises a recoverable **`ToolExecutionException`** with text extracted from text content blocks (via new **`extract_text_from_mcp_content`**). Success paths shape **`content`** by mode: non–agent-optimized tools get the full **`model_dump`**; agent-optimized tools prefer **`structuredContent`**, else joined text blocks, and also attach **`raw_response`**. **`MCPServer`** propagates **`is_optimized_for_agents`** onto discovered **`MCPTool`** instances.
> 
> Integration tests cover text extraction, optimized vs full responses, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa59e3a4d838ff9fe54c6f5f1695d861662f15d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->