### PR TITLE
fix: remove excessive metadata

### DIFF
--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -541,10 +541,6 @@ class Agent(AgentIterativeCheckpointMixin, Node):
         """
         custom_metadata = input_data.metadata.copy()
 
-        # Add extra fields that were provided (model allows extra fields with ConfigDict extra="allow")
-        if input_data.model_extra:
-            custom_metadata.update(input_data.model_extra)
-
         # Clean up any leaked fields
         if "files" in custom_metadata:
             del custom_metadata["files"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes what is stored in memory and propagated to sub-agents; callers who relied on extra input fields in metadata will see different behavior.
> 
> **Overview**
> Stops merging Pydantic **extra** fields from `AgentInputSchema` into the metadata dict built in `_prepare_metadata`.
> 
> Agent runs still copy `input_data.metadata`, strip leaked keys (`files`, `images`, `tool_params`), and add `user_id` / `session_id` when set. Arbitrary extra input properties are no longer folded into metadata used for `_current_call_context`, memory saves, and child-agent context. Extra fields continue to be available for prompt templating via `model_dump(exclude=standard_fields)` in `execute()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca34043abedf21f09a710425e50f3e58e6d6b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->