### PR TITLE
feat: improve recovery

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -606,9 +606,29 @@ class Agent(HistoryManagerMixin, BaseAgent):
         error_detail: str,
         extra_guidance: str | None = None,
     ) -> None:
-        """Append a correction instruction to prompt for recoverable agent errors."""
+        """Append a correction instruction to prompt for recoverable agent errors.
+
+        In FUNCTION_CALLING mode with pending tool_call ids the correction is
+        delivered as ``tool`` replies, phrased in an error-result voice — what the
+        failed call "returned" — which suits the tool role better than a directive.
+        Otherwise it is appended as a ``user``-role correction instruction.
+        """
 
         guidance_suffix = f" {extra_guidance.strip()}" if extra_guidance else ""
+
+        pending_ids = getattr(self, "_pending_fc_tool_call_ids", None) or []
+        if self.inference_mode == InferenceMode.FUNCTION_CALLING and pending_ids:
+            tool_error_message = (
+                "Tool call failed: the previous call could not be processed "
+                f"('{error_label}: {error_detail}'). Retry with a valid function call whose "
+                "arguments are well-formed JSON." + guidance_suffix
+            )
+            for tc_id in pending_ids:
+                self._prompt.messages.append(
+                    Message(role=MessageRole.TOOL, content=tool_error_message, tool_call_id=tc_id, static=True)
+                )
+            self._pending_fc_tool_call_ids = []
+            return
 
         correction_message = (
             "Correction Instruction: The previous response could not be parsed due to the "
@@ -616,16 +636,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
             "strictly following the required format, ensuring all tags or labeled sections are "
             "present and correctly structured, and that any JSON content is valid." + guidance_suffix
         )
-
-        pending_ids = getattr(self, "_pending_fc_tool_call_ids", None) or []
-        if self.inference_mode == InferenceMode.FUNCTION_CALLING and pending_ids:
-            for tc_id in pending_ids:
-                self._prompt.messages.append(
-                    Message(role=MessageRole.TOOL, content=correction_message, tool_call_id=tc_id, static=True)
-                )
-            self._pending_fc_tool_call_ids = []
-            return
-
         self._prompt.messages.append(
             Message(role=MessageRole.USER, content=correction_message, static=True)
         )

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -588,16 +588,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
         *,
         error_label: str,
         error_detail: str,
-        llm_generated_output: str | None,
         extra_guidance: str | None = None,
     ) -> None:
         """Append a correction instruction to prompt for recoverable agent errors."""
-
-        error_context = llm_generated_output if llm_generated_output else "No response generated"
-
-        self._prompt.messages.append(
-            Message(role=MessageRole.ASSISTANT, content=f"Previous response:\n{error_context}", static=True)
-        )
 
         guidance_suffix = f" {extra_guidance.strip()}" if extra_guidance else ""
 
@@ -607,6 +600,15 @@ class Agent(HistoryManagerMixin, BaseAgent):
             "strictly following the required format, ensuring all tags or labeled sections are "
             "present and correctly structured, and that any JSON content is valid." + guidance_suffix
         )
