### PR TITLE
fix: xml parser

### DIFF
--- a/dynamiq/nodes/agents/utils.py
+++ b/dynamiq/nodes/agents/utils.py
@@ -118,7 +118,10 @@ class XMLParser:
                     cleaned = candidate
                     break
             else:
-                cleaned = xml_matches[-1].group(0)
+                if len(xml_matches) > 1:
+                    cleaned = cleaned[xml_matches[0].start():xml_matches[-1].end()]
+                else:
+                    cleaned = xml_matches[-1].group(0)
 
         return cleaned
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow change to LLM output preprocessing in `utils.py`; may alter parsing when multiple XML blocks appear without `<answer>`, but scope is limited to agent XML cleanup.
> 
> **Overview**
> Updates **`XMLParser._clean_content`** so that when multiple top-level XML blocks are found and none contain an `<answer>` tag, the cleaner keeps the **full span** from the first matched block through the last, instead of only the **last** block.
> 
> That preserves multi-tag agent outputs (e.g. `<thought>` plus `<action>`) that were previously truncated to a single fragment before `lxml` parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a9c33d011576d568a1107a46a493425f6525b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->