### PR TITLE
feat: add timeouts for MultiFileConverter sub-converters

### DIFF
--- a/dynamiq/nodes/converters/docx.py
+++ b/dynamiq/nodes/converters/docx.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from dynamiq.components.converters.docx import DOCXConverter as DOCXConverterComponent
 from dynamiq.connections.managers import ConnectionManager
-from dynamiq.nodes.node import Node, NodeGroup, ensure_config
+from dynamiq.nodes.node import ErrorHandling, Node, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.types import DocumentCreationMode
 from dynamiq.utils.logger import logger
@@ -33,6 +33,10 @@ class DOCXFileConverter(Node):
 
     group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
     name: str = "docx-file-converter"
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=60.0),
+        description="Default execution timeout. Set timeout_seconds to None to disable.",
+    )
     document_creation_mode: DocumentCreationMode = DocumentCreationMode.ONE_DOC_PER_FILE
     file_converter: DOCXConverterComponent | None = None
     input_schema: ClassVar[type[DOCXFileConverterInputSchema]] = DOCXFileConverterInputSchema

--- a/dynamiq/nodes/converters/html.py
+++ b/dynamiq/nodes/converters/html.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from dynamiq.components.converters.html import HTMLConverter as HTMLConverterComponent
 from dynamiq.connections.managers import ConnectionManager
-from dynamiq.nodes.node import Node, NodeGroup, ensure_config
+from dynamiq.nodes.node import ErrorHandling, Node, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.utils.logger import logger
 
@@ -32,6 +32,10 @@ class HTMLConverter(Node):
 
     group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
     name: str = "html-file-converter"
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=60.0),
+        description="Default execution timeout. Set timeout_seconds to None to disable.",
+    )
     file_converter: HTMLConverterComponent | None = None
     input_schema: ClassVar[type[HTMLConverterInputSchema]] = HTMLConverterInputSchema
 

--- a/dynamiq/nodes/converters/llm_text_extractor.py
+++ b/dynamiq/nodes/converters/llm_text_extractor.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from PIL import Image
 
 from dynamiq.connections.managers import ConnectionManager
-from dynamiq.nodes.node import Node, NodeDependency, NodeGroup, ensure_config
+from dynamiq.nodes.node import ErrorHandling, Node, NodeDependency, NodeGroup, ensure_config
 from dynamiq.prompts import (
     Prompt,
     VisionMessage,
@@ -108,6 +108,10 @@ class LLMImageConverter(Node):
 
     group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
     name: str = "llm-image-converter"
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=300.0),
+        description="Default execution timeout for LLM-backed extraction. Set timeout_seconds to None to disable.",
+    )
     extraction_instruction: str = DEFAULT_EXTRACTION_INSTRUCTION
     document_creation_mode: DocumentCreationMode = DocumentCreationMode.ONE_DOC_PER_FILE
     llm: Node

--- a/dynamiq/nodes/converters/multi_file_type_converter.py
+++ b/dynamiq/nodes/converters/multi_file_type_converter.py
@@ -14,7 +14,7 @@ from dynamiq.nodes.converters.pptx import PPTXFileConverter
 from dynamiq.nodes.converters.pypdf import PyPDFConverter
 from dynamiq.nodes.converters.text import TextFileConverter
 from dynamiq.nodes.extractors.extractors import EXTENSION_MAP, FileType, FileTypeExtractor, FileTypeExtractorInputSchema
-from dynamiq.nodes.node import Node, NodeDependency, ensure_config
+from dynamiq.nodes.node import ErrorHandling, Node, NodeDependency, ensure_config
 from dynamiq.nodes.types import NodeGroup
 from dynamiq.runnables import RunnableConfig, RunnableStatus
 from dynamiq.types import Document
@@ -42,9 +42,7 @@ FILE_TYPE_TO_SUPPORTED_CONVERTER_CLASS_MAP = {
     FileType.MARKDOWN: (TextFileConverter,),
 }
 
