### PR TITLE
fix: MCP tool schema generation without temporary codegen

### DIFF
--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -1,8 +1,9 @@
 import asyncio
+import json
 import keyword
 from dataclasses import field
 from types import GenericAlias
-from typing import Any, Literal, Union
+from typing import Any, ForwardRef, Literal, Union
 
 from mcp import ClientSession
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, create_model
@@ -123,154 +124,187 @@ def resolve_json_schema_ref(ref: str, definitions: dict[str, Any]) -> dict[str, 
     return {}
 
 
-def merge_all_of(members: list[Any], definitions: dict[str, Any], seen_refs: frozenset[str]) -> dict[str, Any]:
-    """Shallow-merge the subschemas of an ``allOf`` into a single schema dict (intersection)."""
-    merged: dict[str, Any] = {}
-    merged_properties: dict[str, Any] = {}
-    merged_required: list[Any] = []
-    for member in members:
-        if not isinstance(member, dict):
-            continue
-        ref = member.get("$ref")
+class _SchemaModelBuilder:
+    """Builds a Pydantic model from an MCP tool's JSON Schema, with support for recursive ``$ref``s.
+
+    Object schemas are memoized by their canonical content, so a cyclic reference (direct, mutual,
+    or via ``allOf``) resolves to a shared model through a forward reference that is later completed
+    with ``model_rebuild``. The resolution namespace is assembled here rather than read from
+    ``sys.modules``, so it cannot suffer the cross-tool clobbering that previously surfaced as
+    ``name 'Optional' is not defined``.
+    """
+
+    def __init__(self, definitions: dict[str, Any]) -> None:
+        self._definitions = definitions
+        self._models_by_key: dict[str, type[BaseModel]] = {}
+        self._name_by_key: dict[str, str] = {}
+        self._building: set[str] = set()
+        self._namespace: dict[str, Any] = {}
+        self._used_names: set[str] = set()
+
+    @staticmethod
+    def _schema_key(schema: dict[str, Any]) -> str:
+        return json.dumps(schema, sort_keys=True, default=str)
+
+    def _unique_name(self, hint: str) -> str:
+        name = make_model_name(hint)
+        candidate = name
+        index = 1
+        while candidate in self._used_names:
+            candidate = f"{name}{index}"
+            index += 1
+        self._used_names.add(candidate)
+        return candidate
+
+    def _merge_all_of(self, members: list[Any]) -> dict[str, Any]:
+        """Shallow-merge the subschemas of an ``allOf`` into a single schema dict (intersection)."""
+        merged: dict[str, Any] = {}
+        merged_properties: dict[str, Any] = {}
+        merged_required: list[Any] = []
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            ref = member.get("$ref")
+            if isinstance(ref, str):
+                member = resolve_json_schema_ref(ref, self._definitions)
+            properties = member.get("properties")
+            if isinstance(properties, dict):
+                merged_properties.update(properties)
+            required = member.get("required")
+            if isinstance(required, list):
+                merged_required.extend(required)
+            for key, value in member.items():
+                if key not in ("properties", "required", "$ref", "allOf"):
+                    merged.setdefault(key, value)
+        if merged_properties:
+            merged["properties"] = merged_properties
+            merged["type"] = "object"
+        if merged_required:
+            merged["required"] = merged_required
+        return merged
+
+    def _type_for(self, prop: dict[str, Any], name: str) -> Any:
+        ref = prop.get("$ref")
         if isinstance(ref, str):
-            if ref in seen_refs:
-                continue  # cyclic member already being resolved upstream
-            member = resolve_json_schema_ref(ref, definitions)
-        properties = member.get("properties")
-        if isinstance(properties, dict):
-            merged_properties.update(properties)
-        required = member.get("required")
-        if isinstance(required, list):
-            merged_required.extend(required)
-        for key, value in member.items():
-            if key not in ("properties", "required", "$ref", "allOf"):
-                merged.setdefault(key, value)
-    if merged_properties:
-        merged["properties"] = merged_properties
-        merged["type"] = "object"
-    if merged_required:
-        merged["required"] = merged_required
-    return merged
+            resolved = resolve_json_schema_ref(ref, self._definitions)
+            if not resolved:
+                logger.warning(f"MCP tool schema: could not resolve $ref '{ref}'; falling back to a permissive type.")
+                return Any
+            prop = resolved
 
+        enum_values = prop.get("enum")
+        if isinstance(enum_values, list) and enum_values:
+            return get_literal_type(enum_values)
 
-def json_schema_to_type(
-    prop: dict[str, Any], name: str, definitions: dict[str, Any], seen_refs: frozenset[str] = frozenset()
-) -> Any:
-    ref = prop.get("$ref")
-    if isinstance(ref, str):
-        if ref in seen_refs:
-            # A self-recursive definition (e.g. a tree node whose children are the same node).
-            # We type the cycle-closing point permissively instead of building a true recursive
-            # model: the latter needs forward references + model_rebuild(), the same lazy-annotation
-            # path that caused the original "name 'Optional' is not defined" crash. The data still
-            # round-trips and the MCP server validates it on receipt. Non-recursive reuse of a
-            # definition (sibling or nested) is unaffected and still builds a fully-typed model.
-            return dict[str, Any]
-        resolved = resolve_json_schema_ref(ref, definitions)
-        if not resolved:
-            logger.warning(f"MCP tool schema: could not resolve $ref '{ref}'; falling back to a permissive type.")
-            return Any
-        prop = resolved
-        seen_refs = seen_refs | {ref}
+        schema_all_of = prop.get("allOf")
+        if isinstance(schema_all_of, list) and schema_all_of:
+            return self._type_for(self._merge_all_of(schema_all_of), name)
 
-    enum_values = prop.get("enum")
-    if isinstance(enum_values, list) and enum_values:
-        return get_literal_type(enum_values)
+        schema_options = prop.get("anyOf") or prop.get("oneOf")
+        if isinstance(schema_options, list):
+            return get_union_type([self._type_for(o, name) for o in schema_options if isinstance(o, dict)])
 
-    schema_all_of = prop.get("allOf")
-    if isinstance(schema_all_of, list) and schema_all_of:
-        member_refs = {m["$ref"] for m in schema_all_of if isinstance(m, dict) and isinstance(m.get("$ref"), str)}
-        merged = merge_all_of(schema_all_of, definitions, seen_refs)
-        return json_schema_to_type(merged, name, definitions, seen_refs | member_refs)
-
-    schema_options = prop.get("anyOf") or prop.get("oneOf")
-    if isinstance(schema_options, list):
-        return get_union_type(
-            [
-                json_schema_to_type(option, name, definitions, seen_refs)
-                for option in schema_options
-                if isinstance(option, dict)
-            ]
-        )
-
-    schema_type = prop.get("type")
-    if isinstance(schema_type, list):
-        return get_union_type(
-            [
-                json_schema_to_type({**prop, "type": type_}, name, definitions, seen_refs)
-                for type_ in schema_type
-                if isinstance(type_, str)
-            ]
-        )
-
-    if schema_type == "object" or prop.get("properties"):
-        if prop.get("properties"):
-            title = prop.get("title")
-            return create_input_schema_from_json_schema(
-                prop,
-                make_model_name(title if isinstance(title, str) else name),
-                definitions,
-                seen_refs,
+        schema_type = prop.get("type")
+        if isinstance(schema_type, list):
+            return get_union_type(
+                [self._type_for({**prop, "type": type_}, name) for type_ in schema_type if isinstance(type_, str)]
             )
-        additional_props = prop.get("additionalProperties")
-        if isinstance(additional_props, dict):
-            return get_dict_annotation(json_schema_to_type(additional_props, f"{name}Value", definitions, seen_refs))
-        return dict[str, Any]
 
-    if schema_type == "array":
-        items = prop.get("items", {})
-        item_schema = items if isinstance(items, dict) else {}
-        return get_list_annotation(json_schema_to_type(item_schema, f"{name}Item", definitions, seen_refs))
+        if schema_type == "object" or prop.get("properties"):
+            if prop.get("properties"):
+                return self._object_model(prop, name)
+            additional_props = prop.get("additionalProperties")
+            if isinstance(additional_props, dict):
+                return get_dict_annotation(self._type_for(additional_props, f"{name}Value"))
+            return dict[str, Any]
 
-    return JSON_SCHEMA_TYPE_MAPPING.get(schema_type, Any)
+        if schema_type == "array":
+            items = prop.get("items", {})
+            item_schema = items if isinstance(items, dict) else {}
+            return get_list_annotation(self._type_for(item_schema, f"{name}Item"))
+
+        return JSON_SCHEMA_TYPE_MAPPING.get(schema_type, Any)
+
+    def _object_model(self, schema: dict[str, Any], name_hint: str) -> Any:
+        definitions = get_json_schema_definitions(schema)
+        if definitions:
+            self._definitions = {**self._definitions, **definitions}
+
+        key = self._schema_key(schema)
+        if key in self._models_by_key:
+            return self._models_by_key[key]
+        if key in self._building:
+            return ForwardRef(self._name_by_key[key])  # close the cycle with a forward reference
+
+        title = schema.get("title")
+        model_name = self._unique_name(title if isinstance(title, str) else name_hint)
+        return self._register(schema, key, model_name)
+
+    def _register(self, schema: dict[str, Any], key: str, model_name: str) -> type[BaseModel]:
+        self._name_by_key[key] = model_name
+        self._used_names.add(model_name)
+        self._building.add(key)
+        model = self._build_model(schema, model_name)
+        self._building.discard(key)
+        self._models_by_key[key] = model
+        self._namespace[model_name] = model
+        return model
+
+    def _build_model(self, schema: dict[str, Any], model_name: str) -> type[BaseModel]:
+        required = schema.get("required", [])
+        required_fields = set(required if isinstance(required, list) else [])
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            properties = {}
+
+        fields: dict[str, tuple[Any, Any]] = {}
+        used_field_names: set[str] = set()
+        for name, prop in properties.items():
+            if not isinstance(prop, dict):
+                continue
+            field_type = self._type_for(prop, name)
+            default = ... if name in required_fields else prop.get("default", None)
+            if name not in required_fields:
+                field_type = get_union_type([field_type, NONE_TYPE])
+
+            raw_description = prop.get("description")
+            description = raw_description if isinstance(raw_description, str) else None
+            enum_values = prop.get("enum")
+            if isinstance(enum_values, list) and enum_values:
+                enum_description = f" Allowed values: {', '.join(map(str, enum_values))}."
+                description = (description or "").rstrip() + enum_description
+
+            if is_safe_field_name(name) and name not in used_field_names:
+                field_name = name
+                alias = None
+            else:
+                field_name = make_safe_field_name(name, used_field_names)
+                alias = name
+            used_field_names.add(field_name)
+
+            fields[field_name] = (field_type, Field(default, description=description, alias=alias))
+
+        return create_model(
+            model_name,
+            __config__=ConfigDict(populate_by_name=True, protected_namespaces=()),
+            **fields,
+        )
+
+    def build(self, schema_dict: dict[str, Any], model_name: str) -> type[BaseModel]:
+        self._definitions = {**self._definitions, **get_json_schema_definitions(schema_dict)}
+        # The root keeps its requested name verbatim; nested models derive theirs from titles.
+        root = self._register(schema_dict, self._schema_key(schema_dict), model_name)
+        # Complete every forward reference (recursive models) against the namespace built above.
+        for model in self._namespace.values():
+            model.model_rebuild(force=True, _types_namespace=self._namespace)
+        return root
 
 
 def create_input_schema_from_json_schema(
-    schema_dict: dict[str, Any],
-    model_name: str = "MCPToolSchema",
-    definitions: dict[str, Any] | None = None,
-    seen_refs: frozenset[str] = frozenset(),
+    schema_dict: dict[str, Any], model_name: str = "MCPToolSchema", definitions: dict[str, Any] | None = None
 ) -> type[BaseModel]:
-    definitions = {**(definitions or {}), **get_json_schema_definitions(schema_dict)}
-    required = schema_dict.get("required", [])
-    required_fields = set(required if isinstance(required, list) else [])
-    fields: dict[str, tuple[Any, Any]] = {}
-
-    properties = schema_dict.get("properties", {})
-    if not isinstance(properties, dict):
-        properties = {}
-
-    used_field_names: set[str] = set()
-    for name, prop in properties.items():
-        if not isinstance(prop, dict):
-            continue
-        field_type = json_schema_to_type(prop, name, definitions, seen_refs)
-        default = ... if name in required_fields else prop.get("default", None)
-        if name not in required_fields:
-            field_type = get_union_type([field_type, NONE_TYPE])
-
-        raw_description = prop.get("description")
-        description = raw_description if isinstance(raw_description, str) else None
-        enum_values = prop.get("enum")
-        if isinstance(enum_values, list) and enum_values:
-            enum_description = f" Allowed values: {', '.join(map(str, enum_values))}."
-            description = (description or "").rstrip() + enum_description
-
-        if is_safe_field_name(name) and name not in used_field_names:
-            field_name = name
-            alias = None
-        else:
-            field_name = make_safe_field_name(name, used_field_names)
-            alias = name
-        used_field_names.add(field_name)
-
-        fields[field_name] = (field_type, Field(default, description=description, alias=alias))
-
-    return create_model(
-        model_name,
-        __config__=ConfigDict(populate_by_name=True, protected_namespaces=()),
-        **fields,
-    )
+    """Create a Pydantic input-schema model from an MCP tool's JSON Schema."""
+    return _SchemaModelBuilder(dict(definitions or {})).build(schema_dict, model_name)
 
 
 class ServerMetadata(BaseModel):

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -1,4 +1,5 @@
 import asyncio
+import keyword
 from dataclasses import field
 from types import GenericAlias
 from typing import Any, Literal, Union
@@ -26,6 +27,29 @@ JSON_SCHEMA_TYPE_MAPPING: dict[str, Any] = {
     "array": list[Any],
     "null": NONE_TYPE,
 }
+
+# Names that cannot be used directly as Pydantic field names: they shadow BaseModel
+# attributes/methods (e.g. model_config, model_dump, schema, copy) and either break
+# create_model or silently override model internals.
+RESERVED_FIELD_NAMES = frozenset(dir(BaseModel))
+
+
+def is_safe_field_name(name: str) -> bool:
+    """Whether a JSON Schema property name can be used as-is as a Pydantic field name."""
+    return name.isidentifier() and not keyword.iskeyword(name) and name not in RESERVED_FIELD_NAMES
+
+
+def make_safe_field_name(name: str, used: set[str]) -> str:
+    """Derive a unique, valid Python field name for an unsafe JSON Schema property name."""
+    candidate = "".join(char if char.isalnum() else "_" for char in name).strip("_")
+    if not candidate or candidate[0].isdigit() or not is_safe_field_name(candidate):
+        candidate = f"field_{candidate}".rstrip("_")
+    base = candidate
+    index = 1
+    while candidate in used:
+        candidate = f"{base}_{index}"
+        index += 1
+    return candidate
 
 
 def rename_keys_recursive(data: dict[str, Any] | list[Any], key_map: dict[str, str]) -> Any:
@@ -157,6 +181,7 @@ def create_input_schema_from_json_schema(
     if not isinstance(properties, dict):
         properties = {}
 
+    used_field_names: set[str] = set()
     for name, prop in properties.items():
         if not isinstance(prop, dict):
             continue
@@ -172,9 +197,21 @@ def create_input_schema_from_json_schema(
             enum_description = f" Allowed values: {', '.join(map(str, enum_values))}."
             description = (description or "").rstrip() + enum_description
 
-        fields[name] = (field_type, Field(default, description=description))
+        if is_safe_field_name(name) and name not in used_field_names:
+            field_name = name
+            alias = None
+        else:
+            field_name = make_safe_field_name(name, used_field_names)
+            alias = name
+        used_field_names.add(field_name)
 
-    return create_model(model_name, **fields)
+        fields[field_name] = (field_type, Field(default, description=description, alias=alias))
+
+    return create_model(
+        model_name,
+        __config__=ConfigDict(populate_by_name=True, protected_namespaces=()),
+        **fields,
+    )
 
 
 class ServerMetadata(BaseModel):
@@ -268,11 +305,11 @@ class MCPTool(ConnectionNode):
         Returns:
             dict[str, Any]: A dictionary containing the tool's output.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
+        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump(by_alias=True)}")
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
-        input_dict = input_data.model_dump()
+        input_dict = input_data.model_dump(by_alias=True)
 
         try:
             async with self.connection.connect() as result:

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -123,26 +123,75 @@ def resolve_json_schema_ref(ref: str, definitions: dict[str, Any]) -> dict[str, 
     return {}
 
 
-def json_schema_to_type(prop: dict[str, Any], name: str, definitions: dict[str, Any]) -> Any:
+def merge_all_of(members: list[Any], definitions: dict[str, Any], seen_refs: frozenset[str]) -> dict[str, Any]:
+    """Shallow-merge the subschemas of an ``allOf`` into a single schema dict (intersection)."""
+    merged: dict[str, Any] = {}
+    merged_properties: dict[str, Any] = {}
+    merged_required: list[Any] = []
+    for member in members:
+        if not isinstance(member, dict):
+            continue
+        ref = member.get("$ref")
+        if isinstance(ref, str):
+            if ref in seen_refs:
+                continue  # cyclic member already being resolved upstream
+            member = resolve_json_schema_ref(ref, definitions)
+        properties = member.get("properties")
+        if isinstance(properties, dict):
+            merged_properties.update(properties)
+        required = member.get("required")
+        if isinstance(required, list):
+            merged_required.extend(required)
+        for key, value in member.items():
+            if key not in ("properties", "required", "$ref", "allOf"):
+                merged.setdefault(key, value)
+    if merged_properties:
+        merged["properties"] = merged_properties
+        merged["type"] = "object"
+    if merged_required:
+        merged["required"] = merged_required
+    return merged
+
+
+def json_schema_to_type(
+    prop: dict[str, Any], name: str, definitions: dict[str, Any], seen_refs: frozenset[str] = frozenset()
+) -> Any:
     ref = prop.get("$ref")
     if isinstance(ref, str):
-        prop = resolve_json_schema_ref(ref, definitions)
+        if ref in seen_refs:
+            return dict[str, Any]  # break a reference cycle with a permissive type
+        resolved = resolve_json_schema_ref(ref, definitions)
+        if not resolved:
+            logger.warning(f"MCP tool schema: could not resolve $ref '{ref}'; falling back to a permissive type.")
+            return Any
+        prop = resolved
+        seen_refs = seen_refs | {ref}
 
     enum_values = prop.get("enum")
-    if isinstance(enum_values, list):
+    if isinstance(enum_values, list) and enum_values:
         return get_literal_type(enum_values)
+
+    schema_all_of = prop.get("allOf")
+    if isinstance(schema_all_of, list) and schema_all_of:
+        member_refs = {m["$ref"] for m in schema_all_of if isinstance(m, dict) and isinstance(m.get("$ref"), str)}
+        merged = merge_all_of(schema_all_of, definitions, seen_refs)
+        return json_schema_to_type(merged, name, definitions, seen_refs | member_refs)
 
     schema_options = prop.get("anyOf") or prop.get("oneOf")
     if isinstance(schema_options, list):
         return get_union_type(
-            [json_schema_to_type(option, name, definitions) for option in schema_options if isinstance(option, dict)]
+            [
+                json_schema_to_type(option, name, definitions, seen_refs)
+                for option in schema_options
+                if isinstance(option, dict)
+            ]
         )
 
     schema_type = prop.get("type")
     if isinstance(schema_type, list):
         return get_union_type(
             [
-                json_schema_to_type({**prop, "type": type_}, name, definitions)
+                json_schema_to_type({**prop, "type": type_}, name, definitions, seen_refs)
                 for type_ in schema_type
                 if isinstance(type_, str)
             ]
@@ -155,22 +204,26 @@ def json_schema_to_type(prop: dict[str, Any], name: str, definitions: dict[str, 
                 prop,
                 make_model_name(title if isinstance(title, str) else name),
                 definitions,
+                seen_refs,
             )
         additional_props = prop.get("additionalProperties")
         if isinstance(additional_props, dict):
-            return get_dict_annotation(json_schema_to_type(additional_props, f"{name}Value", definitions))
+            return get_dict_annotation(json_schema_to_type(additional_props, f"{name}Value", definitions, seen_refs))
         return dict[str, Any]
 
     if schema_type == "array":
         items = prop.get("items", {})
         item_schema = items if isinstance(items, dict) else {}
-        return get_list_annotation(json_schema_to_type(item_schema, f"{name}Item", definitions))
+        return get_list_annotation(json_schema_to_type(item_schema, f"{name}Item", definitions, seen_refs))
 
     return JSON_SCHEMA_TYPE_MAPPING.get(schema_type, Any)
 
 
 def create_input_schema_from_json_schema(
-    schema_dict: dict[str, Any], model_name: str = "MCPToolSchema", definitions: dict[str, Any] | None = None
+    schema_dict: dict[str, Any],
+    model_name: str = "MCPToolSchema",
+    definitions: dict[str, Any] | None = None,
+    seen_refs: frozenset[str] = frozenset(),
 ) -> type[BaseModel]:
     definitions = {**(definitions or {}), **get_json_schema_definitions(schema_dict)}
     required = schema_dict.get("required", [])
@@ -185,7 +238,7 @@ def create_input_schema_from_json_schema(
     for name, prop in properties.items():
         if not isinstance(prop, dict):
             continue
-        field_type = json_schema_to_type(prop, name, definitions)
+        field_type = json_schema_to_type(prop, name, definitions, seen_refs)
         default = ... if name in required_fields else prop.get("default", None)
         if name not in required_fields:
             field_type = get_union_type([field_type, NONE_TYPE])
@@ -193,7 +246,7 @@ def create_input_schema_from_json_schema(
         raw_description = prop.get("description")
         description = raw_description if isinstance(raw_description, str) else None
         enum_values = prop.get("enum")
-        if isinstance(enum_values, list):
+        if isinstance(enum_values, list) and enum_values:
             enum_description = f" Allowed values: {', '.join(map(str, enum_values))}."
             description = (description or "").rstrip() + enum_description
 

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -159,7 +159,13 @@ def json_schema_to_type(
     ref = prop.get("$ref")
     if isinstance(ref, str):
         if ref in seen_refs:
-            return dict[str, Any]  # break a reference cycle with a permissive type
+            # A self-recursive definition (e.g. a tree node whose children are the same node).
+            # We type the cycle-closing point permissively instead of building a true recursive
+            # model: the latter needs forward references + model_rebuild(), the same lazy-annotation
+            # path that caused the original "name 'Optional' is not defined" crash. The data still
+            # round-trips and the MCP server validates it on receipt. Non-recursive reuse of a
+            # definition (sibling or nested) is unaffected and still builds a fully-typed model.
+            return dict[str, Any]
         resolved = resolve_json_schema_ref(ref, definitions)
         if not resolved:
             logger.warning(f"MCP tool schema: could not resolve $ref '{ref}'; falling back to a permissive type.")

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -2,7 +2,9 @@ import asyncio
 import importlib.util
 import inspect
 import json
+import os
 import sys
+import threading
 from dataclasses import field
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -20,6 +22,18 @@ from dynamiq.nodes.node import ConnectionNode, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.utils import is_called_from_async_context
 from dynamiq.utils.logger import logger
+
+_MCP_SCHEMA_GENERATION_LOCK = threading.Lock()
+
+
+def ensure_process_cwd() -> None:
+    """
+    Repair the process cwd if another thread left it pointing at a deleted directory.
+    """
+    try:
+        Path.cwd()
+    except FileNotFoundError:
+        os.chdir(Path(__file__).resolve().parent)
 
 
 def rename_keys_recursive(data: dict[str, Any] | list[str], key_map: dict[str, str]) -> Any:
@@ -109,14 +123,18 @@ class MCPTool(ConnectionNode):
         input_schema = json.dumps(schema_dict)
 
         with TemporaryDirectory() as tmpdir:
+            schema_path = Path(tmpdir) / "schema.json"
             out_path = Path(tmpdir) / "model.py"
+            schema_path.write_text(input_schema)
 
-            generate(
-                input_schema,
-                input_file_type=InputFileType.JsonSchema,
-                output=out_path,
-                output_model_type=DataModelType.PydanticV2BaseModel,
-            )
+            with _MCP_SCHEMA_GENERATION_LOCK:
+                ensure_process_cwd()
+                generate(
+                    schema_path,
+                    input_file_type=InputFileType.JsonSchema,
+                    output=out_path,
+                    output_model_type=DataModelType.PydanticV2BaseModel,
+                )
 
             module_name = "dynamiq.nodes.tools.MCPTool.mcp_schema"
             spec = importlib.util.spec_from_file_location(module_name, out_path)
@@ -130,7 +148,7 @@ class MCPTool(ConnectionNode):
             ]
 
             model_cls = generated_classes[0]
-            model_cls.model_rebuild()
+            model_cls.model_rebuild(_types_namespace=generated_module.__dict__)
             return model_cls
 
     def execute(self, input_data: BaseModel, config: RunnableConfig | None = None, **kwargs) -> dict[str, Any]:

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -1,18 +1,10 @@
 import asyncio
-import importlib.util
-import inspect
-import json
-import os
-import sys
-import threading
 from dataclasses import field
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Any, Literal
+from types import GenericAlias
+from typing import Any, Literal, Union
 
-from datamodel_code_generator import DataModelType, InputFileType, generate
 from mcp import ClientSession
-from pydantic import BaseModel, ConfigDict, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, create_model
 
 from dynamiq.connections import MCPSse, MCPStdio, MCPStreamableHTTP
 from dynamiq.executors.context import ContextAwareThreadPoolExecutor
@@ -23,20 +15,20 @@ from dynamiq.runnables import RunnableConfig
 from dynamiq.utils import is_called_from_async_context
 from dynamiq.utils.logger import logger
 
-_MCP_SCHEMA_GENERATION_LOCK = threading.Lock()
+NONE_TYPE = type(None)
+
+JSON_SCHEMA_TYPE_MAPPING: dict[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "object": dict[str, Any],
+    "array": list[Any],
+    "null": NONE_TYPE,
+}
 
 
-def ensure_process_cwd() -> None:
-    """
-    Repair the process cwd if another thread left it pointing at a deleted directory.
-    """
-    try:
-        Path.cwd()
-    except FileNotFoundError:
-        os.chdir(Path(__file__).resolve().parent)
-
-
-def rename_keys_recursive(data: dict[str, Any] | list[str], key_map: dict[str, str]) -> Any:
+def rename_keys_recursive(data: dict[str, Any] | list[Any], key_map: dict[str, str]) -> Any:
     """
     Recursively renames keys in a nested dictionary based on a provided key mapping.
     """
@@ -50,6 +42,139 @@ def rename_keys_recursive(data: dict[str, Any] | list[str], key_map: dict[str, s
 def extract_text_from_mcp_content(content: list[Any]) -> str:
     """Join the text of the TextContent blocks in an MCP result's content list."""
     return "\n".join(block.text for block in content if getattr(block, "type", None) == "text")
+
+
+def get_json_schema_definitions(schema: dict[str, Any]) -> dict[str, Any]:
+    definitions: dict[str, Any] = {}
+    for key in ("$defs", "definitions"):
+        value = schema.get(key)
+        if isinstance(value, dict):
+            definitions.update(value)
+    return definitions
+
+
+def make_model_name(name: str | None, fallback: str = "MCPToolSchema") -> str:
+    if not name:
+        return fallback
+    parts = [part for part in "".join(char if char.isalnum() else " " for char in name).title().split() if part]
+    model_name = "".join(parts)
+    if not model_name or model_name[0].isdigit():
+        return fallback
+    return model_name
+
+
+def get_union_type(types: list[Any]) -> Any:
+    unique_types = []
+    for type_ in types:
+        if type_ not in unique_types:
+            unique_types.append(type_)
+    if not unique_types:
+        return Any
+    if len(unique_types) == 1:
+        return unique_types[0]
+    return Union.__getitem__(tuple(unique_types))
+
+
+def get_literal_type(values: list[Any]) -> Any:
+    return Literal.__getitem__(tuple(values))
+
+
+def get_list_annotation(item_type: Any) -> Any:
+    return GenericAlias(list, (item_type,))
+
+
+def get_dict_annotation(value_type: Any) -> Any:
+    return GenericAlias(dict, (str, value_type))
+
+
+def resolve_json_schema_ref(ref: str, definitions: dict[str, Any]) -> dict[str, Any]:
+    prefix = "#/$defs/"
+    definitions_prefix = "#/definitions/"
+    if ref.startswith(prefix):
+        value = definitions.get(ref.removeprefix(prefix))
+        return value if isinstance(value, dict) else {}
+    if ref.startswith(definitions_prefix):
+        value = definitions.get(ref.removeprefix(definitions_prefix))
+        return value if isinstance(value, dict) else {}
+    return {}
+
+
+def json_schema_to_type(prop: dict[str, Any], name: str, definitions: dict[str, Any]) -> Any:
+    ref = prop.get("$ref")
+    if isinstance(ref, str):
+        prop = resolve_json_schema_ref(ref, definitions)
+
+    enum_values = prop.get("enum")
+    if isinstance(enum_values, list):
+        return get_literal_type(enum_values)
+
+    schema_options = prop.get("anyOf") or prop.get("oneOf")
+    if isinstance(schema_options, list):
+        return get_union_type(
+            [json_schema_to_type(option, name, definitions) for option in schema_options if isinstance(option, dict)]
+        )
+
+    schema_type = prop.get("type")
+    if isinstance(schema_type, list):
+        return get_union_type(
+            [
+                json_schema_to_type({**prop, "type": type_}, name, definitions)
+                for type_ in schema_type
+                if isinstance(type_, str)
+            ]
+        )
+
+    if schema_type == "object" or prop.get("properties"):
+        if prop.get("properties"):
+            title = prop.get("title")
+            return create_input_schema_from_json_schema(
+                prop,
+                make_model_name(title if isinstance(title, str) else name),
+                definitions,
+            )
+        additional_props = prop.get("additionalProperties")
+        if isinstance(additional_props, dict):
+            return get_dict_annotation(json_schema_to_type(additional_props, f"{name}Value", definitions))
+        return dict[str, Any]
+
+    if schema_type == "array":
+        items = prop.get("items", {})
+        item_schema = items if isinstance(items, dict) else {}
+        return get_list_annotation(json_schema_to_type(item_schema, f"{name}Item", definitions))
+
+    return JSON_SCHEMA_TYPE_MAPPING.get(schema_type, Any)
+
+
+def create_input_schema_from_json_schema(
+    schema_dict: dict[str, Any], model_name: str = "MCPToolSchema", definitions: dict[str, Any] | None = None
+) -> type[BaseModel]:
+    definitions = {**(definitions or {}), **get_json_schema_definitions(schema_dict)}
+    required = schema_dict.get("required", [])
+    required_fields = set(required if isinstance(required, list) else [])
+    fields: dict[str, tuple[Any, Any]] = {}
+
+    properties = schema_dict.get("properties", {})
+    if not isinstance(properties, dict):
+        properties = {}
+
+    for name, prop in properties.items():
+        if not isinstance(prop, dict):
+            continue
+        field_type = json_schema_to_type(prop, name, definitions)
+        default = ... if name in required_fields else prop.get("default", None)
+        if name not in required_fields:
+            field_type = get_union_type([field_type, NONE_TYPE])
+
+        raw_description = prop.get("description")
+        description = raw_description if isinstance(raw_description, str) else None
+        enum_values = prop.get("enum")
+        if isinstance(enum_values, list):
+            enum_description = f" Allowed values: {', '.join(map(str, enum_values))}."
+            description = (description or "").rstrip() + enum_description
+
+        fields[name] = (field_type, Field(default, description=description))
+
+    return create_model(model_name, **fields)
 
 
 class ServerMetadata(BaseModel):
@@ -112,44 +237,10 @@ class MCPTool(ConnectionNode):
             schema_dict (dict[str, Any]): A JSON schema dictionary describing the tool's expected input.
         """
         schema_dict = rename_keys_recursive(schema_dict, {"type_": "type"})
-
-        for _, props in schema_dict.get("properties", {}).items():
-            enum_values = props.pop("enum", None)
-            if enum_values:
-                description = props.get("description", "")
-                enum_description = f" Allowed values: {', '.join(map(str, enum_values))}."
-                props["description"] = description.rstrip() + enum_description
-
-        input_schema = json.dumps(schema_dict)
-
-        with TemporaryDirectory() as tmpdir:
-            schema_path = Path(tmpdir) / "schema.json"
-            out_path = Path(tmpdir) / "model.py"
-            schema_path.write_text(input_schema)
-
-            with _MCP_SCHEMA_GENERATION_LOCK:
-                ensure_process_cwd()
-                generate(
-                    schema_path,
-                    input_file_type=InputFileType.JsonSchema,
-                    output=out_path,
-                    output_model_type=DataModelType.PydanticV2BaseModel,
-                )
-
-            module_name = "dynamiq.nodes.tools.MCPTool.mcp_schema"
-            spec = importlib.util.spec_from_file_location(module_name, out_path)
-            generated_module = importlib.util.module_from_spec(spec)
-            sys.modules[module_name] = generated_module
-            spec.loader.exec_module(generated_module)
-            generated_classes = [
-                cls
-                for _, cls in inspect.getmembers(generated_module, inspect.isclass)
-                if cls.__module__ == generated_module.__name__
-            ]
-
-            model_cls = generated_classes[0]
-            model_cls.model_rebuild(_types_namespace=generated_module.__dict__)
-            return model_cls
+        return create_input_schema_from_json_schema(
+            schema_dict,
+            "MCPToolSchema",
+        )
 
     def execute(self, input_data: BaseModel, config: RunnableConfig | None = None, **kwargs) -> dict[str, Any]:
         """

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -290,10 +290,28 @@ class _SchemaModelBuilder:
             **fields,
         )
 
+    def _resolve_to_object_schema(self, schema: dict[str, Any]) -> dict[str, Any]:
+        """Follow a root-level $ref / allOf chain to the effective object schema with properties."""
+        seen: set[str] = set()
+        while isinstance(schema, dict) and not schema.get("properties"):
+            ref = schema.get("$ref")
+            if isinstance(ref, str) and ref not in seen:
+                seen.add(ref)
+                schema = resolve_json_schema_ref(ref, self._definitions)
+                continue
+            all_of = schema.get("allOf")
+            if isinstance(all_of, list) and all_of:
+                schema = self._merge_all_of(all_of)
+                continue
+            break
+        return schema
+
     def build(self, schema_dict: dict[str, Any], model_name: str) -> type[BaseModel]:
         self._definitions = {**self._definitions, **get_json_schema_definitions(schema_dict)}
-        # The root keeps its requested name verbatim; nested models derive theirs from titles.
-        root = self._register(schema_dict, self._schema_key(schema_dict), model_name)
+        # A root defined purely through $ref/allOf composition is resolved to its object schema so its
+        # properties are not lost. The root keeps its requested name; nested models derive theirs.
+        root_schema = self._resolve_to_object_schema(schema_dict)
+        root = self._register(root_schema, self._schema_key(root_schema), model_name)
         # Complete every forward reference (recursive models) against the namespace built above.
         for model in self._namespace.values():
             model.model_rebuild(force=True, _types_namespace=self._namespace)

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -1,14 +1,11 @@
 import contextlib
-import os
 import uuid
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from mcp.types import CallToolResult, ImageContent, TextContent
-from pydantic import BaseModel, Field, create_model
+from pydantic import Field, ValidationError, create_model
 
 from dynamiq import connections
 from dynamiq.nodes.agents import Agent
@@ -240,48 +237,52 @@ def test_extract_text_from_mcp_content():
     assert extract_text_from_mcp_content([]) == ""
 
 
-def test_get_input_schema_rebuilds_with_generated_types_namespace(monkeypatch):
-    captured = {}
-    original_model_rebuild = BaseModel.model_rebuild.__func__
-
-    def capture_model_rebuild(cls, *args, **kwargs):
-        if cls.__module__ == "dynamiq.nodes.tools.MCPTool.mcp_schema":
-            captured["types_namespace"] = kwargs.get("_types_namespace")
-        return original_model_rebuild(cls, *args, **kwargs)
-
-    monkeypatch.setattr(BaseModel, "model_rebuild", classmethod(capture_model_rebuild))
-
+def test_get_input_schema_creates_model_from_json_schema():
     model_cls = MCPTool.get_input_schema(
         {
-            "title": "OptionalSchema",
+            "title": "SearchSchema",
             "type": "object",
-            "properties": {"value": {"type": "string"}},
-            "required": [],
+            "$defs": {
+                "Options": {
+                    "type": "object",
+                    "properties": {"case_sensitive": {"type": "boolean"}},
+                }
+            },
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer", "default": 10},
+                "mode": {"type": "string", "enum": ["fast", "full"]},
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "ids": {"type": "array", "items": {"type": "integer"}},
+                "filters": {
+                    "type": "object",
+                    "properties": {"active": {"type": "boolean"}},
+                },
+                "options": {"$ref": "#/$defs/Options"},
+            },
+            "required": ["query"],
         }
     )
 
-    assert model_cls(value="ok").value == "ok"
-    assert "Optional" in captured["types_namespace"]
+    assert model_cls.__name__ == "MCPToolSchema"
+    input_data = model_cls(
+        query="customers",
+        mode="fast",
+        tags=["pii"],
+        ids=[1, 2],
+        filters={"active": True},
+        options={"case_sensitive": False},
+    )
 
+    assert input_data.query == "customers"
+    assert input_data.limit == 10
+    assert input_data.ids == [1, 2]
+    assert input_data.filters.active is True
+    assert input_data.options.case_sensitive is False
+    assert set(model_cls.model_json_schema()["required"]) == {"query"}
 
-def test_get_input_schema_does_not_require_existing_process_cwd():
-    original_cwd = Path.cwd()
-    try:
-        with TemporaryDirectory() as missing_cwd:
-            os.chdir(missing_cwd)
-
-        model_cls = MCPTool.get_input_schema(
-            {
-                "title": "OptionalSchema",
-                "type": "object",
-                "properties": {"value": {"type": "string"}},
-                "required": [],
-            }
-        )
-
-        assert model_cls(value="ok").value == "ok"
-    finally:
-        os.chdir(original_cwd)
+    with pytest.raises(ValidationError):
+        model_cls(query="customers", mode="slow")
 
 
 def _patch_session_with_result(result: CallToolResult):

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -285,6 +285,33 @@ def test_get_input_schema_creates_model_from_json_schema():
         model_cls(query="customers", mode="slow")
 
 
+def test_get_input_schema_handles_reserved_and_invalid_field_names():
+    """Property names that collide with BaseModel attrs or are not valid identifiers must round-trip."""
+    model_cls = MCPTool.get_input_schema(
+        {
+            "type": "object",
+            "properties": {
+                "model_config": {"type": "string"},
+                "schema": {"type": "integer"},
+                "weird-name": {"type": "boolean"},
+                "normal": {"type": "string"},
+            },
+            "required": ["model_config"],
+        }
+    )
+
+    instance = model_cls.model_validate(
+        {"model_config": "cfg", "schema": 5, "weird-name": True, "normal": "ok"}
+    )
+
+    assert instance.model_dump(by_alias=True) == {
+        "model_config": "cfg",
+        "schema": 5,
+        "weird-name": True,
+        "normal": "ok",
+    }
+
+
 def _patch_session_with_result(result: CallToolResult):
     """Patch the connection + ClientSession so call_tool yields `result`."""
 

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -329,7 +329,9 @@ def test_get_input_schema_builds_recursive_model_with_nested_validation():
         }
     )
 
-    instance = model_cls.model_validate({"root": {"value": "a", "children": [{"value": "b", "children": [{"value": "c"}]}]}})
+    instance = model_cls.model_validate(
+        {"root": {"value": "a", "children": [{"value": "b", "children": [{"value": "c"}]}]}}
+    )
     # Nested levels are validated as the recursive model, not loose dicts.
     assert instance.root.value == "a"
     assert instance.root.children[0].value == "b"
@@ -393,6 +395,38 @@ def test_get_input_schema_handles_unresolvable_ref():
     model_cls = MCPTool.get_input_schema({"type": "object", "properties": {"x": {"$ref": "#/$defs/Missing"}}})
 
     assert model_cls.model_validate({"x": {"anything": 1}}).x == {"anything": 1}
+
+
+def test_get_input_schema_handles_root_ref_composition():
+    """A root defined purely as a $ref to $defs must keep the referenced properties."""
+    model_cls = MCPTool.get_input_schema(
+        {
+            "$defs": {"Input": {"type": "object", "properties": {"q": {"type": "string"}}, "required": ["q"]}},
+            "$ref": "#/$defs/Input",
+        }
+    )
+
+    assert list(model_cls.model_fields) == ["q"]
+    assert model_cls.model_validate({"q": "x"}).q == "x"
+    with pytest.raises(ValidationError):
+        model_cls.model_validate({})
+
+
+def test_get_input_schema_handles_root_all_of_composition():
+    """A root defined purely as allOf must merge the composed properties."""
+    model_cls = MCPTool.get_input_schema(
+        {
+            "$defs": {"Base": {"type": "object", "properties": {"a": {"type": "string"}}}},
+            "allOf": [
+                {"$ref": "#/$defs/Base"},
+                {"type": "object", "properties": {"b": {"type": "integer"}}},
+            ],
+        }
+    )
+
+    instance = model_cls.model_validate({"a": "x", "b": 5})
+    assert instance.a == "x"
+    assert instance.b == 5
 
 
 def _patch_session_with_result(result: CallToolResult):

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -310,8 +310,8 @@ def test_get_input_schema_handles_reserved_and_invalid_field_names():
     }
 
 
-def test_get_input_schema_handles_recursive_ref_without_recursion_error():
-    """A self-referential $defs schema must build without a RecursionError."""
+def test_get_input_schema_builds_recursive_model_with_nested_validation():
+    """A self-referential $defs schema must build a true recursive model that validates every level."""
     model_cls = MCPTool.get_input_schema(
         {
             "type": "object",
@@ -329,9 +329,41 @@ def test_get_input_schema_handles_recursive_ref_without_recursion_error():
         }
     )
 
-    instance = model_cls.model_validate({"root": {"value": "a", "children": [{"value": "b"}]}})
+    instance = model_cls.model_validate({"root": {"value": "a", "children": [{"value": "b", "children": [{"value": "c"}]}]}})
+    # Nested levels are validated as the recursive model, not loose dicts.
     assert instance.root.value == "a"
-    assert instance.root.children == [{"value": "b"}]
+    assert instance.root.children[0].value == "b"
+    assert instance.root.children[0].children[0].value == "c"
+    with pytest.raises(ValidationError):
+        model_cls.model_validate({"root": {"value": "a", "children": [{"value": {"not": "a string"}}]}})
+
+
+def test_get_input_schema_recursive_all_of_preserves_base():
+    """An allOf that extends the definition currently being built must keep both base and extension."""
+    model_cls = MCPTool.get_input_schema(
+        {
+            "type": "object",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"},
+                        "next": {
+                            "allOf": [
+                                {"$ref": "#/$defs/Node"},
+                                {"type": "object", "properties": {"tag": {"type": "string"}}},
+                            ]
+                        },
+                    },
+                }
+            },
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+        }
+    )
+
+    instance = model_cls.model_validate({"root": {"value": "a", "next": {"value": "b", "tag": "t"}}})
+    assert instance.root.next.value == "b"  # base field preserved
+    assert instance.root.next.tag == "t"  # extension field present
 
 
 def test_get_input_schema_enforces_all_of():

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -1,11 +1,14 @@
 import contextlib
+import os
 import uuid
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from mcp.types import CallToolResult, ImageContent, TextContent
-from pydantic import Field, create_model
+from pydantic import BaseModel, Field, create_model
 
 from dynamiq import connections
 from dynamiq.nodes.agents import Agent
@@ -235,6 +238,50 @@ def test_extract_text_from_mcp_content():
     ]
     assert extract_text_from_mcp_content(content) == "line one\nline two"
     assert extract_text_from_mcp_content([]) == ""
+
+
+def test_get_input_schema_rebuilds_with_generated_types_namespace(monkeypatch):
+    captured = {}
+    original_model_rebuild = BaseModel.model_rebuild.__func__
+
+    def capture_model_rebuild(cls, *args, **kwargs):
+        if cls.__module__ == "dynamiq.nodes.tools.MCPTool.mcp_schema":
+            captured["types_namespace"] = kwargs.get("_types_namespace")
+        return original_model_rebuild(cls, *args, **kwargs)
+
+    monkeypatch.setattr(BaseModel, "model_rebuild", classmethod(capture_model_rebuild))
+
+    model_cls = MCPTool.get_input_schema(
+        {
+            "title": "OptionalSchema",
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": [],
+        }
+    )
+
+    assert model_cls(value="ok").value == "ok"
+    assert "Optional" in captured["types_namespace"]
+
+
+def test_get_input_schema_does_not_require_existing_process_cwd():
+    original_cwd = Path.cwd()
+    try:
+        with TemporaryDirectory() as missing_cwd:
+            os.chdir(missing_cwd)
+
+        model_cls = MCPTool.get_input_schema(
+            {
+                "title": "OptionalSchema",
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": [],
+            }
+        )
+
+        assert model_cls(value="ok").value == "ok"
+    finally:
+        os.chdir(original_cwd)
 
 
 def _patch_session_with_result(result: CallToolResult):

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 import uuid
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -427,6 +428,28 @@ def test_get_input_schema_handles_root_all_of_composition():
     instance = model_cls.model_validate({"a": "x", "b": 5})
     assert instance.a == "x"
     assert instance.b == 5
+
+
+def test_get_input_schema_does_not_depend_on_cwd(tmp_path):
+    """Schema building must not require a valid working directory.
+
+    Regression for an MCP init failure where the old temp-file codegen path called os.getcwd()
+    while the process working directory had been removed, raising FileNotFoundError.
+    """
+    original_cwd = os.getcwd()
+    doomed = tmp_path / "doomed"
+    doomed.mkdir()
+    os.chdir(doomed)
+    doomed.rmdir()  # the process cwd now points at a deleted directory
+    try:
+        with pytest.raises(FileNotFoundError):
+            os.getcwd()
+        model_cls = MCPTool.get_input_schema(
+            {"type": "object", "properties": {"q": {"type": "string"}}, "required": ["q"]}
+        )
+        assert model_cls.model_validate({"q": "x"}).q == "x"
+    finally:
+        os.chdir(original_cwd)
 
 
 def _patch_session_with_result(result: CallToolResult):

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -300,9 +300,7 @@ def test_get_input_schema_handles_reserved_and_invalid_field_names():
         }
     )
 
