### PR TITLE
fix: resolve MCP server to its tool when used inside a Map node

### DIFF
--- a/dynamiq/nodes/operators/operators.py
+++ b/dynamiq/nodes/operators/operators.py
@@ -234,7 +234,7 @@ class Map(Node):
         local_config = config
         try:
             local_config = config.model_copy(deep=False) if config is not None else RunnableConfig()
-            if node_config := local_config.nodes_override.get(node.id):
+            if node_config := local_config.nodes_override.get(self.node.id):
                 local_config.nodes_override[node_copy.id] = node_config
         except Exception as e:
             logger.warning(f"Map: failed to prepare isolated streaming config for iteration {index}: {e}")
@@ -269,7 +269,7 @@ class Map(Node):
         merged_kwargs = {**kwargs, "parent_run_id": run_id}
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
-        # Resolve an MCPServer it to its single MCPTool.
+        # Resolve an MCPServer to its single MCPTool.
         run_node = resolve_mcp_node(self.node)
 
         try:

--- a/dynamiq/nodes/operators/operators.py
+++ b/dynamiq/nodes/operators/operators.py
@@ -9,6 +9,7 @@ import dynamiq.utils.jsonpath as jsonpath
 from dynamiq.executors.context import ContextAwareThreadPoolExecutor
 from dynamiq.nodes import Behavior, Node, NodeGroup
 from dynamiq.nodes.node import Transformer, ensure_config
+from dynamiq.nodes.tools.mcp import resolve_mcp_node
 from dynamiq.nodes.types import ChoiceCondition, ConditionOperator
 from dynamiq.runnables import RunnableConfig, RunnableResult, RunnableStatus
 from dynamiq.types.cancellation import CanceledException, check_cancellation
@@ -224,16 +225,16 @@ class Map(Node):
         """Clean up resources created during dry run."""
         self.node.dry_run_cleanup(dry_run_config)
 
-    def execute_workflow(self, index, data, config, merged_kwargs):
+    def execute_workflow(self, index, data, config, merged_kwargs, node):
         """Execute a single workflow and handle errors."""
-        node_copy = self.node.clone()
+        node_copy = node.clone()
         node_copy = self.regenerate_ids(node_copy)
 
         # Create an isolated config per iteration with unique streaming override for the cloned node
         local_config = config
         try:
             local_config = config.model_copy(deep=False) if config is not None else RunnableConfig()
-            if node_config := local_config.nodes_override.get(self.node.id):
+            if node_config := local_config.nodes_override.get(node.id):
                 local_config.nodes_override[node_copy.id] = node_config
         except Exception as e:
             logger.warning(f"Map: failed to prepare isolated streaming config for iteration {index}: {e}")
@@ -268,12 +269,15 @@ class Map(Node):
         merged_kwargs = {**kwargs, "parent_run_id": run_id}
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
+        # Resolve an MCPServer it to its single MCPTool.
+        run_node = resolve_mcp_node(self.node)
+
         try:
             check_cancellation(config)
             with ContextAwareThreadPoolExecutor(max_workers=self.max_workers) as executor:
                 results = list(
                     executor.map(
-                        lambda args: self.execute_workflow(args[0], args[1], config, merged_kwargs),
+                        lambda args: self.execute_workflow(args[0], args[1], config, merged_kwargs, run_node),
                         enumerate(input_data),
                     )
                 )

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -596,3 +596,33 @@ Usage Strategy:
             NotImplementedError: Always, because this method is not supported.
         """
         raise NotImplementedError("Use `get_mcp_tools()` to access individual tool instances.")
+
+
+def resolve_mcp_node(node):
+    """Resolve an MCPServer wrapper to its single runnable MCPTool.
+
+    An MCPServer is a discovery wrapper whose execute() is disabled, so operators that wrap and
+    run a single child node (e.g. Map) must resolve it to the individual tool first. Non-MCPServer
+    nodes pass through unchanged.
+
+    Args:
+        node: The wrapped node to resolve.
+
+    Returns:
+        The runnable node: the single MCPTool for an MCPServer, or node itself otherwise.
+
+    Raises:
+        ValueError: If the MCPServer does not resolve to exactly one tool.
+    """
+    if not isinstance(node, MCPServer):
+        return node
+
+    tools = node.get_mcp_tools()
+    if len(tools) == 1:
+        return tools[0]
+
+    selected = ", ".join(tool.name for tool in tools) or "none"
+    raise ValueError(
+        f"MCP server '{node.name}' resolved to {len(tools)} tools ({selected}); operators run one node "
+        f"per item, so select exactly one tool via `include_tools` to use it inside an operator."
+    )

--- a/tests/integration/nodes/tools/test_mcp_tool.py
+++ b/tests/integration/nodes/tools/test_mcp_tool.py
@@ -590,3 +590,35 @@ async def test_initialize_tools_unwraps_nested_exception_group(sse_server_connec
     assert "TimeoutError" in message
     assert "handshake timed out" in message
     assert "unhandled errors in a TaskGroup" not in message
+
+
+def test_map_node_resolves_mcp_server_to_single_tool(sse_server_connection, mock_mcp_tools):
+    """A Map wrapping an MCPServer that selects one tool must run that tool, not the disabled server."""
+    from dynamiq.nodes.operators import Map
+    from dynamiq.runnables import RunnableStatus
+
+    mcp_server = MCPServer(connection=sse_server_connection, include_tools=["multiply"])
+    mcp_server._mcp_tools = mock_mcp_tools
+
+    map_node = Map(node=mcp_server)
+    mocked_result = {"content": {"result": 42}}
+    with patch.object(MCPTool, "execute_async", new_callable=AsyncMock, return_value=mocked_result):
+        result = map_node.run(input_data={"input": [{"a": 2, "b": 3}, {"a": 4, "b": 5}]})
+
+    assert result.status == RunnableStatus.SUCCESS
+    assert result.output == {"output": [mocked_result, mocked_result]}
+
+
+def test_map_node_errors_when_mcp_server_resolves_to_multiple_tools(sse_server_connection, mock_mcp_tools):
+    """Map runs one node per item, so an ambiguous MCPServer (>1 tool) must fail with a clear message."""
+    from dynamiq.nodes.operators import Map
+    from dynamiq.runnables import RunnableStatus
+
+    mcp_server = MCPServer(connection=sse_server_connection)  # no include_tools -> all 3 tools
+    mcp_server._mcp_tools = mock_mcp_tools
+
+    map_node = Map(node=mcp_server)
+    result = map_node.run(input_data={"input": [{"a": 2, "b": 3}]})
+
+    assert result.status == RunnableStatus.FAILURE
+    assert "exactly one tool" in str(result.error).lower()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized operator/MCP wiring with explicit validation; no auth or data-path changes.
> 
> **Overview**
> **Map** nodes can now use an **`MCPServer`** as the child node instead of failing on the server’s disabled `execute()`.
> 
> Before each mapped run, **`resolve_mcp_node`** turns an **`MCPServer`** into its single **`MCPTool`** (respecting `include_tools` / filtering); other node types are unchanged. If more than one tool is available, execution fails with a **`ValueError`** that tells users to narrow selection via **`include_tools`**.
> 
> Integration tests cover successful batch runs with one selected tool and failure when the server exposes multiple tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c36466ce5f2017fcf1e325eb68e9be910c3e608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->