### PR TITLE
fix: patch litellm AWS Bedrock bug

### DIFF
--- a/dynamiq/nodes/llms/bedrock.py
+++ b/dynamiq/nodes/llms/bedrock.py
@@ -46,8 +46,8 @@ def _install_litellm_bedrock_parallel_tool_patch() -> None:
         optional_params = original_map_openai_params(self, *args, **kwargs)
         try:
             _ensure_parallel_tool_choice_type(optional_params)
-        except Exception:
-            pass
+        except Exception as exc:  # never let the workaround break litellm's normal mapping
+            logger.warning("Bedrock parallel-tool-choice fix skipped (litellm#22637): %s", exc)
         return optional_params
 
     AmazonConverseConfig.map_openai_params = map_openai_params_with_parallel_tool_fix

--- a/dynamiq/nodes/llms/bedrock.py
+++ b/dynamiq/nodes/llms/bedrock.py
@@ -8,6 +8,52 @@ _BEDROCK_STOP_UNSUPPORTED_INDICATORS = (
 )
 
 
+def _ensure_parallel_tool_choice_type(optional_params: dict) -> None:
+    """Add Anthropic's required ``type`` to litellm's Bedrock parallel-tool config.
+
+    Workaround for BerriAI/litellm#22637 (fix PR #22638 unmerged): for Claude 4.5+ on
+    Bedrock, litellm builds ``_parallel_tool_use_config`` with a ``tool_choice`` that
+    omits the required ``type`` discriminator, so Bedrock rejects the request with
+    "tool_choice.type: Field required". We add ``type="auto"`` only when it is missing,
+    which preserves litellm's ``disable_parallel_tool_use`` (so a user's
+    ``parallel_tool_calls`` True/False is honoured) and is a no-op once litellm is fixed.
+    """
+    cfg = optional_params.get("_parallel_tool_use_config")
+    if isinstance(cfg, dict):
+        tool_choice = cfg.get("tool_choice")
+        if isinstance(tool_choice, dict) and "type" not in tool_choice:
+            tool_choice["type"] = "auto"
+
+
+def _install_litellm_bedrock_parallel_tool_patch() -> None:
+    """Idempotently wrap ``AmazonConverseConfig.map_openai_params`` to apply the fix.
+
+    Wrapping (rather than replacing) keeps litellm's behaviour intact and merely repairs
+    the malformed parallel-tool config on the way out. Guarded so a litellm refactor can
+    never break importing/constructing this node.
+    """
+    try:
+        from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+    except Exception:
+        return
+
+    if getattr(AmazonConverseConfig, "_dynamiq_parallel_tc_patched", False):
+        return
+
+    original_map_openai_params = AmazonConverseConfig.map_openai_params
+
+    def map_openai_params_with_parallel_tool_fix(self, *args, **kwargs):
+        optional_params = original_map_openai_params(self, *args, **kwargs)
+        try:
+            _ensure_parallel_tool_choice_type(optional_params)
+        except Exception:
+            pass
+        return optional_params
+
+    AmazonConverseConfig.map_openai_params = map_openai_params_with_parallel_tool_fix
+    AmazonConverseConfig._dynamiq_parallel_tc_patched = True
+
+
 class Bedrock(BaseLLM):
     """Bedrock LLM node.
 
@@ -26,6 +72,7 @@ class Bedrock(BaseLLM):
         Args:
             **kwargs: Additional keyword arguments.
         """
+        _install_litellm_bedrock_parallel_tool_patch()
         if kwargs.get("client") is None and kwargs.get("connection") is None:
             kwargs["connection"] = AWSConnection()
         super().__init__(**kwargs)