-    instance = model_cls.model_validate(
-        {"model_config": "cfg", "schema": 5, "weird-name": True, "normal": "ok"}
-    )
+    instance = model_cls.model_validate({"model_config": "cfg", "schema": 5, "weird-name": True, "normal": "ok"})
 
     assert instance.model_dump(by_alias=True) == {
         "model_config": "cfg",
@@ -310,6 +308,59 @@ def test_get_input_schema_handles_reserved_and_invalid_field_names():
         "weird-name": True,
         "normal": "ok",
     }
+
+
+def test_get_input_schema_handles_recursive_ref_without_recursion_error():
+    """A self-referential $defs schema must build without a RecursionError."""
+    model_cls = MCPTool.get_input_schema(
+        {
+            "type": "object",
+            "title": "tree",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"},
+                        "children": {"type": "array", "items": {"$ref": "#/$defs/Node"}},
+                    },
+                }
+            },
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+        }
+    )
+
+    instance = model_cls.model_validate({"root": {"value": "a", "children": [{"value": "b"}]}})
+    assert instance.root.value == "a"
+    assert instance.root.children == [{"value": "b"}]
+
+
+def test_get_input_schema_enforces_all_of():
+    """allOf must contribute its constraints instead of degrading the field to Any."""
+    model_cls = MCPTool.get_input_schema(
+        {
+            "type": "object",
+            "properties": {"count": {"allOf": [{"type": "integer"}]}},
+            "required": ["count"],
+        }
+    )
+
+    assert model_cls(count=5).count == 5
+    with pytest.raises(ValidationError):
+        model_cls(count="not-an-int")
+
+
+def test_get_input_schema_handles_empty_enum():
+    """An empty enum must not produce an invalid Literal[()] annotation."""
+    model_cls = MCPTool.get_input_schema({"type": "object", "properties": {"x": {"type": "string", "enum": []}}})
+
+    assert model_cls.model_validate({"x": "anything"}).x == "anything"
+
+
+def test_get_input_schema_handles_unresolvable_ref():
+    """An unresolvable $ref must degrade to a permissive type instead of crashing."""
+    model_cls = MCPTool.get_input_schema({"type": "object", "properties": {"x": {"$ref": "#/$defs/Missing"}}})
+
+    assert model_cls.model_validate({"x": {"anything": 1}}).x == {"anything": 1}
 
 
 def _patch_session_with_result(result: CallToolResult):

