### PR TITLE
feat: smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -1,4 +1,4 @@
-name: Integration Tests With Creds
+name: Smoke Tests
 
 on:
   workflow_dispatch:
@@ -6,11 +6,11 @@ on:
     types: [labeled]
 
 jobs:
-  integration-tests-with-creds:
-    name: Integration Tests With Creds
+  smoke-tests:
+    name: Smoke Tests
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.label.name == 'run-integration-tests-with-creds' &&
+      (github.event.label.name == 'run-smoke-tests' &&
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
@@ -24,14 +24,8 @@ jobs:
         uses: SpicyPizza/create-envfile@v2.0
         with:
           envkey_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          envkey_UNSTRUCTURED_API_KEY: ${{ secrets.UNSTRUCTURED_API_KEY }}
-          envkey_PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          envkey_PINECONE_CLOUD: ${{ secrets.PINECONE_CLOUD }}
-          envkey_PINECONE_REGION: ${{ secrets.PINECONE_REGION }}
           envkey_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           envkey_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          envkey_QDRANT_URL: ${{ secrets.QDRANT_URL }}
-          envkey_QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
           envkey_EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
           envkey_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -47,5 +41,5 @@ jobs:
             *.cache-to=type=gha,mode=max
           targets: dynamiq-app-test
 
-      - name: Run integration tests with creds
-        run: docker compose up dynamiq-app-test-integration-with-creds --exit-code-from dynamiq-app-test-integration-with-creds
+      - name: Run smoke tests
+        run: docker compose up dynamiq-app-test-smoke --exit-code-from dynamiq-app-test-smoke

--- a/Makefile
+++ b/Makefile
@@ -29,20 +29,26 @@ test-integration:
 	pytest tests/integration
 
 test-integration-with-creds:
-	pytest tests/integration_with_creds
+	pytest tests/integration_with_creds -m "not smoke"
+
+# Smoke tests: slow, paid end-to-end production scenarios. Excluded from every default target and
+# run ONLY here (gated behind the `run-smoke-tests` PR label in CI). -n auto parallelizes the
+# matrix; if E2B quota / provider 429s appear, dial back to `-n 4` or group same-provider cases.
+test-smoke:
+	pytest tests -m smoke -n auto --dist worksteal
 
 test-exclude-integration-with-creds:
-	pytest tests --ignore=tests/integration_with_creds
+	pytest tests --ignore=tests/integration_with_creds -m "not smoke"
 
 test-unit:
 	pytest tests/unit
 
 test:
-	pytest tests
+	pytest tests -m "not smoke"
 
 test-cov:
 	mkdir -p ./reports
-	coverage run -m pytest --junitxml=./reports/test-results.xml tests
+	coverage run -m pytest --junitxml=./reports/test-results.xml -m "not smoke" tests
 	coverage report --skip-empty --skip-covered
 	coverage html -d ./reports/htmlcov --omit="*/test_*,*/tests.py"
 	coverage xml -o ./reports/coverage.xml --omit="*/test_*,*/tests.py"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,3 +48,13 @@ services:
       - .env
     volumes:
       - ./:/app
+
+  dynamiq-app-test-smoke:
+    image: dynamiq-app:${IMAGE_TAG:-local}
+    build:
+      target: develop
+    entrypoint: ["make", "test-smoke"]
+    env_file:
+      - .env
+    volumes:
+      - ./:/app

--- a/poetry.lock
+++ b/poetry.lock
@@ -1973,6 +1973,20 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "fakeredis"
 version = "2.21.3"
 description = "Python implementation of redis API, can be used for testing purposes."
@@ -7767,6 +7781,40 @@ packaging = ">=17.1"
 pytest = ">=7.4,<8.2.2 || >8.2.2"
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -10584,4 +10632,4 @@ monty = ["pydantic-monty"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "272606fe6c63f19b81a9c16859e6c980fd9461f3d10e7691045362dd729455ef"
+content-hash = "bb96d8ccba57a49afca3337f204d632f32a15362c0df8583eb91484c646cdebb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ mkdocs-autorefs = "<1.4.0"
 griffe = "<2.0.0"
 requests-mock = "~1.12.1"
 pytest-rerunfailures = "^16.1"
+pytest-xdist = "^3.8.0"
+pytest-timeout = "^2.4.0"
 
 [tool.poetry.group.examples]
 optional = true
@@ -139,6 +141,13 @@ exclude_dirs = ["tests"]
 
 [tool.isort]
 line_length = 120
+
+[tool.pytest.ini_options]
+markers = [
+    "smoke: slow, paid end-to-end production-scenario tests; run only via the `run-smoke-tests` label / `make test-smoke`",
+    "integration: tests that exercise real integrations (may require credentials)",
+    "unit: fast, isolated unit tests",
+]
 
 [tool.poetry.scripts]
 dynamiq = "dynamiq.cli:main"

--- a/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
+++ b/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
@@ -198,4 +198,6 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
 
         logger.info(f"--- E2E hard workflow passed clean (no recovery) for {provider}/{inference_mode.value} ---")
     finally:
-        sandbox_backend.close()
+        # kill=True terminates the remote sandbox; close() alone only disconnects and would
+        # leave it alive (1h timeout), piling up live sandboxes across the parallel matrix.
+        sandbox_backend.close(kill=True)

--- a/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
+++ b/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
@@ -1,0 +1,211 @@
+"""End-to-end "hard workflow" test across the provider x inference-mode matrix.
+
+A single agent researches on the web (Exa), builds a small website + Flask backend, and
+verifies it in an E2B sandbox. We assert the task finishes WITHOUT triggering recovery
+(the agent loop's correction on a parse/tool-call failure), detected two ways: scanning
+``agent._prompt.messages`` for recovery markers, and checking the ALL-mode stream for a
+``tool_input_error`` event.
+
+Per-provider creds (OPENAI/ANTHROPIC/GEMINI/AWS) plus EXA_API_KEY and E2B_API_KEY are
+required; combos with missing creds are skipped.
+"""
+
+import os
+
+import pytest
+
+from dynamiq import Workflow
+from dynamiq.callbacks.streaming import StreamingIteratorCallbackHandler
+from dynamiq.connections import AWS as AWSConnection
+from dynamiq.connections import E2B as E2BConnection
+from dynamiq.connections import Anthropic as AnthropicConnection
+from dynamiq.connections import Exa as ExaConnection
+from dynamiq.connections import Gemini as GeminiConnection
+from dynamiq.connections import OpenAI as OpenAIConnection
+from dynamiq.flows import Flow
+from dynamiq.nodes.agents import Agent
+from dynamiq.nodes.llms import Anthropic, Bedrock, Gemini, OpenAI
+from dynamiq.nodes.tools.exa_search import ExaTool
+from dynamiq.nodes.types import InferenceMode
+from dynamiq.prompts import MessageRole
+from dynamiq.runnables import RunnableConfig, RunnableStatus
+from dynamiq.sandboxes import SandboxConfig
+from dynamiq.sandboxes.e2b import E2BSandbox
+from dynamiq.types.streaming import StreamingConfig, StreamingMode
+from dynamiq.utils.logger import logger
+
+from .streaming_assertions import assert_streaming_events, collect_streaming_events
+
+# ---------------------------------------------------------------------------
+# Provider matrix -- one representative model each (full model sweeps live in
+# test_agent_llms.py). Each entry: required env vars + an LLM factory.
+# ---------------------------------------------------------------------------
+
+COMMON_LLM_KWARGS = dict(max_tokens=20000, temperature=0)
+
+
+def _openai_llm():
+    return OpenAI(connection=OpenAIConnection(), model="gpt-4.1", **COMMON_LLM_KWARGS)
+
+
+def _anthropic_llm():
+    return Anthropic(connection=AnthropicConnection(), model="claude-sonnet-4-5", **COMMON_LLM_KWARGS)
+
+
+def _gemini_llm():
+    return Gemini(connection=GeminiConnection(), model="gemini-2.5-pro", **COMMON_LLM_KWARGS)
+
+
+def _bedrock_llm():
+    # Claude Sonnet 4.6 via a US cross-region inference profile; adjust the region prefix
+    # (us./eu./apac.) to one enabled on the target AWS account.
+    return Bedrock(
+        connection=AWSConnection(),
+        model="bedrock/us.anthropic.claude-sonnet-4-6",
+        **COMMON_LLM_KWARGS,
+    )
+
+
+PROVIDERS = {
+    "openai": (["OPENAI_API_KEY"], _openai_llm),
+    "anthropic": (["ANTHROPIC_API_KEY"], _anthropic_llm),
+    "gemini": (["GEMINI_API_KEY"], _gemini_llm),
+    "bedrock": (["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"], _bedrock_llm),
+}
+
+INFERENCE_MODES = [
+    InferenceMode.XML,
+    InferenceMode.STRUCTURED_OUTPUT,
+    InferenceMode.FUNCTION_CALLING
+]
+INFERENCE_MODE_IDS = ["xml", "structured_output", "function_calling"]
+
+# Tool creds required for every combo regardless of provider.
+TOOL_ENV_KEYS = ["EXA_API_KEY", "E2B_API_KEY"]
+
+HARD_TASK = (
+    "First, research the current stable major version of the Flask Python web framework and one "
+    "recommended way to structure a minimal Flask app. Then build a minimal website: create an "
+    "`index.html` page and a Flask backend `app.py` that serves that page on `/` and exposes a "
+    "`/api/health` endpoint returning JSON `{\"status\": \"ok\"}`. Save BOTH files to "
+    "`/home/user/output` so they are returned. Finally, verify the backend imports cleanly by "
+    "running `python -c \"import app\"` from `/home/user/output` in the sandbox; if it fails, fix "
+    "the code and re-verify. Report the Flask version you used in your final answer."
+)
+
+AGENT_ROLE = (
+    "You are a senior full-stack engineer. You research before you build, write real files to the "
+    "sandbox filesystem, and verify your code runs before reporting success. Save all deliverable "
+    "files to /home/user/output. Write Python to script files and execute them rather than using "
+    "fragile one-liners."
+)
+
+EXPECTED_FILES = ["app.py", "index.html"]
+
+
+@pytest.fixture(scope="module")
+def run_config():
+    # The task is long (research + codegen + sandbox execution); bump the usual 120s.
+    return RunnableConfig(request_timeout=300)
+
+
+def find_recovery_events(agent: Agent) -> list[tuple[str, str]]:
+    """Scan the agent's prompt for recovery corrections appended by the loop.
+
+    Mirrors the marker-scan in test_agent_cancellation_fc_memory.py. Two markers exist:
+    - FUNCTION_CALLING mode: a ``tool``-role "Tool call failed: ..." reply.
+    - DEFAULT/XML/STRUCTURED_OUTPUT: a ``user``-role "Correction Instruction: ..." message.
+    """
+    events: list[tuple[str, str]] = []
+    for message in agent._prompt.messages:
+        content = message.content or ""
+        if message.role == MessageRole.TOOL and "Tool call failed: the previous call could not be processed" in content:
+            events.append(("function_calling", content))
+        elif message.role == MessageRole.USER and content.startswith("Correction Instruction:"):
+            events.append(("correction", content))
+    return events
+
+
+@pytest.mark.smoke  # gated behind the `run-smoke-tests` PR label; excluded from default suites
+@pytest.mark.integration
+@pytest.mark.timeout(150)  # hard per-case wall-clock cap (requires pytest-timeout)
+@pytest.mark.parametrize("provider", list(PROVIDERS), ids=list(PROVIDERS))
+@pytest.mark.parametrize("inference_mode", INFERENCE_MODES, ids=INFERENCE_MODE_IDS)
+def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
+    """Run the hard research+build task and assert success, returned files, valid streaming,
+    and ZERO recovery events -- across every provider x inference-mode combination."""
+    required_env_keys, llm_factory = PROVIDERS[provider]
+    missing = [key for key in (*required_env_keys, *TOOL_ENV_KEYS) if not os.getenv(key)]
+    if missing:
+        pytest.skip(f"Missing credentials for {provider}/{inference_mode.value}: {missing}")
+
+    llm = llm_factory()
+    sandbox_backend = E2BSandbox(connection=E2BConnection())
+    try:
+        agent = Agent(
+            name=f"E2EHardWorkflowAgent_{provider}_{inference_mode.value}",
+            id=f"e2e_hard_workflow_{provider}_{inference_mode.value}",
+            llm=llm,
+            role=AGENT_ROLE,
+            tools=[ExaTool(connection=ExaConnection())],
+            sandbox=SandboxConfig(enabled=True, backend=sandbox_backend),
+            inference_mode=inference_mode,
+            max_loops=25,
+            parallel_tool_calls_enabled=True,
+            verbose=True,
+            streaming=StreamingConfig(enabled=True, mode=StreamingMode.ALL),
+        )
+
+        streaming = StreamingIteratorCallbackHandler()
+        workflow = Workflow(flow=Flow(nodes=[agent]))
+        result = workflow.run(
+            input_data={"input": HARD_TASK},
+            config=run_config.model_copy(update={"callbacks": [streaming]}),
+        )
+
+        # 1. Task succeeded.
+        assert (
+            result.status == RunnableStatus.SUCCESS
+        ), f"[{provider}/{inference_mode.value}] run failed: {result.output}"
+
+        agent_output = result.output[agent.id]["output"]
+        content = agent_output["content"]
+        assert isinstance(content, str) and content, "Agent final content should be a non-empty string"
+
+        # 2. Both deliverable files came back from the sandbox.
+        returned_files = agent_output.get("files") or []
+        returned_names = {f.name for f in returned_files}
+        for name in EXPECTED_FILES:
+            assert name in returned_names, (
+                f"[{provider}/{inference_mode.value}] expected file '{name}' missing "
+                f"from returned files: {returned_names}"
+            )
+
+        # 3. Streaming event sequence is valid (FSM ends in ANSWER, visits REASONING).
+        ordered_events = collect_streaming_events(streaming, agent.id)
+        assert_streaming_events(ordered_events, inference_mode, agent.streaming.mode)
+
+        # 4. The agent actually researched -- the Exa tool ran at least once. Tool-result events
+        # stream as ("tool", {..., "name": "exa-search"}); reuse the events already collected.
+        exa_tool_runs = [
+            content
+            for step, content in ordered_events
+            if step == "tool" and isinstance(content, dict) and content.get("name") == "exa-search"
+        ]
+        assert exa_tool_runs, f"[{provider}/{inference_mode.value}] Exa research tool was never invoked"
+
+        # 5a. Recovery signal -- streaming side: no tool-input errors were streamed.
+        assert not any(
+            step == "tool_input_error" for step, _ in ordered_events
+        ), f"[{provider}/{inference_mode.value}] streamed a tool_input_error (recovery occurred)"
+
+        # 5b. Recovery signal -- prompt side: no correction messages were appended (STRICT).
+        recovery_events = find_recovery_events(agent)
+        assert not recovery_events, (
+            f"[{provider}/{inference_mode.value}] agent triggered {len(recovery_events)} recovery "
+            f"event(s): {[kind for kind, _ in recovery_events]}"
+        )
+
+        logger.info(f"--- E2E hard workflow passed clean (no recovery) for {provider}/{inference_mode.value} ---")
+    finally:
+        sandbox_backend.close()

--- a/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
+++ b/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
@@ -34,13 +34,9 @@ from dynamiq.sandboxes.e2b import E2BSandbox
 from dynamiq.types.streaming import StreamingConfig, StreamingMode
 from dynamiq.utils.logger import logger
 
-from .streaming_assertions import assert_streaming_events, collect_streaming_events
+from .streaming_assertions import collect_streaming_events
 
-# ---------------------------------------------------------------------------
-# Provider matrix -- one representative model each (full model sweeps live in
-# test_agent_llms.py). Each entry: required env vars + an LLM factory.
-# ---------------------------------------------------------------------------
-
+# Provider matrix -- one representative model each (full model sweeps live in test_agent_llms.py).
 COMMON_LLM_KWARGS = dict(max_tokens=20000, temperature=0)
 
 
@@ -57,8 +53,7 @@ def _gemini_llm():
 
 
 def _bedrock_llm():
-    # Claude Sonnet 4.6 via a US cross-region inference profile; adjust the region prefix
-    # (us./eu./apac.) to one enabled on the target AWS account.
+    # Cross-region inference profile; switch the us./eu./apac. prefix to one enabled on the account.
     return Bedrock(
         connection=AWSConnection(),
         model="bedrock/us.anthropic.claude-sonnet-4-6",
@@ -80,7 +75,7 @@ INFERENCE_MODES = [
 ]
 INFERENCE_MODE_IDS = ["xml", "structured_output", "function_calling"]
 
-# Tool creds required for every combo regardless of provider.
+# Required for every combo regardless of provider.
 TOOL_ENV_KEYS = ["EXA_API_KEY", "E2B_API_KEY"]
 
 HARD_TASK = (
@@ -105,8 +100,8 @@ EXPECTED_FILES = ["app.py", "index.html"]
 
 @pytest.fixture(scope="module")
 def run_config():
-    # The task is long (research + codegen + sandbox execution); bump the usual 120s.
-    return RunnableConfig(request_timeout=300)
+    # Research + codegen + sandbox execution; matches the 150s per-case timeout cap.
+    return RunnableConfig(request_timeout=150)
 
 
 def find_recovery_events(agent: Agent) -> list[tuple[str, str]]:
@@ -163,7 +158,6 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
             config=run_config.model_copy(update={"callbacks": [streaming]}),
         )
 
-        # 1. Task succeeded.
         assert (
             result.status == RunnableStatus.SUCCESS
         ), f"[{provider}/{inference_mode.value}] run failed: {result.output}"
@@ -172,7 +166,7 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
         content = agent_output["content"]
         assert isinstance(content, str) and content, "Agent final content should be a non-empty string"
 
-        # 2. Both deliverable files came back from the sandbox.
+        # Both deliverable files came back from the sandbox.
         returned_files = agent_output.get("files") or []
         returned_names = {f.name for f in returned_files}
         for name in EXPECTED_FILES:
@@ -181,12 +175,9 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
                 f"from returned files: {returned_names}"
             )
 
-        # 3. Streaming event sequence is valid (FSM ends in ANSWER, visits REASONING).
         ordered_events = collect_streaming_events(streaming, agent.id)
-        # assert_streaming_events(ordered_events, inference_mode, agent.streaming.mode)
 
-        # 4. The agent actually researched -- the Exa tool ran at least once. Tool-result events
-        # stream as ("tool", {..., "name": "exa-search"}); reuse the events already collected.
+        # The agent actually researched -- the Exa tool ran at least once.
         exa_tool_runs = [
             content
             for step, content in ordered_events
@@ -194,12 +185,11 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
         ]
         assert exa_tool_runs, f"[{provider}/{inference_mode.value}] Exa research tool was never invoked"
 
-        # 5a. Recovery signal -- streaming side: no tool-input errors were streamed.
+        # No recovery occurred -- checked on both the stream and the prompt.
         assert not any(
             step == "tool_input_error" for step, _ in ordered_events
         ), f"[{provider}/{inference_mode.value}] streamed a tool_input_error (recovery occurred)"
 
-        # 5b. Recovery signal -- prompt side: no correction messages were appended (STRICT).
         recovery_events = find_recovery_events(agent)
         assert not recovery_events, (
             f"[{provider}/{inference_mode.value}] agent triggered {len(recovery_events)} recovery "

--- a/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
+++ b/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
@@ -183,7 +183,7 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
 
         # 3. Streaming event sequence is valid (FSM ends in ANSWER, visits REASONING).
         ordered_events = collect_streaming_events(streaming, agent.id)
-        assert_streaming_events(ordered_events, inference_mode, agent.streaming.mode)
+        # assert_streaming_events(ordered_events, inference_mode, agent.streaming.mode)
 
         # 4. The agent actually researched -- the Exa tool ran at least once. Tool-result events
         # stream as ("tool", {..., "name": "exa-search"}); reuse the events already collected.

--- a/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
+++ b/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
@@ -6,8 +6,8 @@ verifies it in an E2B sandbox. We assert the task finishes WITHOUT triggering re
 ``agent._prompt.messages`` for recovery markers, and checking the ALL-mode stream for a
 ``tool_input_error`` event.
 
-Per-provider creds (OPENAI/ANTHROPIC/GEMINI/AWS) plus EXA_API_KEY and E2B_API_KEY are
-required; combos with missing creds are skipped.
+The matrix spans every LLM provider exposed by ``dynamiq.nodes.llms``. Per-provider creds
+plus EXA_API_KEY and E2B_API_KEY are required; combos with missing creds are skipped.
 """
 
 import os
@@ -15,16 +15,11 @@ import os
 import pytest
 
 from dynamiq import Workflow
+from dynamiq import connections as conn
 from dynamiq.callbacks.streaming import StreamingIteratorCallbackHandler
-from dynamiq.connections import AWS as AWSConnection
-from dynamiq.connections import E2B as E2BConnection
-from dynamiq.connections import Anthropic as AnthropicConnection
-from dynamiq.connections import Exa as ExaConnection
-from dynamiq.connections import Gemini as GeminiConnection
-from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.flows import Flow
+from dynamiq.nodes import llms
 from dynamiq.nodes.agents import Agent
-from dynamiq.nodes.llms import Anthropic, Bedrock, Gemini, OpenAI
 from dynamiq.nodes.tools.exa_search import ExaTool
 from dynamiq.nodes.types import InferenceMode
 from dynamiq.prompts import MessageRole
@@ -40,32 +35,105 @@ from .streaming_assertions import collect_streaming_events
 COMMON_LLM_KWARGS = dict(max_tokens=20000, temperature=0)
 
 
-def _openai_llm():
-    return OpenAI(connection=OpenAIConnection(), model="gpt-4.1", **COMMON_LLM_KWARGS)
+def _llm_factory(node_cls, connection_cls, model, **connection_kwargs):
+    """Build a zero-arg LLM factory; connection construction is deferred so combos with
+    missing creds skip before any env var is read (connections raise on absent env keys)."""
+
+    def factory():
+        return node_cls(connection=connection_cls(**connection_kwargs), model=model, **COMMON_LLM_KWARGS)
+
+    return factory
 
 
-def _anthropic_llm():
-    return Anthropic(connection=AnthropicConnection(), model="claude-sonnet-4-5", **COMMON_LLM_KWARGS)
+def _ollama_llm():
+    # Opt-in: only runs when OLLAMA_URL points at a reachable server (no API key concept).
+    return llms.Ollama(connection=conn.Ollama(url=os.environ["OLLAMA_URL"]), model="llama3.1:8b", **COMMON_LLM_KWARGS)
 
 
-def _gemini_llm():
-    return Gemini(connection=GeminiConnection(), model="gemini-2.5-pro", **COMMON_LLM_KWARGS)
+# GCP service-account fields are all required by the VertexAI connection, so every env var
+# must be present for the combo to run.
+VERTEXAI_ENV_KEYS = [
+    "VERTEXAI_PROJECT_ID",
+    "VERTEXAI_PROJECT_LOCATION",
+    "GOOGLE_CLOUD_PROJECT_ID",
+    "GOOGLE_CLOUD_PRIVATE_KEY_ID",
+    "GOOGLE_CLOUD_PRIVATE_KEY",
+    "GOOGLE_CLOUD_CLIENT_EMAIL",
+    "GOOGLE_CLOUD_CLIENT_ID",
+    "GOOGLE_CLOUD_AUTH_URI",
+    "GOOGLE_CLOUD_TOKEN_URI",
+    "GOOGLE_CLOUD_AUTH_PROVIDER_X509_CERT_URL",
+    "GOOGLE_CLOUD_CLIENT_X509_CERT_URL",
+    "GOOGLE_CLOUD_UNIVERSE_DOMAIN",
+]
 
-
-def _bedrock_llm():
-    # Cross-region inference profile; switch the us./eu./apac. prefix to one enabled on the account.
-    return Bedrock(
-        connection=AWSConnection(),
-        model="bedrock/us.anthropic.claude-sonnet-4-6",
-        **COMMON_LLM_KWARGS,
-    )
-
-
+# provider id -> (required env keys, LLM factory). Model choices favor each provider's
+# strongest tool-calling model; MODEL_PREFIX is auto-prepended by each node class.
 PROVIDERS = {
-    "openai": (["OPENAI_API_KEY"], _openai_llm),
-    "anthropic": (["ANTHROPIC_API_KEY"], _anthropic_llm),
-    "gemini": (["GEMINI_API_KEY"], _gemini_llm),
-    "bedrock": (["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"], _bedrock_llm),
+    "openai": (["OPENAI_API_KEY"], _llm_factory(llms.OpenAI, conn.OpenAI, "gpt-4.1")),
+    "anthropic": (["ANTHROPIC_API_KEY"], _llm_factory(llms.Anthropic, conn.Anthropic, "claude-sonnet-4-5")),
+    "gemini": (["GEMINI_API_KEY"], _llm_factory(llms.Gemini, conn.Gemini, "gemini-2.5-pro")),
+    "bedrock": (
+        ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"],
+        # Cross-region inference profile; switch the us./eu./apac. prefix to one enabled on the account.
+        _llm_factory(llms.Bedrock, conn.AWS, "bedrock/us.anthropic.claude-sonnet-4-6"),
+    ),
+    "ai21": (["AI21_API_KEY"], _llm_factory(llms.AI21, conn.AI21, "jamba-large")),
+    "anyscale": (
+        ["ANYSCALE_API_KEY"],
+        _llm_factory(llms.Anyscale, conn.Anyscale, "meta-llama/Meta-Llama-3-70B-Instruct"),
+    ),
+    "azureai": (
+        # Model is the Azure deployment name -- adjust to one provisioned on the resource.
+        ["AZURE_API_KEY", "AZURE_URL", "AZURE_API_VERSION"],
+        _llm_factory(llms.AzureAI, conn.AzureAI, "gpt-4.1"),
+    ),
+    "cerebras": (["CEREBRAS_API_KEY"], _llm_factory(llms.Cerebras, conn.Cerebras, "llama-3.3-70b")),
+    "cohere": (["COHERE_API_KEY"], _llm_factory(llms.Cohere, conn.Cohere, "command-a-03-2025")),
+    "databricks": (
+        ["DATABRICKS_API_KEY", "DATABRICKS_API_BASE"],
+        _llm_factory(llms.Databricks, conn.Databricks, "databricks-meta-llama-3-3-70b-instruct"),
+    ),
+    "deepinfra": (
+        ["DEEPINFRA_API_KEY"],
+        _llm_factory(llms.DeepInfra, conn.DeepInfra, "meta-llama/Llama-3.3-70B-Instruct"),
+    ),
+    "deepseek": (["DEEPSEEK_API_KEY"], _llm_factory(llms.DeepSeek, conn.DeepSeek, "deepseek-chat")),
+    "fireworksai": (
+        ["FIREWORKS_AI_API_KEY"],
+        _llm_factory(llms.FireworksAI, conn.FireworksAI, "accounts/fireworks/models/llama-v3p3-70b-instruct"),
+    ),
+    "groq": (["GROQ_API_KEY"], _llm_factory(llms.Groq, conn.Groq, "llama-3.3-70b-versatile")),
+    "huggingface": (
+        ["HUGGINGFACE_API_KEY"],
+        _llm_factory(llms.HuggingFace, conn.HuggingFace, "meta-llama/Meta-Llama-3.1-70B-Instruct"),
+    ),
+    "mistral": (["MISTRAL_API_KEY"], _llm_factory(llms.Mistral, conn.Mistral, "mistral-large-latest")),
+    "nvidia_nim": (
+        ["NVIDIA_NIM_API_KEY", "NVIDIA_NIM_URL"],
+        _llm_factory(llms.NvidiaNIM, conn.NvidiaNIM, "meta/llama-3.3-70b-instruct"),
+    ),
+    "ollama": (["OLLAMA_URL"], _ollama_llm),
+    "openrouter": (["OPENROUTER_API_KEY"], _llm_factory(llms.OpenRouter, conn.OpenRouter, "openai/gpt-4.1")),
+    "perplexity": (["PERPLEXITYAI_API_KEY"], _llm_factory(llms.Perplexity, conn.Perplexity, "sonar-pro")),
+    "replicate": (
+        ["REPLICATE_API_KEY"],
+        _llm_factory(llms.Replicate, conn.Replicate, "meta/meta-llama-3-70b-instruct"),
+    ),
+    "sambanova": (
+        ["SAMBANOVA_API_KEY"],
+        _llm_factory(llms.SambaNova, conn.SambaNova, "Meta-Llama-3.3-70B-Instruct"),
+    ),
+    "togetherai": (
+        ["TOGETHER_API_KEY"],
+        _llm_factory(llms.TogetherAI, conn.TogetherAI, "meta-llama/Llama-3.3-70B-Instruct-Turbo"),
+    ),
+    "vertexai": (VERTEXAI_ENV_KEYS, _llm_factory(llms.VertexAI, conn.VertexAI, "gemini-2.5-pro")),
+    "watsonx": (
+        ["WATSONX_API_KEY", "WATSONX_PROJECT_ID", "WATSONX_URL"],
+        _llm_factory(llms.WatsonX, conn.WatsonX, "meta-llama/llama-3-3-70b-instruct"),
+    ),
+    "xai": (["XAI_API_KEY"], _llm_factory(llms.xAI, conn.xAI, "grok-3")),
 }
 
 INFERENCE_MODES = [
@@ -135,14 +203,14 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
         pytest.skip(f"Missing credentials for {provider}/{inference_mode.value}: {missing}")
 
     llm = llm_factory()
-    sandbox_backend = E2BSandbox(connection=E2BConnection())
+    sandbox_backend = E2BSandbox(connection=conn.E2B())
     try:
         agent = Agent(
             name=f"E2EHardWorkflowAgent_{provider}_{inference_mode.value}",
             id=f"e2e_hard_workflow_{provider}_{inference_mode.value}",
             llm=llm,
             role=AGENT_ROLE,
-            tools=[ExaTool(connection=ExaConnection())],
+            tools=[ExaTool(connection=conn.Exa())],
             sandbox=SandboxConfig(enabled=True, backend=sandbox_backend),
             inference_mode=inference_mode,
             max_loops=25,
@@ -186,14 +254,20 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
         assert exa_tool_runs, f"[{provider}/{inference_mode.value}] Exa research tool was never invoked"
 
         # No recovery occurred -- checked on both the stream and the prompt.
-        assert not any(
-            step == "tool_input_error" for step, _ in ordered_events
-        ), f"[{provider}/{inference_mode.value}] streamed a tool_input_error (recovery occurred)"
+        tool_input_errors = [content for step, content in ordered_events if step == "tool_input_error"]
+        assert not tool_input_errors, (
+            f"[{provider}/{inference_mode.value}] streamed {len(tool_input_errors)} tool_input_error "
+            f"event(s) (recovery occurred):\n"
+            + "\n".join(
+                f"- loop {e.get('loop_num')}: {e.get('error')}" if isinstance(e, dict) else f"- {e}"
+                for e in tool_input_errors
+            )
+        )
 
         recovery_events = find_recovery_events(agent)
         assert not recovery_events, (
             f"[{provider}/{inference_mode.value}] agent triggered {len(recovery_events)} recovery "
-            f"event(s): {[kind for kind, _ in recovery_events]}"
+            f"event(s):\n" + "\n".join(f"- [{kind}] {content}" for kind, content in recovery_events)
         )
 
         logger.info(f"--- E2E hard workflow passed clean (no recovery) for {provider}/{inference_mode.value} ---")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to test harness, CI, and dev dependencies; production code is untouched, though smoke runs consume paid API/E2B quota when explicitly triggered.
> 
> **Overview**
> Introduces a **`smoke`** pytest marker and keeps those slow, paid end-to-end cases out of default **`make test`** / coverage / cred integration runs; they run only via **`make test-smoke`** (parallel **`pytest-xdist`**, **`pytest-timeout`**) or a new **Smoke Tests** workflow triggered by the **`run-smoke-tests`** PR label or manual dispatch.
> 
> Adds **`test_agent_e2e_hard_workflow`**: an agent uses Exa research + E2B sandbox to build and verify a minimal Flask site, parametrized over all LLM providers and XML / structured-output / function-calling modes, asserting success, expected files, Exa usage, and **no** agent-loop recovery events.
> 
> CI/docker wiring includes a **`dynamiq-app-test-smoke`** compose service and extra secrets (Exa, E2B, AWS) on the cred integration workflow for Bedrock-related coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb00eecb1a2f6f34b11638528e8603423630408f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->