### PR TITLE
fix: disable strict for open functions

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -703,7 +703,10 @@ class BaseLLM(ConnectionNode):
             tool = dict(tool)
             fn = tool.get("function")
             eligible = (
-                isinstance(fn, dict) and strict_count < cap and (whitelist is None or fn.get("name") in whitelist)
+                isinstance(fn, dict)
+                and strict_count < cap
+                and (whitelist is None or fn.get("name") in whitelist)
+                and not self._has_open_parameters(fn)
             )
             if eligible:
                 try:
@@ -721,6 +724,18 @@ class BaseLLM(ConnectionNode):
                     strict_count += 1
             out.append(tool)
         return out
+
+    @staticmethod
+    def _has_open_parameters(fn: dict) -> bool:
+        """Whether a tool's top-level parameters declare an open object.
+
+        Strict mode requires ``additionalProperties: false``, so an open tool
+        (e.g. an ``extra="allow"`` Python tool taking arbitrary kwargs) can't
+        be made strict without rendering its real arguments unreachable.
+        :meth:`transform_tool_schemas` skips these and ships them non-strict.
+        """
+        params = fn.get("parameters")
+        return isinstance(params, dict) and params.get("additionalProperties") is True
 
     def _to_strict_function(self, fn: dict) -> dict:
         """Convert one function-tool definition into this provider's strict form.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, targeted change to strict tool gating in BaseLLM with no auth or data-path impact; behavior improves correctness for open-schema tools.
> 
> **Overview**
> When **`strict_tools`** is enabled, **`transform_tool_schemas`** now **skips strict conversion** for tools whose top-level **`parameters`** use an open object schema (`additionalProperties: true`), e.g. Pydantic tools with **`extra="allow"`** that accept arbitrary kwargs.
> 
> A new **`_has_open_parameters`** helper gates eligibility before **`_to_strict_function`** runs, so those tools are sent **non-strict** instead of being forced into a closed schema that would hide real arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f071a8d81f77f0fbeba08f3c3082e247ff9fe54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->