### PR TITLE
fix: disable sampling params for Claude 4.7+ models

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -165,15 +165,8 @@ class LLMCheckpointState(BaseCheckpointState):
     is_fallback_run: bool = Field(default=False, description="Whether LLM is in fallback mode")
 
 
-# Sampling parameters that some newer models reject with an HTTP 400.
 SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
 
-# Substrings of model names that reject the sampling parameters above with an HTTP 400.
-# These models are newer than LiteLLM's static capability map, so the ``drop_params=True``
-# we already pass to LiteLLM does not strip the params for them and the request fails. We
-# strip them ourselves. Matched by substring so the check is independent of the provider
-# prefix (``anthropic/``, ``bedrock/...anthropic.``, OpenRouter, etc.).
-# Ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
 SAMPLING_UNSUPPORTED_MODEL_MARKERS: tuple[str, ...] = (
     "claude-opus-4-7",
     "claude-opus-4-8",
@@ -182,10 +175,6 @@ SAMPLING_UNSUPPORTED_MODEL_MARKERS: tuple[str, ...] = (
     "claude-mythos-preview",
 )
 
-# Error-message fragments that signal a provider rejected a param because it is *unsupported*
-# (as opposed to out-of-range). Used by the reactive backstop to catch models not yet listed
-# in SAMPLING_UNSUPPORTED_MODEL_MARKERS, while leaving genuine validation errors
-# (e.g. "temperature: must be less than or equal to 1.0") to surface normally.
 _SAMPLING_UNSUPPORTED_INDICATORS: tuple[str, ...] = (
     "not permitted",
     "not supported",
@@ -680,10 +669,7 @@ class BaseLLM(ConnectionNode):
         return response_format, tools
 
     def _model_rejects_sampling_params(self) -> bool:
-        """Whether ``self.model`` is known to reject sampling params with a 400.
-
-        See :data:`SAMPLING_UNSUPPORTED_MODEL_MARKERS`.
-        """
+        """Whether self.model is known to reject sampling params with a 400."""
         model_lower = self.model.lower()
         return any(marker in model_lower for marker in SAMPLING_UNSUPPORTED_MODEL_MARKERS)
 
@@ -694,8 +680,7 @@ class BaseLLM(ConnectionNode):
         This method can be overridden by subclasses to customize the parameters
         passed to the completion method. By default, it enables usage information
         in streaming mode if streaming is enabled and include_usage is set, and
-        strips sampling params for models that reject them (see
-        :data:`SAMPLING_UNSUPPORTED_MODEL_MARKERS`).
+        strips sampling params for models that reject them.
         Args:
             params (dict[str, Any]): The parameters to be updated.
 
@@ -878,8 +863,7 @@ class BaseLLM(ConnectionNode):
         re-raise the original error.
 
         Default implementation: backstop for models that reject sampling params with a 400
-        but are not yet listed in :data:`SAMPLING_UNSUPPORTED_MODEL_MARKERS` (the deterministic
-        path in :meth:`update_completion_params` handles the listed ones up front). Strips the
+        but are not yet listed in SAMPLING_UNSUPPORTED_MODEL_MARKERS. Strips the
         sampling params and persists the removal so later calls in this run skip the failing
         first attempt. Only fires when the error both names a present sampling param and looks
         like an unsupported-param error, so genuine validation errors (e.g. out-of-range

--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -182,9 +182,12 @@ _SAMPLING_UNSUPPORTED_INDICATORS: tuple[str, ...] = (
     "does not support",
     "doesn't support",
     "unsupported",
-    "unexpected",
+    "unexpected keyword",
     "unrecognized",
 )
+
+# Upper bound on sequential completion-param recoveries (e.g. strip `stop`, then sampling params).
+_MAX_COMPLETION_RECOVERIES = 3
 
 
 class BaseLLM(ConnectionNode):
@@ -979,11 +982,20 @@ class BaseLLM(ConnectionNode):
         try:
             response = self._completion(**common_params)
         except Exception as e:
-            recovered = self._recover_completion_params(e, common_params)
-            if recovered is None:
-                raise
-            response = self._completion(**recovered)
-            self._persist_completion_recovery(common_params, recovered)
+            attempt_params = common_params
+            for _ in range(_MAX_COMPLETION_RECOVERIES):
+                recovered = self._recover_completion_params(e, attempt_params)
+                if recovered is None:
+                    raise e
+                try:
+                    response = self._completion(**recovered)
+                except Exception as retry_exc:
+                    e, attempt_params = retry_exc, recovered
+                    continue
+                self._persist_completion_recovery(common_params, recovered)
+                break
+            else:
+                raise e
         handle_completion = (
             self._handle_streaming_completion_response
             if common_params.get("stream")
@@ -1043,11 +1055,20 @@ class BaseLLM(ConnectionNode):
         try:
             response = await self._acompletion(**common_params)
         except Exception as e:
-            recovered = self._recover_completion_params(e, common_params)
-            if recovered is None:
-                raise
-            response = await self._acompletion(**recovered)
-            self._persist_completion_recovery(common_params, recovered)
+            attempt_params = common_params
+            for _ in range(_MAX_COMPLETION_RECOVERIES):
+                recovered = self._recover_completion_params(e, attempt_params)
+                if recovered is None:
+                    raise e
+                try:
+                    response = await self._acompletion(**recovered)
+                except Exception as retry_exc:
+                    e, attempt_params = retry_exc, recovered
+                    continue
+                self._persist_completion_recovery(common_params, recovered)
+                break
+            else:
+                raise e
 
         if common_params.get("stream"):
             return await self._handle_streaming_completion_response_async(

--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -165,6 +165,38 @@ class LLMCheckpointState(BaseCheckpointState):
     is_fallback_run: bool = Field(default=False, description="Whether LLM is in fallback mode")
 
 
+# Sampling parameters that some newer models reject with an HTTP 400.
+SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
+
+# Substrings of model names that reject the sampling parameters above with an HTTP 400.
+# These models are newer than LiteLLM's static capability map, so the ``drop_params=True``
+# we already pass to LiteLLM does not strip the params for them and the request fails. We
+# strip them ourselves. Matched by substring so the check is independent of the provider
+# prefix (``anthropic/``, ``bedrock/...anthropic.``, OpenRouter, etc.).
+# Ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
+SAMPLING_UNSUPPORTED_MODEL_MARKERS: tuple[str, ...] = (
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-mythos-preview",
+)
+
+# Error-message fragments that signal a provider rejected a param because it is *unsupported*
+# (as opposed to out-of-range). Used by the reactive backstop to catch models not yet listed
+# in SAMPLING_UNSUPPORTED_MODEL_MARKERS, while leaving genuine validation errors
+# (e.g. "temperature: must be less than or equal to 1.0") to surface normally.
+_SAMPLING_UNSUPPORTED_INDICATORS: tuple[str, ...] = (
+    "not permitted",
+    "not supported",
+    "does not support",
+    "doesn't support",
+    "unsupported",
+    "unexpected",
+    "unrecognized",
+)
+
+
 class BaseLLM(ConnectionNode):
     """Base class for all LLM nodes.
 
@@ -647,13 +679,23 @@ class BaseLLM(ConnectionNode):
 
         return response_format, tools
 
+    def _model_rejects_sampling_params(self) -> bool:
+        """Whether ``self.model`` is known to reject sampling params with a 400.
+
+        See :data:`SAMPLING_UNSUPPORTED_MODEL_MARKERS`.
+        """
+        model_lower = self.model.lower()
+        return any(marker in model_lower for marker in SAMPLING_UNSUPPORTED_MODEL_MARKERS)
+
     def update_completion_params(self, params: dict[str, Any]) -> dict[str, Any]:
         """
         Updates or modifies the parameters for the completion method.
 
         This method can be overridden by subclasses to customize the parameters
         passed to the completion method. By default, it enables usage information
-        in streaming mode if streaming is enabled and include_usage is set.
+        in streaming mode if streaming is enabled and include_usage is set, and
+        strips sampling params for models that reject them (see
+        :data:`SAMPLING_UNSUPPORTED_MODEL_MARKERS`).
         Args:
             params (dict[str, Any]): The parameters to be updated.
 
@@ -663,6 +705,9 @@ class BaseLLM(ConnectionNode):
         if self.streaming and self.streaming.enabled and self.streaming.include_usage and params.get("stream", False):
             params.setdefault("stream_options", {})
             params["stream_options"]["include_usage"] = True
+        if self._model_rejects_sampling_params():
+            for param in SAMPLING_PARAMS:
+                params.pop(param, None)
         return params
 
     # Per-request cap on strict tools. ``None`` means no cap. Providers with a
@@ -832,8 +877,34 @@ class BaseLLM(ConnectionNode):
         and return a modified `common_params` dict to retry with, or return ``None`` to
         re-raise the original error.
 
-        Default implementation: no recovery (return ``None``).
+        Default implementation: backstop for models that reject sampling params with a 400
+        but are not yet listed in :data:`SAMPLING_UNSUPPORTED_MODEL_MARKERS` (the deterministic
+        path in :meth:`update_completion_params` handles the listed ones up front). Strips the
+        sampling params and persists the removal so later calls in this run skip the failing
+        first attempt. Only fires when the error both names a present sampling param and looks
+        like an unsupported-param error, so genuine validation errors (e.g. out-of-range
+        temperature) still surface.
         """
+        msg = str(exc).lower()
+        present = [param for param in SAMPLING_PARAMS if common_params.get(param) is not None]
+        references_param = any(param in msg for param in present)
+        looks_unsupported = any(ind in msg for ind in _SAMPLING_UNSUPPORTED_INDICATORS)
+        if present and references_param and looks_unsupported:
+            logger.warning(
+                "LLM '%s': model '%s' rejected sampling params %s; retrying without them "
+                "(add the model to SAMPLING_UNSUPPORTED_MODEL_MARKERS to skip this failed attempt).",
+                self.name,
+                self.model,
+                present,
+            )
+            recovered = dict(common_params)
+            for param in SAMPLING_PARAMS:
+                recovered.pop(param, None)
+                if param in type(self).model_fields:
+                    setattr(self, param, None)
+                elif self.__pydantic_extra__ is not None:
+                    self.__pydantic_extra__.pop(param, None)
+            return recovered
         return None
 
     def execute(

--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -863,11 +863,10 @@ class BaseLLM(ConnectionNode):
         re-raise the original error.
 
         Default implementation: backstop for models that reject sampling params with a 400
-        but are not yet listed in SAMPLING_UNSUPPORTED_MODEL_MARKERS. Strips the
-        sampling params and persists the removal so later calls in this run skip the failing
-        first attempt. Only fires when the error both names a present sampling param and looks
-        like an unsupported-param error, so genuine validation errors (e.g. out-of-range
-        temperature) still surface.
+        but are not yet listed in SAMPLING_UNSUPPORTED_MODEL_MARKERS. Returns the params
+        with the sampling params stripped. Only fires when the error both names a present
+        sampling param and looks like an unsupported-param error, so genuine validation
+        errors (e.g. out-of-range temperature) still surface.
         """
         msg = str(exc).lower()
         present = [param for param in SAMPLING_PARAMS if common_params.get(param) is not None]
@@ -884,12 +883,23 @@ class BaseLLM(ConnectionNode):
             recovered = dict(common_params)
             for param in SAMPLING_PARAMS:
                 recovered.pop(param, None)
+            return recovered
+        return None
+
+    def _persist_completion_recovery(self, common_params: dict, recovered: dict) -> None:
+        """Persist a successful param recovery on the instance.
+
+        Called only after a retry with ``recovered`` succeeds, so a failed retry never
+        leaves the reusable node mutated. Default: for every sampling param the recovery
+        dropped, clear it on the instance so later calls in this run skip the failing
+        first attempt.
+        """
+        for param in SAMPLING_PARAMS:
+            if param in common_params and param not in recovered:
                 if param in type(self).model_fields:
                     setattr(self, param, None)
                 elif self.__pydantic_extra__ is not None:
                     self.__pydantic_extra__.pop(param, None)
-            return recovered
-        return None
 
     def execute(
         self,
@@ -944,6 +954,7 @@ class BaseLLM(ConnectionNode):
             if recovered is None:
                 raise
             response = self._completion(**recovered)
+            self._persist_completion_recovery(common_params, recovered)
         handle_completion = (
             self._handle_streaming_completion_response
             if common_params.get("stream")
@@ -1007,6 +1018,7 @@ class BaseLLM(ConnectionNode):
             if recovered is None:
                 raise
             response = await self._acompletion(**recovered)
+            self._persist_completion_recovery(common_params, recovered)
 
         if common_params.get("stream"):
             return await self._handle_streaming_completion_response_async(

--- a/dynamiq/nodes/llms/bedrock.py
+++ b/dynamiq/nodes/llms/bedrock.py
@@ -35,8 +35,10 @@ class Bedrock(BaseLLM):
 
         Currently handles: hosted models (e.g. openai.gpt-oss-*, moonshotai.kimi-k2.5)
         that reject the `stopSequences` field even though LiteLLM's per-model registry
-        claims they support it. We strip `stop` and persist that recovery on the
-        instance so later calls do not repeat the same failing first attempt.
+        claims they support it. We strip `stop`; the removal is persisted on the instance
+        only after a successful retry (see :meth:`_persist_completion_recovery`) so later
+        calls do not repeat the same failing first attempt. Anything else falls through to
+        the base sampling-param backstop.
         """
         msg = str(exc)
         if any(ind in msg for ind in _BEDROCK_STOP_UNSUPPORTED_INDICATORS) and common_params.get("stop"):
@@ -46,8 +48,13 @@ class Bedrock(BaseLLM):
                 self.name,
                 self.model,
             )
-            self.stop = None
             recovered = dict(common_params)
             recovered.pop("stop", None)
             return recovered
-        return None
+        return super()._recover_completion_params(exc, common_params)
+
+    def _persist_completion_recovery(self, common_params: dict, recovered: dict) -> None:
+        """Persist Bedrock's `stop` drop, then the base sampling-param drops."""
+        if common_params.get("stop") and "stop" not in recovered:
+            self.stop = None
+        super()._persist_completion_recovery(common_params, recovered)

--- a/tests/unit/nodes/llms/test_llm_async.py
+++ b/tests/unit/nodes/llms/test_llm_async.py
@@ -175,6 +175,10 @@ class TestBuildCompletionParams:
 
             assert recovered is not None
             assert recovered.get("stop") is None
+            # Recovery is pure: the instance is not mutated until the retry succeeds.
+            assert node.stop == ["DONE"]
+
+            node._persist_completion_recovery(initial_params, recovered)
             assert node.stop is None
 
             next_params = node._build_completion_params(

--- a/tests/unit/nodes/llms/test_sampling_params_unsupported.py
+++ b/tests/unit/nodes/llms/test_sampling_params_unsupported.py
@@ -88,8 +88,25 @@ class TestReactiveBackstop:
         assert recovered is not None
         assert "temperature" not in recovered
         assert recovered["max_tokens"] == 100
+        # The recovery hook is pure: it must not mutate the instance, so a failed retry
+        # leaves the reusable node untouched.
+        assert anthropic_supported.temperature == 0.5
+
+    def test_persist_recovery_clears_dropped_params(self, anthropic_supported):
+        # Persistence runs only after a successful retry, mirroring execute().
+        anthropic_supported.temperature = 0.5
+        common = {"model": "anthropic/claude-opus-4-6", "temperature": 0.5, "max_tokens": 100}
+        recovered = {"model": "anthropic/claude-opus-4-6", "max_tokens": 100}
+        anthropic_supported._persist_completion_recovery(common, recovered)
         # Persisted so the next call skips the failing first attempt.
         assert anthropic_supported.temperature is None
+
+    def test_persist_recovery_noop_when_param_kept(self, anthropic_supported):
+        # A param still present in the recovered dict must not be cleared.
+        anthropic_supported.temperature = 0.5
+        common = {"model": "anthropic/claude-opus-4-6", "temperature": 0.5}
+        anthropic_supported._persist_completion_recovery(common, dict(common))
+        assert anthropic_supported.temperature == 0.5
 
     def test_no_recovery_on_out_of_range_error(self, anthropic_supported):
         # A genuine validation error must surface, not be silently stripped.

--- a/tests/unit/nodes/llms/test_sampling_params_unsupported.py
+++ b/tests/unit/nodes/llms/test_sampling_params_unsupported.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from dynamiq.connections import AWS as AWSConnection
@@ -7,6 +9,24 @@ from dynamiq.nodes.llms.anthropic import Anthropic
 from dynamiq.nodes.llms.base import SAMPLING_PARAMS, SAMPLING_UNSUPPORTED_MODEL_MARKERS
 from dynamiq.nodes.llms.bedrock import Bedrock
 from dynamiq.nodes.llms.custom_llm import CustomLLM
+from dynamiq.prompts import Prompt
+from dynamiq.runnables import RunnableConfig
+
+
+def _mock_response(content="ok"):
+    """Minimal litellm ModelResponse stand-in for _handle_completion_response."""
+    choice = MagicMock()
+    choice.message.content = content
+    choice.message.tool_calls = None
+    response = MagicMock()
+    response.choices = [choice]
+    response.model_extra = {}
+    usage = MagicMock()
+    usage.prompt_tokens = usage.completion_tokens = usage.total_tokens = 0
+    usage.prompt_tokens_details = None
+    usage.cache_read_input_tokens = usage.cache_creation_input_tokens = None
+    response.usage = usage
+    return response
 
 
 @pytest.fixture
@@ -119,6 +139,22 @@ class TestReactiveBackstop:
         exc = Exception("some unrelated unsupported field error")
         assert anthropic_supported._recover_completion_params(exc, {"model": "x", "max_tokens": 10}) is None
 
+    def test_no_recovery_on_unexpected_value_validation_error(self, anthropic_supported):
+        # "unexpected value" is a validation error, not an unsupported-param signal.
+        anthropic_supported.temperature = 5.0
+        common = {"model": "anthropic/claude-opus-4-6", "temperature": 5.0}
+        exc = Exception("temperature: unexpected value; permitted range is 0..1")
+        assert anthropic_supported._recover_completion_params(exc, common) is None
+
+    def test_recovers_on_unexpected_keyword_error(self, anthropic_supported):
+        # A Python-level "unexpected keyword argument" still counts as unsupported.
+        anthropic_supported.temperature = 0.5
+        common = {"model": "anthropic/claude-opus-4-6", "temperature": 0.5}
+        exc = Exception("completion() got an unexpected keyword argument 'temperature'")
+        recovered = anthropic_supported._recover_completion_params(exc, common)
+        assert recovered is not None
+        assert "temperature" not in recovered
+
 
 class TestBedrockBackstop:
     @pytest.fixture
@@ -152,3 +188,53 @@ class TestBedrockBackstop:
         # Persisted only after a successful retry.
         bedrock._persist_completion_recovery(common, recovered)
         assert bedrock.stop is None
+
+
+class TestRecoveryLoop:
+    def test_retry_failure_triggers_next_recovery(self):
+        # Bedrock strips `stop`, the retry fails on sampling, so the loop runs the sampling
+        # backstop next and persists both drops.
+        with patch("litellm.completion"), patch("litellm.stream_chunk_builder"):
+            node = Bedrock(
+                name="b",
+                model="bedrock/eu.anthropic.claude-some-future-model",
+                connection=AWSConnection(access_key_id="x", secret_access_key="y", region_name="eu-west-1"),
+                prompt=Prompt(messages=[{"role": "user", "content": "Hello"}]),
+                stop=["DONE"],
+                temperature=0.5,
+            )
+
+            def fake_completion(**params):
+                if params.get("stop"):
+                    raise Exception("This model doesn't support the stopSequences field")
+                if params.get("temperature") is not None:
+                    raise Exception("temperature: Extra inputs are not permitted")
+                return _mock_response("ok")
+
+            node._completion = fake_completion
+            result = node.execute(MagicMock(messages=None, files=None), config=RunnableConfig(callbacks=[]))
+
+            assert result["content"] == "ok"
+            assert node.stop is None
+            assert node.temperature is None
+
+    def test_unrecoverable_retry_raises_latest_error(self):
+        # The most recent failure surfaces, not the first.
+        with patch("litellm.completion"), patch("litellm.stream_chunk_builder"):
+            node = Bedrock(
+                name="b",
+                model="bedrock/eu.anthropic.claude-some-future-model",
+                connection=AWSConnection(access_key_id="x", secret_access_key="y", region_name="eu-west-1"),
+                prompt=Prompt(messages=[{"role": "user", "content": "Hello"}]),
+                stop=["DONE"],
+                temperature=0.5,
+            )
+
+            def fake_completion(**params):
+                if params.get("stop"):
+                    raise Exception("This model doesn't support the stopSequences field")
+                raise Exception("temperature: Input should be less than or equal to 1.0")
+
+            node._completion = fake_completion
+            with pytest.raises(Exception, match="less than or equal to 1.0"):
+                node.execute(MagicMock(messages=None, files=None), config=RunnableConfig(callbacks=[]))

--- a/tests/unit/nodes/llms/test_sampling_params_unsupported.py
+++ b/tests/unit/nodes/llms/test_sampling_params_unsupported.py
@@ -1,14 +1,3 @@
-"""Tests for stripping sampling params on models that reject them.
-
-Regression for: Claude Opus 4.7/4.8 (and Fable/Mythos 5) return an HTTP 400 when sent
-``temperature``/``top_p``/``top_k``. These models are newer than LiteLLM's capability map,
-so the ``drop_params=True`` we pass does not strip the params for them. ``BaseLLM`` strips
-them up front for known models (``SAMPLING_UNSUPPORTED_MODEL_MARKERS``) and, as a backstop,
-reactively retries without them when an unlisted model rejects them at runtime.
-
-The strip lives in the base class, so it applies across every provider node (Anthropic,
-Bedrock, CustomLLM) regardless of the provider prefix on the model name.
-"""
 import pytest
 
 from dynamiq.connections import AWS as AWSConnection

--- a/tests/unit/nodes/llms/test_sampling_params_unsupported.py
+++ b/tests/unit/nodes/llms/test_sampling_params_unsupported.py
@@ -119,3 +119,37 @@ class TestReactiveBackstop:
     def test_no_recovery_when_no_sampling_params_present(self, anthropic_supported):
         exc = Exception("some unrelated unsupported field error")
         assert anthropic_supported._recover_completion_params(exc, {"model": "x", "max_tokens": 10}) is None
+
+
+class TestBedrockBackstop:
+    @pytest.fixture
+    def bedrock(self):
+        return Bedrock(
+            name="b",
+            model="bedrock/eu.anthropic.claude-some-future-model",
+            connection=AWSConnection(access_key_id="x", secret_access_key="y", region_name="eu-west-1"),
+        )
+
+    def test_bedrock_falls_through_to_sampling_backstop(self, bedrock):
+        # An unlisted Bedrock model must still get the base sampling recovery,
+        # not be dropped because Bedrock overrides the hook.
+        bedrock.temperature = 0.5
+        common = {"model": bedrock.model, "temperature": 0.5, "max_tokens": 100}
+        exc = Exception("litellm.BadRequestError: temperature: Extra inputs are not permitted")
+        recovered = bedrock._recover_completion_params(exc, common)
+        assert recovered is not None
+        assert "temperature" not in recovered
+        assert recovered["max_tokens"] == 100
+
+    def test_bedrock_stop_recovery_is_pure(self, bedrock):
+        # The stop recovery must not mutate the instance before the retry succeeds.
+        bedrock.stop = ["STOP"]
+        common = {"model": bedrock.model, "stop": ["STOP"], "max_tokens": 100}
+        exc = Exception("This model doesn't support the stopSequences field")
+        recovered = bedrock._recover_completion_params(exc, common)
+        assert recovered is not None
+        assert "stop" not in recovered
+        assert bedrock.stop == ["STOP"]
+        # Persisted only after a successful retry.
+        bedrock._persist_completion_recovery(common, recovered)
+        assert bedrock.stop is None

--- a/tests/unit/nodes/llms/test_sampling_params_unsupported.py
+++ b/tests/unit/nodes/llms/test_sampling_params_unsupported.py
@@ -1,0 +1,115 @@
+"""Tests for stripping sampling params on models that reject them.
+
+Regression for: Claude Opus 4.7/4.8 (and Fable/Mythos 5) return an HTTP 400 when sent
+``temperature``/``top_p``/``top_k``. These models are newer than LiteLLM's capability map,
+so the ``drop_params=True`` we pass does not strip the params for them. ``BaseLLM`` strips
+them up front for known models (``SAMPLING_UNSUPPORTED_MODEL_MARKERS``) and, as a backstop,
+reactively retries without them when an unlisted model rejects them at runtime.
+
+The strip lives in the base class, so it applies across every provider node (Anthropic,
+Bedrock, CustomLLM) regardless of the provider prefix on the model name.
+"""
+import pytest
+
+from dynamiq.connections import AWS as AWSConnection
+from dynamiq.connections import Anthropic as AnthropicConnection
+from dynamiq.connections import HttpApiKey
+from dynamiq.nodes.llms.anthropic import Anthropic
+from dynamiq.nodes.llms.base import SAMPLING_PARAMS
+from dynamiq.nodes.llms.bedrock import Bedrock
+from dynamiq.nodes.llms.custom_llm import CustomLLM
+
+
+@pytest.fixture
+def anthropic_unsupported():
+    return Anthropic(name="a", model="claude-opus-4-8", connection=AnthropicConnection(api_key="x"))
+
+
+@pytest.fixture
+def anthropic_supported():
+    return Anthropic(name="a", model="claude-opus-4-6", connection=AnthropicConnection(api_key="x"))
+
+
+class TestDetection:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-fable-5",
+            "claude-mythos-5",
+            "claude-mythos-preview",
+            "bedrock/eu.anthropic.claude-opus-4-8-20251101-v1:0",
+            "openrouter/anthropic/claude-opus-4-7",
+        ],
+    )
+    def test_unsupported_models_detected(self, model):
+        llm = Anthropic(name="a", model=model, connection=AnthropicConnection(api_key="x"))
+        assert llm._model_rejects_sampling_params() is True
+
+    @pytest.mark.parametrize("model", ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-4o"])
+    def test_supported_models_not_detected(self, model):
+        llm = Anthropic(name="a", model=model, connection=AnthropicConnection(api_key="x"))
+        assert llm._model_rejects_sampling_params() is False
+
+
+class TestDeterministicStrip:
+    def test_sampling_params_stripped_for_unsupported(self, anthropic_unsupported):
+        params = anthropic_unsupported.update_completion_params(
+            {"model": "anthropic/claude-opus-4-8", "temperature": 0.5, "top_p": 0.9, "top_k": 40, "max_tokens": 100}
+        )
+        for param in SAMPLING_PARAMS:
+            assert param not in params
+        # Non-sampling params are untouched.
+        assert params["max_tokens"] == 100
+
+    def test_sampling_params_kept_for_supported(self, anthropic_supported):
+        params = anthropic_supported.update_completion_params(
+            {"model": "anthropic/claude-opus-4-6", "temperature": 0.5, "top_p": 0.9}
+        )
+        assert params["temperature"] == 0.5
+        assert params["top_p"] == 0.9
+
+    def test_strip_is_provider_independent_bedrock(self):
+        llm = Bedrock(
+            name="b",
+            model="bedrock/eu.anthropic.claude-opus-4-8-20251101-v1:0",
+            connection=AWSConnection(access_key_id="x", secret_access_key="y", region_name="eu-west-1"),
+        )
+        params = llm.update_completion_params({"model": llm.model, "temperature": 0.7})
+        assert "temperature" not in params
+
+    def test_strip_is_provider_independent_custom(self):
+        llm = CustomLLM(
+            name="c",
+            model="anthropic/claude-opus-4-8",
+            connection=HttpApiKey(url="https://example.com", api_key="x"),
+        )
+        params = llm.update_completion_params({"model": llm.model, "temperature": 0.7})
+        assert "temperature" not in params
+
+
+class TestReactiveBackstop:
+    def test_recovers_on_unsupported_error(self, anthropic_supported):
+        # Model not in the marker list, so the deterministic path leaves the param in.
+        anthropic_supported.temperature = 0.5
+        common = {"model": "anthropic/claude-opus-4-6", "temperature": 0.5, "max_tokens": 100}
+        exc = Exception("litellm.BadRequestError: temperature: Extra inputs are not permitted")
+        recovered = anthropic_supported._recover_completion_params(exc, common)
+        assert recovered is not None
+        assert "temperature" not in recovered
+        assert recovered["max_tokens"] == 100
+        # Persisted so the next call skips the failing first attempt.
+        assert anthropic_supported.temperature is None
+
+    def test_no_recovery_on_out_of_range_error(self, anthropic_supported):
+        # A genuine validation error must surface, not be silently stripped.
+        anthropic_supported.temperature = 5.0
+        common = {"model": "anthropic/claude-opus-4-6", "temperature": 5.0}
+        exc = Exception("temperature: Input should be less than or equal to 1.0")
+        assert anthropic_supported._recover_completion_params(exc, common) is None
+        assert anthropic_supported.temperature == 5.0
+
+    def test_no_recovery_when_no_sampling_params_present(self, anthropic_supported):
+        exc = Exception("some unrelated unsupported field error")
+        assert anthropic_supported._recover_completion_params(exc, {"model": "x", "max_tokens": 10}) is None

--- a/tests/unit/nodes/llms/test_sampling_params_unsupported.py
+++ b/tests/unit/nodes/llms/test_sampling_params_unsupported.py
@@ -4,7 +4,7 @@ from dynamiq.connections import AWS as AWSConnection
 from dynamiq.connections import Anthropic as AnthropicConnection
 from dynamiq.connections import HttpApiKey
 from dynamiq.nodes.llms.anthropic import Anthropic
-from dynamiq.nodes.llms.base import SAMPLING_PARAMS
+from dynamiq.nodes.llms.base import SAMPLING_PARAMS, SAMPLING_UNSUPPORTED_MODEL_MARKERS
 from dynamiq.nodes.llms.bedrock import Bedrock
 from dynamiq.nodes.llms.custom_llm import CustomLLM
 
@@ -20,19 +20,18 @@ def anthropic_supported():
 
 
 class TestDetection:
-    @pytest.mark.parametrize(
-        "model",
-        [
-            "claude-opus-4-7",
-            "claude-opus-4-8",
-            "claude-fable-5",
-            "claude-mythos-5",
-            "claude-mythos-preview",
-            "bedrock/eu.anthropic.claude-opus-4-8-20251101-v1:0",
-            "openrouter/anthropic/claude-opus-4-7",
-        ],
-    )
+    @pytest.mark.parametrize("model", SAMPLING_UNSUPPORTED_MODEL_MARKERS)
     def test_unsupported_models_detected(self, model):
+        llm = Anthropic(name="a", model=model, connection=AnthropicConnection(api_key="x"))
+        assert llm._model_rejects_sampling_params() is True
+
+    @pytest.mark.parametrize(
+        "template",
+        ["bedrock/eu.anthropic.{}-20251101-v1:0", "openrouter/anthropic/{}"],
+    )
+    def test_detection_is_provider_prefix_independent(self, template):
+        # A marker must be detected regardless of the provider prefix wrapped around it.
+        model = template.format(SAMPLING_UNSUPPORTED_MODEL_MARKERS[0])
         llm = Anthropic(name="a", model=model, connection=AnthropicConnection(api_key="x"))
         assert llm._model_rejects_sampling_params() is True
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core LLM request paths for all providers and changes error/retry semantics; behavior is well-tested but misclassification of API errors could hide real misconfiguration.
> 
> **Overview**
> **LLM completion calls** now avoid sending `temperature`, `top_p`, and `top_k` to models that reject them (notably newer Claude markers such as `claude-opus-4-7` / `4-8`), both **up front** via `update_completion_params` and as a **reactive retry** when the API returns an unsupported-parameter error—while **out-of-range validation errors** still fail normally.
> 
> **Sync and async `execute`** use a **multi-step recovery loop** (capped at 3 attempts) instead of a single retry: each failure can strip more bad params, and **instance fields are only cleared after a successful retry** via `_persist_completion_recovery`, so reusable nodes are not mutated on failed retries.
> 
> **Bedrock** keeps its `stopSequences` recovery but **defers persistence** to the same pattern and **falls through** to the base sampling-param backstop; tests cover detection, stripping, backstop behavior, and chained stop-then-sampling recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f765af87364948524aa040cf28c2a59082c8266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->