### PR TITLE
fix: fix xml output parsing

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1046,13 +1046,14 @@ class Agent(HistoryManagerMixin, BaseAgent):
         block that fabricates an ``<answer>`` before the tool ran. Keeping only the first block makes
         the agent take the real step and keeps thought/action/answer consistent within one turn.
 
-        The scan treats the content of free-form tags (``action_input``/``thought``/``answer``) as
-        opaque, so tag-like text inside code or JSON (e.g. ``print('</output>')``) cannot be mistaken
-        for a block boundary. The first ``</output>`` reached outside any opaque tag ends the block.
-        Returns ``text`` unchanged when no closing ``</output>`` is present.
+        The scan treats the content of free-form tags
+        (``action_input``/``thought``/``answer``/``output_files``) as opaque, so tag-like text inside
+        code, JSON or a filename (e.g. ``print('</output>')``) cannot be mistaken for a block
+        boundary. The first ``</output>`` reached outside any opaque tag ends the block. Returns
+        ``text`` unchanged when no closing ``</output>`` is present.
         """
-        # Tags whose content is free-form (code/JSON/prose) and may contain </output>-like text.
-        opaque_tags = ("action_input", "thought", "answer")
+        # Tags whose content is free-form (code/JSON/prose/filenames) and may contain </output>-like text.
+        opaque_tags = ("action_input", "thought", "answer", "output_files")
         closing = "</output>"
         i, n = 0, len(text)
         while i < n:

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1037,6 +1037,20 @@ class Agent(HistoryManagerMixin, BaseAgent):
         self.log_reasoning(thought, action, action_input, loop_num)
         return thought, action, action_input
 
+    @staticmethod
+    def _first_output_block(text: str) -> str:
+        """Return only the first complete ``<output>...</output>`` block.
+
+        This re-imposes the one-step-per-turn boundary that the XML stop-sequence used to enforce
+        before it was stripped for reasoning models. If no closing ``</output>`` is present (e.g. the
+        model did not wrap its response), the text is returned unchanged so parsing degrades gracefully.
+        """
+        closing = "</output>"
+        end = text.find(closing)
+        if end == -1:
+            return text
+        return text[: end + len(closing)]
+
     def _handle_xml_mode(
         self, llm_generated_output: str, loop_num: int, config: RunnableConfig, **kwargs
     ) -> tuple[str | None, str | None, dict | list | None]:
@@ -1056,6 +1070,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 ),
             )
             return None, None, None
+
+        # Keep only the first <output>...</output> block, re-imposing the "one step per turn" boundary.
+        llm_generated_output = self._first_output_block(llm_generated_output)
 
         try:
             parsed_data = XMLParser.parse(

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1092,9 +1092,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
             )
             return None, None, None
 
-        # Drop any fabricated trailing <output> blocks so we parse only the real step.
-        llm_generated_output = self._first_output_block(llm_generated_output)
-
         # Parse the action before the answer so a same-turn fabricated <answer> can't make us skip the
         # tool (reasoning models run with `stop` stripped, so they may emit both in one response).
         try:

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -18,7 +18,8 @@ from dynamiq.nodes.agents.exceptions import (
     MaxLoopsExceededException,
     OutputFileNotFoundError,
     ParsingError,
-    RecoverableAgentException
+    RecoverableAgentException,
+    TagNotFoundError,
 )
 from dynamiq.nodes.agents.prompts.manager import AgentPromptManager, ReactPromptConfig
 from dynamiq.nodes.agents.utils import SummarizationConfig, ToolCacheEntry, XMLParser, extract_message_text
@@ -1092,57 +1093,56 @@ class Agent(HistoryManagerMixin, BaseAgent):
             )
             return None, None, None
 
-        # Parse the action before the answer so a same-turn fabricated <answer> can't make us skip the
-        # tool (reasoning models run with `stop` stripped, so they may emit both in one response).
         try:
             parsed_data = XMLParser.parse(
                 llm_generated_output,
-                required_tags=["thought", "action", "action_input"],
-                optional_tags=["output"],
-                json_fields=["action_input"],
+                required_tags=["thought", "answer"],
+                optional_tags=["output", "output_files"],
             )
             thought = parsed_data.get("thought")
-            action = parsed_data.get("action")
-            action_input = parsed_data.get("action_input")
-            self.log_reasoning(thought, action, action_input, loop_num)
-            return thought, action, action_input
+            final_answer = parsed_data.get("answer")
 
-        except JSONParsingError as e:
-            # An <action> was present but its <action_input> was malformed JSON — a real action
-            # attempt, not a final answer. Request a corrected action instead of falling through.
-            logger.error(f"XMLParser: Invalid JSON in action_input: {e}")
-            raise ActionParsingException(
-                "The <action_input> value must be valid JSON. Put the whole JSON on one line; "
-                'use \\n for newlines inside strings and \\" for quotes. '
-                "Provide <thought> with <action> and <action_input> again.",
-                recoverable=True,
-            )
+            self._requested_output_files = self._parse_output_files_csv(parsed_data.get("output_files") or "")
 
-        except ParsingError:
-            # No (parseable) action structure — treat the response as a final answer. TagNotFoundError
-            # is a ParsingError subclass; JSONParsingError is handled above so it never reaches here.
-            logger.debug("XMLParser: No action structure found, trying final-answer structure.")
+            self.log_final_output(thought, final_answer, loop_num)
+            return thought, "final_answer", final_answer
+
+        except TagNotFoundError:
+            logger.debug("XMLParser: Not a final answer structure, trying action structure.")
             try:
                 parsed_data = XMLParser.parse(
                     llm_generated_output,
-                    required_tags=["thought", "answer"],
-                    optional_tags=["output", "output_files"],
+                    required_tags=["thought", "action", "action_input"],
+                    optional_tags=["output"],
+                    json_fields=["action_input"],
                 )
                 thought = parsed_data.get("thought")
-                final_answer = parsed_data.get("answer")
-
-                self._requested_output_files = self._parse_output_files_csv(parsed_data.get("output_files") or "")
-
-                self.log_final_output(thought, final_answer, loop_num)
-                return thought, "final_answer", final_answer
-
+                action = parsed_data.get("action")
+                action_input = parsed_data.get("action_input")
+                self.log_reasoning(thought, action, action_input, loop_num)
+                return thought, action, action_input
+            except JSONParsingError as e:
+                logger.error(f"XMLParser: Invalid JSON in action_input: {e}")
+                raise ActionParsingException(
+                    "The <action_input> value must be valid JSON. Put the whole JSON on one line; "
+                    'use \\n for newlines inside strings and \\" for quotes. '
+                    "Provide <thought> with <action> and <action_input> again.",
+                    recoverable=True,
+                )
             except ParsingError as e:
-                logger.error(f"XMLParser: Empty or invalid XML response: {e}")
+                logger.error(f"XMLParser: Empty or invalid XML response for action parsing: {e}")
                 raise ActionParsingException(
                     "The previous response was empty or invalid. "
                     "Provide <thought> with either <action>/<action_input> or <answer>.",
                     recoverable=True,
                 )
+
+        except ParsingError as e:
+            logger.error(f"XMLParser: Empty or invalid XML response: {e}")
+            raise ActionParsingException(
+                "The previous response was empty or invalid. " "Please provide the required XML tags.",
+                recoverable=True,
+            )
 
     def _setup_stop_sequences(self) -> None:
         """Configure LLM stop sequences based on the current inference mode."""
@@ -1735,6 +1735,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             if first_block != llm_generated_output:
                 logger.warning(
                     f"Agent {self.name} - {self.id}: model emitted more than one <output> block; "
+                    "keeping only the first block and dropping the rest."
                 )
                 llm_generated_output = first_block
         self._last_llm_output = llm_generated_output

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1036,6 +1036,42 @@ class Agent(HistoryManagerMixin, BaseAgent):
         self.log_reasoning(thought, action, action_input, loop_num)
         return thought, action, action_input
 
+    @staticmethod
+    def _first_output_block(text: str) -> str:
+        """Return only the first ``<output>...</output>`` block, dropping any later blocks.
+
+        Reasoning models (OpenAI o-series / gpt-5) run with ``stop`` stripped (the API rejects it), so
+        the XML turn-boundary stop-sequence never fires and the model can emit a second ``<output>``
+        block that fabricates an ``<answer>`` before the tool ran. Keeping only the first block makes
+        the agent take the real step and keeps thought/action/answer consistent within one turn.
+
+        The scan treats the content of free-form tags (``action_input``/``thought``/``answer``) as
+        opaque, so tag-like text inside code or JSON (e.g. ``print('</output>')``) cannot be mistaken
+        for a block boundary. The first ``</output>`` reached outside any opaque tag ends the block.
+        Returns ``text`` unchanged when no closing ``</output>`` is present.
+        """
+        # Tags whose content is free-form (code/JSON/prose) and may contain </output>-like text.
+        opaque_tags = ("action_input", "thought", "answer")
+        closing = "</output>"
+        i, n = 0, len(text)
+        while i < n:
+            matched_opaque = False
+            for tag in opaque_tags:
+                open_tag = f"<{tag}"
+                # Match <tag>, <tag ...> or <tag/>, but not <tagx>; guard against end-of-string.
+                if text.startswith(open_tag, i) and (i + len(open_tag) >= n or text[i + len(open_tag)] in " >/"):
+                    close_tag = f"</{tag}>"
+                    close_idx = text.find(close_tag, i)
+                    i = close_idx + len(close_tag) if close_idx != -1 else n
+                    matched_opaque = True
+                    break
+            if matched_opaque:
+                continue
+            if text.startswith(closing, i):
+                return text[: i + len(closing)]
+            i += 1
+        return text
+
     def _handle_xml_mode(
         self, llm_generated_output: str, loop_num: int, config: RunnableConfig, **kwargs
     ) -> tuple[str | None, str | None, dict | list | None]:
@@ -1055,6 +1091,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 ),
             )
             return None, None, None
+
+        # Drop any fabricated trailing <output> blocks so we parse only the real step.
+        llm_generated_output = self._first_output_block(llm_generated_output)
 
         # Parse the action before the answer so a same-turn fabricated <answer> can't make us skip the
         # tool (reasoning models run with `stop` stripped, so they may emit both in one response).
@@ -1693,6 +1732,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
             llm_generated_output = streaming_callback.accumulated_content
         else:
             llm_generated_output = llm_result.output.get("content", "")
+        if self.inference_mode == InferenceMode.XML and llm_generated_output:
+            # Drop fabricated trailing <output> blocks so history and parsing see only the real step.
+            llm_generated_output = self._first_output_block(llm_generated_output)
         self._last_llm_output = llm_generated_output
 
         llm_reasoning = (

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1731,7 +1731,12 @@ class Agent(HistoryManagerMixin, BaseAgent):
             llm_generated_output = llm_result.output.get("content", "")
         if self.inference_mode == InferenceMode.XML and llm_generated_output:
             # Drop fabricated trailing <output> blocks so history and parsing see only the real step.
-            llm_generated_output = self._first_output_block(llm_generated_output)
+            first_block = self._first_output_block(llm_generated_output)
+            if first_block != llm_generated_output:
+                logger.warning(
+                    f"Agent {self.name} - {self.id}: model emitted more than one <output> block; "
+                )
+                llm_generated_output = first_block
         self._last_llm_output = llm_generated_output
 
         llm_reasoning = (

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -18,8 +18,7 @@ from dynamiq.nodes.agents.exceptions import (
     MaxLoopsExceededException,
     OutputFileNotFoundError,
     ParsingError,
-    RecoverableAgentException,
-    TagNotFoundError,
+    RecoverableAgentException
 )
 from dynamiq.nodes.agents.prompts.manager import AgentPromptManager, ReactPromptConfig
 from dynamiq.nodes.agents.utils import SummarizationConfig, ToolCacheEntry, XMLParser, extract_message_text
@@ -1037,20 +1036,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
         self.log_reasoning(thought, action, action_input, loop_num)
         return thought, action, action_input
 
-    @staticmethod
-    def _first_output_block(text: str) -> str:
-        """Return only the first complete ``<output>...</output>`` block.
-
-        This re-imposes the one-step-per-turn boundary that the XML stop-sequence used to enforce
-        before it was stripped for reasoning models. If no closing ``</output>`` is present (e.g. the
-        model did not wrap its response), the text is returned unchanged so parsing degrades gracefully.
-        """
-        closing = "</output>"
-        end = text.find(closing)
-        if end == -1:
-            return text
-        return text[: end + len(closing)]
-
     def _handle_xml_mode(
         self, llm_generated_output: str, loop_num: int, config: RunnableConfig, **kwargs
     ) -> tuple[str | None, str | None, dict | list | None]:
@@ -1071,61 +1056,57 @@ class Agent(HistoryManagerMixin, BaseAgent):
             )
             return None, None, None
 
-        # Keep only the first <output>...</output> block, re-imposing the "one step per turn" boundary.
-        llm_generated_output = self._first_output_block(llm_generated_output)
-
+        # Parse the action before the answer so a same-turn fabricated <answer> can't make us skip the
+        # tool (reasoning models run with `stop` stripped, so they may emit both in one response).
         try:
             parsed_data = XMLParser.parse(
                 llm_generated_output,
-                required_tags=["thought", "answer"],
-                optional_tags=["output", "output_files"],
+                required_tags=["thought", "action", "action_input"],
+                optional_tags=["output"],
+                json_fields=["action_input"],
             )
             thought = parsed_data.get("thought")
-            final_answer = parsed_data.get("answer")
+            action = parsed_data.get("action")
+            action_input = parsed_data.get("action_input")
+            self.log_reasoning(thought, action, action_input, loop_num)
+            return thought, action, action_input
 
-            self._requested_output_files = self._parse_output_files_csv(
-                parsed_data.get("output_files") or ""
+        except JSONParsingError as e:
+            # An <action> was present but its <action_input> was malformed JSON — a real action
+            # attempt, not a final answer. Request a corrected action instead of falling through.
+            logger.error(f"XMLParser: Invalid JSON in action_input: {e}")
+            raise ActionParsingException(
+                "The <action_input> value must be valid JSON. Put the whole JSON on one line; "
+                'use \\n for newlines inside strings and \\" for quotes. '
+                "Provide <thought> with <action> and <action_input> again.",
+                recoverable=True,
             )
 
-            self.log_final_output(thought, final_answer, loop_num)
-            return thought, "final_answer", final_answer
-
-        except TagNotFoundError:
-            logger.debug("XMLParser: Not a final answer structure, trying action structure.")
+        except ParsingError:
+            # No (parseable) action structure — treat the response as a final answer. TagNotFoundError
+            # is a ParsingError subclass; JSONParsingError is handled above so it never reaches here.
+            logger.debug("XMLParser: No action structure found, trying final-answer structure.")
             try:
                 parsed_data = XMLParser.parse(
                     llm_generated_output,
-                    required_tags=["thought", "action", "action_input"],
-                    optional_tags=["output"],
-                    json_fields=["action_input"],
+                    required_tags=["thought", "answer"],
+                    optional_tags=["output", "output_files"],
                 )
                 thought = parsed_data.get("thought")
-                action = parsed_data.get("action")
-                action_input = parsed_data.get("action_input")
-                self.log_reasoning(thought, action, action_input, loop_num)
-                return thought, action, action_input
-            except JSONParsingError as e:
-                logger.error(f"XMLParser: Invalid JSON in action_input: {e}")
-                raise ActionParsingException(
-                    "The <action_input> value must be valid JSON. Put the whole JSON on one line; "
-                    'use \\n for newlines inside strings and \\" for quotes. '
-                    "Provide <thought> with <action> and <action_input> again.",
-                    recoverable=True,
-                )
+                final_answer = parsed_data.get("answer")
+
+                self._requested_output_files = self._parse_output_files_csv(parsed_data.get("output_files") or "")
+
+                self.log_final_output(thought, final_answer, loop_num)
+                return thought, "final_answer", final_answer
+
             except ParsingError as e:
-                logger.error(f"XMLParser: Empty or invalid XML response for action parsing: {e}")
+                logger.error(f"XMLParser: Empty or invalid XML response: {e}")
                 raise ActionParsingException(
                     "The previous response was empty or invalid. "
                     "Provide <thought> with either <action>/<action_input> or <answer>.",
                     recoverable=True,
                 )
-
-        except ParsingError as e:
-            logger.error(f"XMLParser: Empty or invalid XML response: {e}")
-            raise ActionParsingException(
-                "The previous response was empty or invalid. " "Please provide the required XML tags.",
-                recoverable=True,
-            )
 
     def _setup_stop_sequences(self) -> None:
         """Configure LLM stop sequences based on the current inference mode."""

--- a/tests/integration/nodes/agents/test_agent_methods.py
+++ b/tests/integration/nodes/agents/test_agent_methods.py
@@ -249,17 +249,18 @@ def test_agent_xml_mode_action_and_answer_in_one_response_runs_tool(xml_react_ag
 
     Reasoning models (gpt-5 / o-series) run with `stop` stripped, so the XML turn-boundary
     stop-sequence never fires and the model can emit a valid tool call followed by a second
-    <output> block that fabricates the answer before the tool ran. The agent must parse the action
-    before the answer and execute the tool, ignoring the fabricated final answer.
+    <output> block that fabricates the answer before the tool ran. The agent must keep only the
+    first <output> block: execute the tool, and source thought/action/action_input from that same
+    block so the recorded reasoning matches what ran.
     """
     llm_generated_output = (
         "<output>\n"
-        "    <thought>I will use the tool, as required.</thought>\n"
+        "    <thought>BLOCK1: I will use the tool, as required.</thought>\n"
         "    <action>StringLengthTool</action>\n"
         '    <action_input>{"text":"dsfdfgdsfgfsghfghsddfg"}</action_input>\n'
         "</output>\n"
         "<output>\n"
-        "    <thought>I will answer directly with the result.</thought>\n"
+        "    <thought>BLOCK2: I will answer directly with the result.</thought>\n"
         "    <answer>The length of the string is 21.</answer>\n"
         "</output>"
     )