--- a/tests/integration_with_creds/agents/test_agent_python_tool.py
+++ b/tests/integration_with_creds/agents/test_agent_python_tool.py
@@ -189,7 +189,11 @@ def expected_length(test_input_string):
 
 @pytest.fixture(scope="module")
 def agent_role():
-    return "is to help user with various tasks, goal is to provide best of possible answers to user queries"
+    return (
+        "is to help user with various tasks. You MUST use the StringLengthTool to determine the length "
+        "of any string. Never compute, estimate, or state a string's length yourself, and never answer "
+        "directly before the tool has returned its result."
+    )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how every MCP tool validates and serializes inputs; behavior is broader and better tested but still on the critical agent→MCP execution path.
> 
> **Overview**
> Replaces **MCP tool input schema** generation that wrote temp Python via `datamodel-code-generator` and loaded it from `sys.modules` with an in-process **`_SchemaModelBuilder`** that maps JSON Schema to Pydantic models (`create_model`), including **`$ref`**, **`allOf`**, recursion, enums, and unsafe property names (aliases + `populate_by_name`).
> 
> **`MCPTool.execute_async`** now serializes tool arguments with **`model_dump(by_alias=True)`** so MCP servers receive original JSON keys when fields use aliases. Integration tests cover schema edge cases and a **deleted cwd** regression; the credentialed agent test role is tightened to force tool use for string length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e0c34d41362c9182e7d62f3618911edd21b871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->