### PR TITLE
fix: unwrap MCP TaskGroup exception groups in error messages

### DIFF
--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -21,6 +21,29 @@ from dynamiq.runnables import RunnableConfig
 from dynamiq.utils import is_called_from_async_context
 from dynamiq.utils.logger import logger
 
+try:  # Python 3.11+ exposes ExceptionGroup as a builtin
+    from builtins import BaseExceptionGroup
+except ImportError:  # Python 3.10 relies on the backport (a transitive dependency of anyio/mcp)
+    from exceptiongroup import BaseExceptionGroup
+
+
+def flatten_exception_group(exc: BaseException) -> list[BaseException]:
+    """Recursively flatten a (possibly nested) ExceptionGroup into its leaf exceptions."""
+    if isinstance(exc, BaseExceptionGroup):
+        return [leaf for sub in exc.exceptions for leaf in flatten_exception_group(sub)]
+    return [exc]
+
+
+def format_exception(exc: BaseException) -> str:
+    """Render an exception as a readable string, unwrapping anyio/asyncio TaskGroup ExceptionGroups.
+
+    The MCP client runs its transports inside anyio task groups, so transport failures surface as an
+    ExceptionGroup whose ``str()`` is the opaque "unhandled errors in a TaskGroup (N sub-exceptions)".
+    This unwraps the group to its leaf errors so the real cause is visible in logs and tool errors.
+    """
+    leaves = flatten_exception_group(exc)
+    return "; ".join(f"{type(leaf).__name__}: {leaf}" for leaf in leaves)
+
 
 def rename_keys_recursive(data: dict[str, Any] | list[str], key_map: dict[str, str]) -> Any:
     """
@@ -172,10 +195,11 @@ class MCPTool(ConnectionNode):
                     await session.initialize()
                     result = await session.call_tool(self.name, input_dict)
         except Exception as e:
-            logger.error(f"Tool {self.name} - {self.id}: failed to get results. Error: {str(e)}")
+            error = format_exception(e)
+            logger.error(f"Tool {self.name} - {self.id}: failed to get results. Error: {error}")
             raise ToolExecutionException(
                 f"Tool '{self.name}' failed to call tool from the MCP server."
-                f"Error: {str(e)}. Please analyze the error and take appropriate action.",
+                f"Error: {error}. Please analyze the error and take appropriate action.",
                 recoverable=True,
             )
 
@@ -265,8 +289,9 @@ Usage Strategy:
 
             logger.info(f"Tool {self.name}: {len(self._mcp_tools)} MCP tools initialized from a server.")
         except Exception as e:
-            logger.error(f"Tool {self.name} - {self.id}: failed to initialize session. Error: {str(e)}")
-            raise ToolExecutionException(f"Tool {self.name} - {self.id}: failed to initialize session. Error: {str(e)}")
+            error = format_exception(e)
+            logger.error(f"Tool {self.name} - {self.id}: failed to initialize session. Error: {error}")
+            raise ToolExecutionException(f"Tool {self.name} - {self.id}: failed to initialize session. Error: {error}")
 
     def get_mcp_tools(self, select_all: bool = False) -> list[MCPTool]:
         """

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -329,3 +329,49 @@ async def test_execute_async_raises_on_is_error(mcp_server_tool):
     with conn_patch, session_patch:
         with pytest.raises(ToolExecutionException, match="API rate limit exceeded"):
             await tool.execute_async(tool.input_schema(a=20, b=22))
+
+
+@pytest.mark.asyncio
+async def test_execute_async_unwraps_task_group_exception_group(mcp_server_tool):
+    """A TaskGroup ExceptionGroup must surface its real leaf error, not the opaque wrapper."""
+    tool = mcp_server_tool._mcp_tools["add"]
+
+    @contextlib.asynccontextmanager
+    async def failing_connect(self):
+        raise ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ConnectionRefusedError("[Errno 61] Connection refused")],
+        )
+        yield  # pragma: no cover - makes this an async generator
+
+    with patch.object(MCPSse, "connect", new=failing_connect):
+        with pytest.raises(ToolExecutionException) as exc_info:
+            await tool.execute_async(tool.input_schema(a=20, b=22))
+
+    message = str(exc_info.value)
+    assert "ConnectionRefusedError" in message
+    assert "Connection refused" in message
+    assert "unhandled errors in a TaskGroup" not in message
+
+
+@pytest.mark.asyncio
+async def test_initialize_tools_unwraps_nested_exception_group(sse_server_connection):
+    """initialize_tools should report leaf errors from nested TaskGroup ExceptionGroups."""
+    server = MCPServer(connection=sse_server_connection)
+
+    @contextlib.asynccontextmanager
+    async def failing_connect(self):
+        raise ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ExceptionGroup("inner", [TimeoutError("handshake timed out")])],
+        )
+        yield  # pragma: no cover - makes this an async generator
+
+    with patch.object(MCPSse, "connect", new=failing_connect):
+        with pytest.raises(ToolExecutionException) as exc_info:
+            await server.initialize_tools()
+
+    message = str(exc_info.value)
+    assert "TimeoutError" in message
+    assert "handshake timed out" in message
+    assert "unhandled errors in a TaskGroup" not in message


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only changes how exceptions are stringified on failure paths; no changes to connection, auth, or successful execution behavior.
> 
> **Overview**
> MCP tool execution and server initialization now **unwrap nested `ExceptionGroup`s** (including anyio TaskGroup wrappers) before logging and raising `ToolExecutionException`, so failures show leaf causes like `ConnectionRefusedError` instead of opaque "unhandled errors in a TaskGroup" text.
> 
> New helpers `flatten_exception_group` and `format_exception` in `mcp.py` handle Python 3.10 via the `exceptiongroup` backport. Integration tests cover flat and nested groups on `execute_async` and `initialize_tools`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646691e28d679e93b19ab8af18f3338baf1b8326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->