@@ -271,6 +272,9 @@ def test_agent_xml_mode_action_and_answer_in_one_response_runs_tool(xml_react_ag
     assert action == "StringLengthTool", "the tool action must win over the same-turn fabricated answer"
     assert action != "final_answer"
     assert action_input == {"text": "dsfdfgdsfgfsghfghsddfg"}
+    # thought must come from the SAME block as the action, not the fabricated answer block.
+    assert thought is not None and thought.startswith("BLOCK1")
+    assert "BLOCK2" not in (thought or "")
 
 
 def test_agent_xml_mode_genuine_final_answer_still_returns_answer(xml_react_agent):
@@ -285,6 +289,44 @@ def test_agent_xml_mode_genuine_final_answer_still_returns_answer(xml_react_agen
 
     assert action == "final_answer"
     assert "22" in final_answer
+
+
+def test_agent_xml_mode_dropping_extra_block_preserves_output_in_action_input(xml_react_agent):
+    """A literal </output> inside the first block's action_input must survive dropping a 2nd block.
+
+    The scan treats action_input content as opaque, so an output tag inside code/JSON is kept verbatim
+    while the trailing fabricated-answer block is still discarded and the tool runs.
+    """
+    llm_generated_output = (
+        "<output><thought>Print the closing tag.</thought>"
+        "<action>code-executor</action>"
+        '<action_input>{"python": "print(\'</output>\')"}</action_input></output>'
+        "<output><thought>fabricated</thought><answer>done</answer></output>"
+    )
+
+    thought, action, action_input = xml_react_agent._handle_xml_mode(
+        llm_generated_output=llm_generated_output, loop_num=1, config=RunnableConfig()
+    )
+
+    assert action == "code-executor"
+    assert action_input == {"python": "print('</output>')"}
+
+
+def test_first_output_block_handles_adjacent_output_tags_in_content():
+    """Adjacent </output><output> literally inside action_input content must not be a false boundary."""
+    text = (
+        "<output><action>code-executor</action>"
+        '<action_input>{"python": "print(\'</output><output>\')"}</action_input></output>'
+        "<output><answer>fabricated</answer></output>"
+    )
+    block = Agent._first_output_block(text)
+
+    # The whole first block (incl. the adjacent tags inside the JSON) is kept; the 2nd block is dropped.
+    assert block == (
+        "<output><action>code-executor</action>"
+        '<action_input>{"python": "print(\'</output><output>\')"}</action_input></output>'
+    )
+    assert "fabricated" not in block
 
 
 def test_xmlparser_parse_missing_required_tag():

--- a/tests/integration/nodes/agents/test_agent_methods.py
+++ b/tests/integration/nodes/agents/test_agent_methods.py
@@ -249,8 +249,8 @@ def test_agent_xml_mode_action_and_answer_in_one_response_runs_tool(xml_react_ag
 
     Reasoning models (gpt-5 / o-series) run with `stop` stripped, so the XML turn-boundary
     stop-sequence never fires and the model can emit a valid tool call followed by a second
-    <output> block that fabricates the answer before the tool ran. The agent must keep only the
-    first <output> block and execute the tool, ignoring the fabricated final answer.
+    <output> block that fabricates the answer before the tool ran. The agent must parse the action
+    before the answer and execute the tool, ignoring the fabricated final answer.
     """
     llm_generated_output = (
         "<output>\n"
@@ -285,6 +285,26 @@ def test_agent_xml_mode_genuine_final_answer_still_returns_answer(xml_react_agen
 
     assert action == "final_answer"
     assert "22" in final_answer
+
+
+def test_agent_xml_mode_literal_output_tag_inside_action_input(xml_react_agent):
+    """A literal </output> inside action_input content must not corrupt the tool call.
+
+    Guards against re-introducing any </output> substring slicing: the parser isolates each field
+    by its own tag, so embedded output tags in code/JSON are preserved verbatim.
+    """
+    llm_generated_output = (
+        "<output><thought>Print the closing tag.</thought>"
+        "<action>code-executor</action>"
+        '<action_input>{"python": "print(\'</output>\')"}</action_input></output>'
+    )
+
+    thought, action, action_input = xml_react_agent._handle_xml_mode(
+        llm_generated_output=llm_generated_output, loop_num=1, config=RunnableConfig()
+    )
+
+    assert action == "code-executor"
+    assert action_input == {"python": "print('</output>')"}
 
 
 def test_xmlparser_parse_missing_required_tag():

--- a/tests/integration/nodes/agents/test_agent_methods.py
+++ b/tests/integration/nodes/agents/test_agent_methods.py
@@ -265,6 +265,8 @@ def test_agent_xml_mode_action_and_answer_in_one_response_runs_tool(xml_react_ag
         "</output>"
     )
 
+    # Mirror the run loop: trailing fabricated <output> blocks are dropped before parsing.
+    llm_generated_output = Agent._first_output_block(llm_generated_output)
     thought, action, action_input = xml_react_agent._handle_xml_mode(
         llm_generated_output=llm_generated_output, loop_num=1, config=RunnableConfig()
     )
@@ -291,32 +293,11 @@ def test_agent_xml_mode_genuine_final_answer_still_returns_answer(xml_react_agen
     assert "22" in final_answer
 
 
-def test_agent_xml_mode_dropping_extra_block_preserves_output_in_action_input(xml_react_agent):
-    """A literal </output> inside the first block's action_input must survive dropping a 2nd block.
-
-    The scan treats action_input content as opaque, so an output tag inside code/JSON is kept verbatim
-    while the trailing fabricated-answer block is still discarded and the tool runs.
-    """
-    llm_generated_output = (
-        "<output><thought>Print the closing tag.</thought>"
-        "<action>code-executor</action>"
-        '<action_input>{"python": "print(\'</output>\')"}</action_input></output>'
-        "<output><thought>fabricated</thought><answer>done</answer></output>"
-    )
-
-    thought, action, action_input = xml_react_agent._handle_xml_mode(
-        llm_generated_output=llm_generated_output, loop_num=1, config=RunnableConfig()
-    )
-
-    assert action == "code-executor"
-    assert action_input == {"python": "print('</output>')"}
-
-
 def test_first_output_block_handles_adjacent_output_tags_in_content():
     """Adjacent </output><output> literally inside action_input content must not be a false boundary."""
     text = (
         "<output><action>code-executor</action>"
-        '<action_input>{"python": "print(\'</output><output>\')"}</action_input></output>'
+        '<action_input>{"python": "print(\'<output></output>\')"}</action_input></output>'
         "<output><answer>fabricated</answer></output>"
     )
     block = Agent._first_output_block(text)
@@ -324,7 +305,7 @@ def test_first_output_block_handles_adjacent_output_tags_in_content():
     # The whole first block (incl. the adjacent tags inside the JSON) is kept; the 2nd block is dropped.
     assert block == (
         "<output><action>code-executor</action>"
-        '<action_input>{"python": "print(\'</output><output>\')"}</action_input></output>'
+        '<action_input>{"python": "print(\'<output></output>\')"}</action_input></output>'
     )
     assert "fabricated" not in block
 

--- a/tests/integration/nodes/agents/test_agent_methods.py
+++ b/tests/integration/nodes/agents/test_agent_methods.py
@@ -287,26 +287,6 @@ def test_agent_xml_mode_genuine_final_answer_still_returns_answer(xml_react_agen
     assert "22" in final_answer
 
 
-def test_agent_xml_mode_literal_output_tag_inside_action_input(xml_react_agent):
-    """A literal </output> inside action_input content must not corrupt the tool call.
-
-    Guards against re-introducing any </output> substring slicing: the parser isolates each field
-    by its own tag, so embedded output tags in code/JSON are preserved verbatim.
-    """
-    llm_generated_output = (
-        "<output><thought>Print the closing tag.</thought>"
-        "<action>code-executor</action>"
-        '<action_input>{"python": "print(\'</output>\')"}</action_input></output>'
-    )
-
-    thought, action, action_input = xml_react_agent._handle_xml_mode(
-        llm_generated_output=llm_generated_output, loop_num=1, config=RunnableConfig()
-    )
-
-    assert action == "code-executor"
-    assert action_input == {"python": "print('</output>')"}
-
-
 def test_xmlparser_parse_missing_required_tag():
     text = "<output><thought>OK</thought></output>"
     with pytest.raises(TagNotFoundError, match="Required tag <action> not found"):

--- a/tests/integration/nodes/agents/test_agent_methods.py
+++ b/tests/integration/nodes/agents/test_agent_methods.py
@@ -244,6 +244,49 @@ def test_agent_xml_mode_invalid_action_input_json_is_recoverable(xml_react_agent
     assert excinfo.value.recoverable is True
 
 
+def test_agent_xml_mode_action_and_answer_in_one_response_runs_tool(xml_react_agent):
+    """A response with an <action> AND a premature <answer> must take the action, not the answer.
+
+    Reasoning models (gpt-5 / o-series) run with `stop` stripped, so the XML turn-boundary
+    stop-sequence never fires and the model can emit a valid tool call followed by a second
+    <output> block that fabricates the answer before the tool ran. The agent must keep only the
+    first <output> block and execute the tool, ignoring the fabricated final answer.
+    """
+    llm_generated_output = (
+        "<output>\n"
+        "    <thought>I will use the tool, as required.</thought>\n"
+        "    <action>StringLengthTool</action>\n"
+        '    <action_input>{"text":"dsfdfgdsfgfsghfghsddfg"}</action_input>\n'
+        "</output>\n"
+        "<output>\n"
+        "    <thought>I will answer directly with the result.</thought>\n"
+        "    <answer>The length of the string is 21.</answer>\n"
+        "</output>"
+    )
+
+    thought, action, action_input = xml_react_agent._handle_xml_mode(
+        llm_generated_output=llm_generated_output, loop_num=1, config=RunnableConfig()
+    )
+
+    assert action == "StringLengthTool", "the tool action must win over the same-turn fabricated answer"
+    assert action != "final_answer"
+    assert action_input == {"text": "dsfdfgdsfgfsghfghsddfg"}
+
+
+def test_agent_xml_mode_genuine_final_answer_still_returns_answer(xml_react_agent):
+    """A single <output> block with only a final answer must still be treated as the final answer."""
+    llm_generated_output = (
+        "<output><thought>I have the result.</thought>" "<answer>The length of the string is 22.</answer></output>"
+    )
+
+    thought, action, final_answer = xml_react_agent._handle_xml_mode(
+        llm_generated_output=llm_generated_output, loop_num=1, config=RunnableConfig()
+    )
+
+    assert action == "final_answer"
+    assert "22" in final_answer
+
+
 def test_xmlparser_parse_missing_required_tag():
     text = "<output><thought>OK</thought></output>"
     with pytest.raises(TagNotFoundError, match="Required tag <action> not found"):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core ReAct XML parsing and what gets stored in conversation history; behavior is narrowed with tests but could affect edge cases with malformed or multi-block XML.
> 
> **Overview**
> Fixes XML-mode agents when reasoning models emit **multiple `<output>` blocks** in one turn (e.g. a real tool call, then a fabricated `<answer>`), because `stop` sequences are often stripped for those models.
> 
> Adds **`Agent._first_output_block`**, which keeps only the first `<output>...</output>` segment. Content inside `action_input`, `thought`, `answer`, and `output_files` is treated as opaque so literal `</output>` in JSON or code does not truncate early.
> 
> **`_run_react_llm_step`** applies this trim for XML mode before history append and parsing, with a warning when extra blocks are dropped. Integration tests cover tool-vs-answer precedence, single-block final answers, and false boundaries inside `action_input`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a83daa29be812f4854c60650c007ff4e29e8d170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->