### PR TITLE
fix: handle empty file name in FileTypeExtractor

### DIFF
--- a/dynamiq/nodes/extractors/extractors.py
+++ b/dynamiq/nodes/extractors/extractors.py
@@ -209,9 +209,9 @@ class FileTypeExtractor(Node):
         file = input_data.file
         filename = input_data.filename
         try:
-            filename = getattr(file, "name", filename) if file else filename
+            filename = (getattr(file, "name", None) or filename) if file else filename
             if not filename:
-                raise ValueError("Invalid filename provided.")
+                return {"type": None}
             file_ext = filename.split(".")[-1] if "." in filename else ""
             file_ext = file_ext.lower()
 

--- a/tests/integration/nodes/extractors/test_extractors.py
+++ b/tests/integration/nodes/extractors/test_extractors.py
@@ -97,6 +97,9 @@ def create_bytesio_with_name(content, name):
         (None, create_bytesio_with_name(b"executable content", "test.exe"), "executable"),
         (None, create_bytesio_with_name(b"ebook content", "test.epub"), "ebook"),
         (None, create_bytesio_with_name(b"unknown content", "unknownfile.xyz"), None),
+        ("file_0", create_bytesio_with_name(b"content", ""), None),
+        (None, create_bytesio_with_name(b"content", ""), None),
+        ("", None, None),
     ],
 )
 def test_workflow_with_file_type_extraction(filename, file, result):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is limited to invalid/empty filename inputs; normal extension detection is unchanged and failures are softened rather than broadened.
> 
> **Overview**
> **`FileTypeExtractor`** no longer raises when the resolved filename is missing or empty. It returns `{"type": None}` instead, so workflows can treat “unknown type” without failing.
> 
> Filename resolution now treats an empty `file.name` as absent and falls back to the input `filename` via `(getattr(file, "name", None) or filename)`.
> 
> Integration tests cover empty `filename`, empty `BytesIO.name`, and the case where a non-empty `filename` is paired with a file whose name is `""`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit badd002b9ae7c438c9d43a66b4fd7ba18fceb7d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->