--- a/tests/unit/nodes/llms/test_bedrock.py
+++ b/tests/unit/nodes/llms/test_bedrock.py
@@ -1,0 +1,99 @@
+"""Unit tests for the Bedrock node's litellm #22637 parallel-tool-calls workaround.
+
+litellm builds an `additionalModelRequestFields.tool_choice` for Claude 4.5+ on Bedrock
+that omits Anthropic's required `type` discriminator, so Bedrock rejects the request with
+"tool_choice.type: Field required". The Bedrock node idempotently wraps litellm's
+`AmazonConverseConfig.map_openai_params` to inject the missing `type` while preserving the
+user's `parallel_tool_calls` value (True -> parallel allowed, False -> sequential).
+"""
+
+import pytest
+
+from dynamiq.connections import AWS as AWSConnection
+from dynamiq.nodes.llms.bedrock import (
+    Bedrock,
+    _ensure_parallel_tool_choice_type,
+    _install_litellm_bedrock_parallel_tool_patch,
+)
+
+_MODEL_3_5 = "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"
+_MODEL_4_5 = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+
+class TestEnsureParallelToolChoiceType:
+    """The pure repair helper."""
+
+    def test_adds_type_when_missing_and_parallel_enabled(self):
+        params = {"_parallel_tool_use_config": {"tool_choice": {"disable_parallel_tool_use": False}}}
+        _ensure_parallel_tool_choice_type(params)
+        assert params["_parallel_tool_use_config"]["tool_choice"] == {
+            "type": "auto",
+            "disable_parallel_tool_use": False,
+        }
+
+    def test_adds_type_but_preserves_disabled_flag(self):
+        # parallel_tool_calls=False -> disable_parallel_tool_use=True must be kept (sequential).
+        params = {"_parallel_tool_use_config": {"tool_choice": {"disable_parallel_tool_use": True}}}
+        _ensure_parallel_tool_choice_type(params)
+        tool_choice = params["_parallel_tool_use_config"]["tool_choice"]
+        assert tool_choice["type"] == "auto"
+        assert tool_choice["disable_parallel_tool_use"] is True
+
+    def test_does_not_override_existing_type(self):
+        params = {"_parallel_tool_use_config": {"tool_choice": {"type": "any", "disable_parallel_tool_use": False}}}
+        _ensure_parallel_tool_choice_type(params)
+        assert params["_parallel_tool_use_config"]["tool_choice"]["type"] == "any"
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {},
+            {"_parallel_tool_use_config": None},
+            {"_parallel_tool_use_config": {}},
+            {"_parallel_tool_use_config": {"tool_choice": None}},
+            {"_parallel_tool_use_config": {"tool_choice": "auto"}},
+        ],
+    )
+    def test_tolerates_missing_or_unexpected_shapes(self, params):
+        before = repr(params)
+        _ensure_parallel_tool_choice_type(params)  # must not raise
+        assert repr(params) == before  # and must not mutate anything
+
+
+class TestBedrockPatchWiring:
+    """Constructing the node installs the patch, once."""
+
+    def test_constructing_bedrock_installs_patch(self):
+        Bedrock(model=_MODEL_3_5, connection=AWSConnection())
+        from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+        assert getattr(AmazonConverseConfig, "_dynamiq_parallel_tc_patched", False) is True
+
+    def test_patch_is_idempotent(self):
+        from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+        _install_litellm_bedrock_parallel_tool_patch()
+        wrapped = AmazonConverseConfig.map_openai_params
+        _install_litellm_bedrock_parallel_tool_patch()
+        Bedrock(model=_MODEL_3_5, connection=AWSConnection())
+        # Not re-wrapped: same function object after repeated installs / constructions.
+        assert AmazonConverseConfig.map_openai_params is wrapped
+
+
+class TestPatchedMapOpenAIParams:
+    """End-to-end: litellm's transform now emits a valid, value-preserving tool_choice."""
+
+    @pytest.mark.parametrize(("parallel_tool_calls", "expected_disable"), [(True, False), (False, True)])
+    def test_injects_type_and_honors_value(self, parallel_tool_calls, expected_disable):
+        _install_litellm_bedrock_parallel_tool_patch()
+        from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+        optional_params = AmazonConverseConfig().map_openai_params(
+            non_default_params={"parallel_tool_calls": parallel_tool_calls},
+            optional_params={},
+            model=_MODEL_4_5,
+            drop_params=False,
+        )
+        tool_choice = optional_params["_parallel_tool_use_config"]["tool_choice"]
+        assert tool_choice["type"] == "auto"
+        assert tool_choice["disable_parallel_tool_use"] is expected_disable


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Monkey-patches a global litellm class at node init, which could affect all Bedrock Converse traffic in the process but is guarded, idempotent, and narrowly scoped to missing `type` fields.
> 
> **Overview**
> Adds a **runtime workaround** for [litellm#22637](https://github.com/BerriAI/litellm/issues/22637): on Bedrock (Claude 4.5+), parallel tool use requests fail because litellm omits `tool_choice.type`, which Anthropic requires.
> 
> When a `Bedrock` node is constructed, it **idempotently wraps** litellm's `AmazonConverseConfig.map_openai_params` to inject `type: "auto"` only when missing, while keeping `disable_parallel_tool_use` so `parallel_tool_calls` still behaves correctly. Failures in the patch are logged and do not break normal mapping. New unit tests cover the helper, patch wiring, and end-to-end `map_openai_params` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6fd90ebb809aa7350d2bb6255e825ddc3eb8ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->