### PR TITLE
fix: fix history aggregation

### DIFF
--- a/dynamiq/nodes/agents/components/history_manager.py
+++ b/dynamiq/nodes/agents/components/history_manager.py
@@ -139,15 +139,12 @@ class HistoryManagerMixin:
                         history += content.text
             else:
                 if message.role == MessageRole.ASSISTANT:
-                    # FUNCTION_CALLING content is just a "Calling: <tool>" stub;
-                    # the name + args live in tool_calls.
                     history += f"-TOOL DESCRIPTION START-\n{message.content}\n"
                     for tool_call in message.tool_calls or []:
                         fn = tool_call.get("function", {})
                         history += f"Tool: {fn.get('name', '')}\nArguments: {fn.get('arguments', '')}\n"
                     history += "-TOOL DESCRIPTION END-\n"
                 elif message.role in (MessageRole.USER, MessageRole.TOOL):
-                    # Tool results: TOOL role in FUNCTION_CALLING, USER in XML/ReAct.
                     history += f"-TOOL OUTPUT START-\n{message.content}\n-TOOL OUTPUT END-\n"
 
         return history

--- a/dynamiq/nodes/agents/components/history_manager.py
+++ b/dynamiq/nodes/agents/components/history_manager.py
@@ -139,8 +139,15 @@ class HistoryManagerMixin:
                         history += content.text
             else:
                 if message.role == MessageRole.ASSISTANT:
-                    history += f"-TOOL DESCRIPTION START-\n{message.content}\n-TOOL DESCRIPTION END-\n"
-                elif message.role == MessageRole.USER:
+                    # FUNCTION_CALLING content is just a "Calling: <tool>" stub;
+                    # the name + args live in tool_calls.
+                    history += f"-TOOL DESCRIPTION START-\n{message.content}\n"
+                    for tool_call in message.tool_calls or []:
+                        fn = tool_call.get("function", {})
+                        history += f"Tool: {fn.get('name', '')}\nArguments: {fn.get('arguments', '')}\n"
+                    history += "-TOOL DESCRIPTION END-\n"
+                elif message.role in (MessageRole.USER, MessageRole.TOOL):
+                    # Tool results: TOOL role in FUNCTION_CALLING, USER in XML/ReAct.
                     history += f"-TOOL OUTPUT START-\n{message.content}\n-TOOL OUTPUT END-\n"
 
         return history

--- a/tests/integration_with_creds/agents/test_agent_python_tool.py
+++ b/tests/integration_with_creds/agents/test_agent_python_tool.py
@@ -212,7 +212,7 @@ def llm_instance():
     connection = OpenAIConnection()
     llm = OpenAI(
         connection=connection,
-        model="gpt-5.4-mini",
+        model="gpt-4o",
         max_tokens=5000,
         temperature=0,
     )

--- a/tests/unit/nodes/agents/test_history_manager.py
+++ b/tests/unit/nodes/agents/test_history_manager.py
@@ -343,3 +343,55 @@ class TestSplitHistoryFCSafety:
 
         for m in to_preserve:
             assert m.role != MessageRole.TOOL
+
+
+class TestAggregateHistory:
+    """aggregate_history flattens structured history into a readable transcript.
+
+    The max-loops recovery path is the sole caller; it must surface both the
+    agent's tool calls (with arguments) and the tool outputs, including the
+    FUNCTION_CALLING case where results are TOOL-role messages.
+    """
+
+    def test_function_calling_tool_output_included(self):
+        msgs = [
+            _assistant_tc(
+                "Calling: semantic_search",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "semantic_search", "arguments": '{"query": "apple"}'},
+                    }
+                ],
+            ),
+            _tool_reply("Apple is a fruit and a company.", "call_1", "semantic_search"),
+        ]
+
+        history = HistoryManagerMixin.aggregate_history(msgs)
+
+        # TOOL-role result must appear (the original bug dropped it entirely).
+        assert "-TOOL OUTPUT START-" in history
+        assert "Apple is a fruit and a company." in history
+        # Tool call name + arguments must be surfaced from tool_calls.
+        assert "semantic_search" in history
+        assert '{"query": "apple"}' in history
+
+    def test_xml_user_observation_still_rendered(self):
+        msgs = [
+            _assistant("Thought: I should search."),
+            _user("Observation: result text"),
+        ]
+
+        history = HistoryManagerMixin.aggregate_history(msgs)
+
+        assert "-TOOL DESCRIPTION START-" in history
+        assert "Thought: I should search." in history
+        assert "-TOOL OUTPUT START-" in history
+        assert "Observation: result text" in history
+
+    def test_assistant_without_tool_calls_has_no_arguments_line(self):
+        history = HistoryManagerMixin.aggregate_history([_assistant("Calling: nothing")])
+
+        assert "-TOOL DESCRIPTION START-" in history
+        assert "Arguments:" not in history


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized change to history string formatting for max-loops recovery, with unit coverage; no auth or data-path changes.
> 
> **Overview**
> **Fixes agent history flattening** for the max-loops recovery path, where `aggregate_history` builds a transcript from the prompt.
> 
> Assistant messages now append each entry in `tool_calls` as **Tool** name and **Arguments** before closing the tool-description block. **TOOL**-role messages are treated like user observations and rendered inside `-TOOL OUTPUT START-` / `-TOOL OUTPUT END-`, so function-calling tool results are no longer dropped from the aggregated string.
> 
> New unit tests cover function-calling tool output, XML-style user observations, and assistants without `tool_calls`. The credentialed Python-tool integration fixture switches the LLM model from `gpt-5.4-mini` to `gpt-4o`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5fc6f52c714d95dcc0a3df11183337f061b502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->