-DEFAULT_LOCAL_CONVERTER_TIMEOUT_SECONDS = 60.0
-DEFAULT_LLM_CONVERTER_TIMEOUT_SECONDS = 300.0
-DEFAULT_FALLBACK_CONVERTER_TIMEOUT_SECONDS = 300.0
+DEFAULT_TIMEOUT_SECONDS = 600.0
 
 
 # TODO: Add parallel processing for multiple files.
@@ -90,20 +88,10 @@ class MultiFileTypeConverter(Node):
     file_type_extractor: FileTypeExtractor | None = None
     converters: list[Node] | None = None
     converter_mapping: dict[FileType, Node] | None = None
-    local_converter_timeout_seconds: float | None = Field(
-        default=DEFAULT_LOCAL_CONVERTER_TIMEOUT_SECONDS,
-        description="Execution timeout for local parsing converters (PDF, DOCX, PPTX, HTML, text). "
-        "Only applied to converters that don't already have a timeout set. Set to None to disable.",
-    )
-    llm_converter_timeout_seconds: float | None = Field(
-        default=DEFAULT_LLM_CONVERTER_TIMEOUT_SECONDS,
-        description="Execution timeout for LLM-backed converters (image, PDF). "
-        "Only applied to converters that don't already have a timeout set. Set to None to disable.",
-    )
-    fallback_converter_timeout_seconds: float | None = Field(
-        default=DEFAULT_FALLBACK_CONVERTER_TIMEOUT_SECONDS,
-        description="Execution timeout for the fallback converter. "
-        "Only applied when the fallback converter doesn't already have a timeout set. Set to None to disable.",
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=DEFAULT_TIMEOUT_SECONDS),
+        description="Overall execution timeout for the whole batch. Sub-converters carry their own "
+        "per-file timeouts. Set timeout_seconds to None to disable.",
     )
     model_config = ConfigDict(arbitrary_types_allowed=True)
     input_schema: ClassVar[type[MultiFileTypeConverterInputSchema]] = MultiFileTypeConverterInputSchema
@@ -172,8 +160,6 @@ class MultiFileTypeConverter(Node):
 
         self._setup_converters()
 
-        self._apply_converter_timeouts()
-
         # Initialize components for converters in the mapping
         initialized_converters = set()
         for converter in self.converter_mapping.values():
@@ -182,26 +168,6 @@ class MultiFileTypeConverter(Node):
                     converter.init_components(connection_manager)
                 initialized_converters.add(id(converter))
                 logger.info(f"Initialized converter: {converter.name}")
-
-    def _apply_converter_timeouts(self):
-        """Apply tiered default execution timeouts to converters that don't have one configured."""
-        if self.fallback_converter is not None:
-            self._set_timeout_if_unset(self.fallback_converter, self.fallback_converter_timeout_seconds)
-
-        for converter in self.converter_mapping.values():
-            if converter is self.fallback_converter:
-                continue
-            if isinstance(converter, (LLMImageConverter, LLMPDFConverter)):
-                timeout_seconds = self.llm_converter_timeout_seconds
-            else:
-                timeout_seconds = self.local_converter_timeout_seconds
-            self._set_timeout_if_unset(converter, timeout_seconds)
-
-    @staticmethod
-    def _set_timeout_if_unset(converter: Node, timeout_seconds: float | None):
-        """Set the converter's execution timeout only when the caller hasn't configured one."""
-        if timeout_seconds is not None and converter.error_handling.timeout_seconds is None:
-            converter.error_handling.timeout_seconds = timeout_seconds
 
     def _setup_converters(self):
         """Setup internal converter components."""

--- a/dynamiq/nodes/converters/multi_file_type_converter.py
+++ b/dynamiq/nodes/converters/multi_file_type_converter.py
@@ -42,6 +42,10 @@ FILE_TYPE_TO_SUPPORTED_CONVERTER_CLASS_MAP = {
     FileType.MARKDOWN: (TextFileConverter,),
 }
 