+
+        pending_ids = getattr(self, "_pending_fc_tool_call_ids", None) or []
+        if self.inference_mode == InferenceMode.FUNCTION_CALLING and pending_ids:
+            for tc_id in pending_ids:
+                self._prompt.messages.append(
+                    Message(role=MessageRole.TOOL, content=correction_message, tool_call_id=tc_id, static=True)
+                )
+            self._pending_fc_tool_call_ids = []
+            return
 
         self._prompt.messages.append(
             Message(role=MessageRole.USER, content=correction_message, static=True)
@@ -865,7 +867,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
             self._append_recovery_instruction(
                 error_label="EmptyResponse",
                 error_detail="The model returned an empty reply while using the Thought/Action format.",
-                llm_generated_output=llm_generated_output,
                 extra_guidance=(
                     "Re-evaluate the latest observation and respond with 'Thought:' followed by either "
                     "an 'Action:' plus JSON 'Action Input:' or a final 'Answer:' section."
@@ -1048,7 +1049,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
             self._append_recovery_instruction(
                 error_label="EmptyResponse",
                 error_detail="The model returned an empty reply while XML format was required.",
-                llm_generated_output=llm_generated_output,
                 extra_guidance=(
                     "Respond with <thought>...</thought> and "
                     "either <action>/<action_input> or <answer> tags, "
@@ -1838,7 +1838,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 self._append_recovery_instruction(
                     error_label=type(e).__name__,
                     error_detail=str(e),
-                    llm_generated_output=self._last_llm_output,
                     extra_guidance=(
                         "The response format is correct, but some files could not be found. "
                         "Please create the missing files or correct the file paths, "
@@ -1851,7 +1850,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 self._append_recovery_instruction(
                     error_label=type(e).__name__,
                     error_detail=str(e),
-                    llm_generated_output=self._last_llm_output,
                     extra_guidance=(
                         "Your final answer must be valid JSON that conforms exactly to the declared "
                         "response_format schema. Return only the JSON document — no prose, Markdown, "
@@ -1885,7 +1883,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 self._append_recovery_instruction(
                     error_label=type(e).__name__,
                     error_detail=str(e),
-                    llm_generated_output=self._last_llm_output,
                     extra_guidance=extra_guidance,
                 )
                 continue

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -940,7 +940,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
         action = first_call.function.name.strip()
 
         if action == "provide_final_answer":
-            self._acknowledge_pending_fc_tool_calls("Skipped — a final answer was provided instead.")
+            self._acknowledge_pending_fc_tool_calls("Skipped — superseded by a final-answer call.")
             final_args = first_call.function.parse_as_final_answer()
             thought = final_args.thought
             self._requested_output_files = self._parse_output_files_csv(final_args.output_files)

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -583,6 +583,22 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
         return self
 
+    def _acknowledge_pending_fc_tool_calls(self, content: str) -> None:
+        """Answer and clear any pending FC tool_call ids with a neutral stub.
+
+        Keeps OpenAI's function-calling protocol valid when tool calls are
+        abandoned without execution (e.g. the model returned ``provide_final_answer``
+        alongside other tool calls), so no unpaired ``tool_call`` is left to 400 a
+        subsequent request and recovery for unrelated errors is not misdirected to
+        these ids.
+        """
+        pending_ids = getattr(self, "_pending_fc_tool_call_ids", None) or []
+        for tc_id in pending_ids:
+            self._prompt.messages.append(
+                Message(role=MessageRole.TOOL, content=content, tool_call_id=tc_id, static=True)
+            )
+        self._pending_fc_tool_call_ids = []
+
     def _append_recovery_instruction(
         self,
         *,
@@ -924,6 +940,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
         action = first_call.function.name.strip()
 
         if action == "provide_final_answer":
+            self._acknowledge_pending_fc_tool_calls("Skipped — a final answer was provided instead.")
             final_args = first_call.function.parse_as_final_answer()
             thought = final_args.thought
             self._requested_output_files = self._parse_output_files_csv(final_args.output_files)

--- a/tests/integration/cancellation/test_agent_cancellation_fc_memory.py
+++ b/tests/integration/cancellation/test_agent_cancellation_fc_memory.py
@@ -129,7 +129,7 @@ def test_fc_agent_recovers_when_tool_call_arguments_are_malformed_json():
     """FC mode: LLM emits a tool_call whose ``arguments`` string is not valid JSON.
 
     ``FunctionCall.parse_arguments`` raises ValueError → wrapped as
-    ActionParsingException → the agent appends a Correction Instruction reply.
+    ActionParsingException → the agent appends a "Tool call failed" recovery reply.
     Under the canonical-state FC policy the malformed assistant ``tool_call`` is
     kept in history, so the correction is delivered as a TOOL message replying
     to that ``tool_call_id`` (a USER message would orphan the tool_call), and the
@@ -201,9 +201,7 @@ def test_fc_agent_recovers_when_tool_call_arguments_are_malformed_json():
         assert result.status == RunnableStatus.SUCCESS
 
     recovery = [
-        m
-        for m in agent._prompt.messages
-        if m.role == MessageRole.TOOL and "Correction Instruction" in (m.content or "")
+        m for m in agent._prompt.messages if m.role == MessageRole.TOOL and "Tool call failed" in (m.content or "")
     ]
     assert recovery, "no recovery instruction added for malformed tool_call arguments"
     assert "ActionParsingException" in recovery[-1].content

--- a/tests/integration/cancellation/test_agent_cancellation_fc_memory.py
+++ b/tests/integration/cancellation/test_agent_cancellation_fc_memory.py
@@ -129,8 +129,11 @@ def test_fc_agent_recovers_when_tool_call_arguments_are_malformed_json():
     """FC mode: LLM emits a tool_call whose ``arguments`` string is not valid JSON.
 
     ``FunctionCall.parse_arguments`` raises ValueError → wrapped as
-    ActionParsingException → the agent appends a Correction Instruction user
-    message and recovers on the next loop.
+    ActionParsingException → the agent appends a Correction Instruction reply.
+    Under the canonical-state FC policy the malformed assistant ``tool_call`` is
+    kept in history, so the correction is delivered as a TOOL message replying
+    to that ``tool_call_id`` (a USER message would orphan the tool_call), and the
+    agent recovers on the next loop.
     """
     conn = connections.OpenAI(id="fake-conn", api_key="fake-key")
     llm = OpenAI(
@@ -200,7 +203,10 @@ def test_fc_agent_recovers_when_tool_call_arguments_are_malformed_json():
     recovery = [
         m
         for m in agent._prompt.messages
-        if m.role == MessageRole.USER and "Correction Instruction" in (m.content or "")
+        if m.role == MessageRole.TOOL and "Correction Instruction" in (m.content or "")
     ]
     assert recovery, "no recovery instruction added for malformed tool_call arguments"
     assert "ActionParsingException" in recovery[-1].content
+    # Canonical-state policy: the correction replies to the malformed tool_call's id
+    # so no orphan tool_call is left in history.
+    assert recovery[-1].tool_call_id == "call_bad"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes prompt/history shaping in FUNCTION_CALLING mode during parse failures and final-answer paths; incorrect pairing could still break LLM APIs or mis-route retries, though scope is limited to agent recovery logic.
> 
> **Overview**
> Improves **function-calling (FC) error recovery** so conversation history stays valid under OpenAI’s tool protocol when parsing fails or a turn ends without executing every `tool_call`.
> 
> **Recovery path:** `_append_recovery_instruction` no longer echoes the prior assistant output as a static USER/ASSISTANT correction. In FC mode when `_pending_fc_tool_call_ids` is set, it appends **TOOL** messages (per id) with a “Tool call failed…” payload and optional guidance, then clears the pending list. Other inference modes still get the USER “Correction Instruction” message.
> 
> **Final answer with leftover calls:** New `_acknowledge_pending_fc_tool_calls` stubs any still-pending tool calls with neutral TOOL replies before handling `provide_final_answer`, avoiding orphan `tool_call`s that could 400 the next request.
> 
> Integration test updated to expect TOOL recovery (including `tool_call_id` on malformed JSON arguments) instead of USER correction text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420e38223068998ec0dc3a68d58d4fcbd3284bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->