+DEFAULT_LOCAL_CONVERTER_TIMEOUT_SECONDS = 60.0
+DEFAULT_LLM_CONVERTER_TIMEOUT_SECONDS = 300.0
+DEFAULT_FALLBACK_CONVERTER_TIMEOUT_SECONDS = 300.0
+
 
 # TODO: Add parallel processing for multiple files.
 class MultiFileTypeConverterInputSchema(BaseModel):
@@ -86,6 +90,21 @@ class MultiFileTypeConverter(Node):
     file_type_extractor: FileTypeExtractor | None = None
     converters: list[Node] | None = None
     converter_mapping: dict[FileType, Node] | None = None
+    local_converter_timeout_seconds: float | None = Field(
+        default=DEFAULT_LOCAL_CONVERTER_TIMEOUT_SECONDS,
+        description="Execution timeout for local parsing converters (PDF, DOCX, PPTX, HTML, text). "
+        "Only applied to converters that don't already have a timeout set. Set to None to disable.",
+    )
+    llm_converter_timeout_seconds: float | None = Field(
+        default=DEFAULT_LLM_CONVERTER_TIMEOUT_SECONDS,
+        description="Execution timeout for LLM-backed converters (image, PDF). "
+        "Only applied to converters that don't already have a timeout set. Set to None to disable.",
+    )
+    fallback_converter_timeout_seconds: float | None = Field(
+        default=DEFAULT_FALLBACK_CONVERTER_TIMEOUT_SECONDS,
+        description="Execution timeout for the fallback converter. "
+        "Only applied when the fallback converter doesn't already have a timeout set. Set to None to disable.",
+    )
     model_config = ConfigDict(arbitrary_types_allowed=True)
     input_schema: ClassVar[type[MultiFileTypeConverterInputSchema]] = MultiFileTypeConverterInputSchema
 
@@ -153,6 +172,8 @@ class MultiFileTypeConverter(Node):
 
         self._setup_converters()
 
+        self._apply_converter_timeouts()
+
         # Initialize components for converters in the mapping
         initialized_converters = set()
         for converter in self.converter_mapping.values():
@@ -161,6 +182,26 @@ class MultiFileTypeConverter(Node):
                     converter.init_components(connection_manager)
                 initialized_converters.add(id(converter))
                 logger.info(f"Initialized converter: {converter.name}")
+
+    def _apply_converter_timeouts(self):
+        """Apply tiered default execution timeouts to converters that don't have one configured."""
+        if self.fallback_converter is not None:
+            self._set_timeout_if_unset(self.fallback_converter, self.fallback_converter_timeout_seconds)
+
+        for converter in self.converter_mapping.values():
+            if converter is self.fallback_converter:
+                continue
+            if isinstance(converter, (LLMImageConverter, LLMPDFConverter)):
+                timeout_seconds = self.llm_converter_timeout_seconds
+            else:
+                timeout_seconds = self.local_converter_timeout_seconds
+            self._set_timeout_if_unset(converter, timeout_seconds)
+
+    @staticmethod
+    def _set_timeout_if_unset(converter: Node, timeout_seconds: float | None):
+        """Set the converter's execution timeout only when the caller hasn't configured one."""
+        if timeout_seconds is not None and converter.error_handling.timeout_seconds is None:
+            converter.error_handling.timeout_seconds = timeout_seconds
 
     def _setup_converters(self):
         """Setup internal converter components."""

--- a/dynamiq/nodes/converters/pptx.py
+++ b/dynamiq/nodes/converters/pptx.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from dynamiq.components.converters.pptx import PPTXConverter as PPTXConverterComponent
 from dynamiq.connections.managers import ConnectionManager
-from dynamiq.nodes.node import Node, NodeGroup, ensure_config
+from dynamiq.nodes.node import ErrorHandling, Node, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.types import DocumentCreationMode
 from dynamiq.utils.logger import logger
@@ -43,6 +43,10 @@ class PPTXFileConverter(Node):
 
     group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
     name: str = "pptx-file-converter"
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=60.0),
+        description="Default execution timeout. Set timeout_seconds to None to disable.",
+    )
     document_creation_mode: DocumentCreationMode = DocumentCreationMode.ONE_DOC_PER_FILE
     file_converter: PPTXConverterComponent | None = None
     input_schema: ClassVar[type[PPTXFileConverterInputSchema]] = PPTXFileConverterInputSchema

--- a/dynamiq/nodes/converters/pypdf.py
+++ b/dynamiq/nodes/converters/pypdf.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from dynamiq.components.converters.pypdf import DocumentCreationMode, ExtractionMode
 from dynamiq.components.converters.pypdf import PyPDFFileConverter as PyPDFFileConverterComponent
 from dynamiq.connections.managers import ConnectionManager
-from dynamiq.nodes.node import Node, NodeGroup, ensure_config
+from dynamiq.nodes.node import ErrorHandling, Node, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.utils.logger import logger
 
@@ -43,6 +43,10 @@ class PyPDFConverter(Node):
 
     group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
     name: str = "pypdf-file-converter"
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=60.0),
+        description="Default execution timeout. Set timeout_seconds to None to disable.",
+    )
     document_creation_mode: DocumentCreationMode = DocumentCreationMode.ONE_DOC_PER_FILE
     file_converter: PyPDFFileConverterComponent | None = None
     extraction_mode: ExtractionMode = ExtractionMode.PLAIN

--- a/dynamiq/nodes/converters/text.py
+++ b/dynamiq/nodes/converters/text.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from dynamiq.components.converters.text import TextFileConverter as TextFileConverterComponent
 from dynamiq.connections.managers import ConnectionManager
-from dynamiq.nodes.node import Node, NodeGroup, ensure_config
+from dynamiq.nodes.node import ErrorHandling, Node, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.utils.logger import logger
 
@@ -32,6 +32,10 @@ class TextFileConverter(Node):
 
     group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
     name: str = "text-file-converter"
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=60.0),
+        description="Default execution timeout. Set timeout_seconds to None to disable.",
+    )
     file_converter: TextFileConverterComponent | None = None
     input_schema: ClassVar[type[TextFileConverterInputSchema]] = TextFileConverterInputSchema
 

--- a/dynamiq/nodes/converters/unstructured.py
+++ b/dynamiq/nodes/converters/unstructured.py
@@ -7,7 +7,7 @@ from dynamiq.components.converters.unstructured import ConvertStrategy, Document
 from dynamiq.components.converters.unstructured import UnstructuredFileConverter as UnstructuredFileConverterComponent
 from dynamiq.connections import Unstructured
 from dynamiq.connections.managers import ConnectionManager
-from dynamiq.nodes.node import ConnectionNode, NodeGroup, ensure_config
+from dynamiq.nodes.node import ConnectionNode, ErrorHandling, NodeGroup, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.utils.logger import logger
 
@@ -59,6 +59,10 @@ class UnstructuredFileConverter(ConnectionNode):
 
     group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
     name: str = "unstructured-file-converter"
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=300.0),
+        description="Default execution timeout. Set timeout_seconds to None to disable.",
+    )
     connection: Unstructured = None
     document_creation_mode: DocumentCreationMode = DocumentCreationMode.ONE_DOC_PER_FILE
     strategy: ConvertStrategy = ConvertStrategy.AUTO


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default runtime behavior for all converter executions (timeouts where none existed before), which may cause previously slow jobs to fail unless timeouts are overridden or disabled.
> 
> **Overview**
> This PR adds **default execution timeouts** on file converter nodes via `error_handling.timeout_seconds`, so long-running or stuck conversions fail instead of running indefinitely. Timeouts apply when each node is executed (including when `MultiFileTypeConverter` invokes sub-converters via `.run()`).
> 
> **Per-converter defaults:** most local format converters (`DOCX`, `HTML`, `PPTX`, `PyPDF`, `Text`) use **60s**; **LLM image** extraction and **Unstructured** use **300s**. **`MultiFileTypeConverter`** gets a **600s** batch cap (`DEFAULT_TIMEOUT_SECONDS`), with docs noting sub-converters still enforce their own per-file limits. Each field documents setting `timeout_seconds` to **`None`** to disable the timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb535a6ab5f5bb2cb95260650fa42facde4d6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->