### PR TITLE
feat: register models in litellm

### DIFF
--- a/dynamiq/nodes/llms/model_registry.json
+++ b/dynamiq/nodes/llms/model_registry.json
@@ -79,6 +79,7 @@
         "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
+        "litellm_provider": "together_ai",
         "supports_vision": true,
         "supports_pdf_input": false,
         "supports_function_calling": true,

--- a/dynamiq/nodes/llms/registry.py
+++ b/dynamiq/nodes/llms/registry.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 from dynamiq.utils.logger import logger
 
@@ -26,11 +26,9 @@ def _sync_to_litellm_enabled() -> bool:
 class ModelMetadata(BaseModel):
     """Structured, litellm-compatible model metadata.
 
-    The common fields are typed for validation/discoverability; ``extra="allow"`` lets any
-    other litellm spec field (the spec is large and evolving) pass through untyped.
+    The common litellm fields are typed for validation/discoverability. Unknown fields are
+    ignored (Pydantic default), so only the fields listed here are carried into the registry.
     """
-
-    model_config = ConfigDict(extra="allow")
 
     max_tokens: int | None = None
     max_input_tokens: int | None = None

--- a/dynamiq/nodes/llms/registry.py
+++ b/dynamiq/nodes/llms/registry.py
@@ -93,9 +93,12 @@ class ModelRegistry:
         Args:
             models: New model definitions (``{model_id: info}``) to add to the registry and
                 sync directly. Defaults to syncing all already-loaded models.
+
+        Note:
+            Registering ``models`` into the registry is unconditional; the
+            ``DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM`` toggle only gates the litellm gap-fill
+            below, so callers can still extend the registry with the sync disabled.
         """
-        if not _sync_to_litellm_enabled():
-            return
         if models is None:
             items = self._models
         else:
@@ -103,6 +106,8 @@ class ModelRegistry:
             for model, info in models.items():
                 self.register(model, info)
                 items[model.lower()] = self._models[model.lower()]
+        if not _sync_to_litellm_enabled():
+            return
         if not items:
             return
         try:

--- a/dynamiq/nodes/llms/registry.py
+++ b/dynamiq/nodes/llms/registry.py
@@ -5,17 +5,53 @@ import os
 from pathlib import Path
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict
+
 from dynamiq.utils.logger import logger
 
 REGISTRY_FILE = Path(__file__).with_name("model_registry.json")
 
 _SYNC_ENV_VAR = "DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM"
-_SYNC_DISABLED_VALUES = {"0", "false", "no", "off"}
 
 
 def _sync_to_litellm_enabled() -> bool:
-    """Whether registry entries should be mirrored into litellm's ``model_cost`` (default on)."""
-    return os.getenv(_SYNC_ENV_VAR, "1").strip().lower() not in _SYNC_DISABLED_VALUES
+    """Whether registry entries should be mirrored into litellm's ``model_cost`` (default on).
+
+    Only the literal ``"false"`` (case-insensitive) disables it; unset or any other value
+    keeps it on.
+    """
+    return os.getenv(_SYNC_ENV_VAR, "true").strip().lower() != "false"
+
+
+class ModelMetadata(BaseModel):
+    """Structured, litellm-compatible model metadata.
+
+    The common fields are typed for validation/discoverability; ``extra="allow"`` lets any
+    other litellm spec field (the spec is large and evolving) pass through untyped.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    max_tokens: int | None = None
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
+    mode: str | None = None
+    litellm_provider: str | None = None
+    supports_vision: bool | None = None
+    supports_pdf_input: bool | None = None
+    supports_function_calling: bool | None = None
+    supports_parallel_function_calling: bool | None = None
+    supports_response_schema: bool | None = None
+    supports_system_messages: bool | None = None
+    input_cost_per_token: float | None = None
+    output_cost_per_token: float | None = None
+
+
+def _as_info_dict(info: ModelMetadata | dict[str, Any]) -> dict[str, Any]:
+    """Normalize a model entry to a plain dict, dropping unset (``None``) fields."""
+    if isinstance(info, ModelMetadata):
+        return info.model_dump(exclude_none=True)
+    return info
 
 
 class ModelRegistry:
@@ -48,15 +84,28 @@ class ModelRegistry:
         logger.debug("ModelRegistry: loaded %d models from %s", len(self._models), path)
         self.sync_to_litellm()
 
-    def sync_to_litellm(self) -> None:
-        """Gap-fill loaded registry entries into litellm's in-memory ``model_cost``.
+    def sync_to_litellm(self, models: dict[str, ModelMetadata | dict[str, Any]] | None = None) -> None:
+        """Gap-fill registry entries into litellm's in-memory ``model_cost``.
 
-        For every loaded model litellm does NOT already recognize, register it so that
-        ``litellm.supports_function_calling`` and ``drop_params`` honor our metadata. Never
-        clobbers an entry litellm already knows. Per-process, non-persistent, exception-safe:
-        a missing or misbehaving litellm can never break ``import dynamiq``.
+        For every selected model litellm does NOT already recognize, register it so litellm's
+        own metadata lookups honor our values. Never clobbers an entry litellm already knows.
+        Per-process, non-persistent, exception-safe: a missing or misbehaving litellm can
+        never break ``import dynamiq``.
+
+        Args:
+            models: New model definitions (``{model_id: info}``) to add to the registry and
+                sync directly. Defaults to syncing all already-loaded models.
         """
-        if not _sync_to_litellm_enabled() or not self._models:
+        if not _sync_to_litellm_enabled():
+            return
+        if models is None:
+            items = self._models
+        else:
+            items = {}
+            for model, info in models.items():
+                self.register(model, info)
+                items[model.lower()] = self._models[model.lower()]
+        if not items:
             return
         try:
             import litellm
@@ -65,7 +114,7 @@ class ModelRegistry:
             return
 
         registered = skipped = failed = 0
-        for key, info in self._models.items():
+        for key, info in items.items():
             try:
                 existing = litellm.get_model_info(model=key)  # case-/prefix-tolerant lookup
             except Exception:
@@ -83,16 +132,17 @@ class ModelRegistry:
         log = logger.warning if failed else logger.debug
         log("ModelRegistry->litellm sync: registered=%d skipped=%d failed=%d", registered, skipped, failed)
 
-    def register(self, model: str, info: dict[str, Any]) -> None:
+    def register(self, model: str, info: ModelMetadata | dict[str, Any]) -> None:
         """Add or update a model entry.
 
         Args:
             model: Model identifier (e.g. ``"openai/my-ft-model"``).
-            info: Dict following the litellm model spec (``max_input_tokens``,
-                ``max_output_tokens``, ``supports_vision``, etc.).
+            info: A :class:`ModelMetadata` (preferred) or a litellm-spec dict
+                (``max_input_tokens``, ``supports_vision``, etc.). Merged onto any existing
+                entry, so partial updates only touch the fields provided.
         """
         model = model.lower()
-        self._models[model] = {**self._models.get(model, {}), **info}
+        self._models[model] = {**self._models.get(model, {}), **_as_info_dict(info)}
 
     def _resolve(self, model: str) -> dict[str, Any] | None:
         """Look up model info, stripping the litellm provider prefix if needed.

--- a/dynamiq/nodes/llms/registry.py
+++ b/dynamiq/nodes/llms/registry.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 from dynamiq.utils.logger import logger
 
 REGISTRY_FILE = Path(__file__).with_name("model_registry.json")
+
+_SYNC_ENV_VAR = "DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM"
+_SYNC_DISABLED_VALUES = {"0", "false", "no", "off"}
+
+
+def _sync_to_litellm_enabled() -> bool:
+    """Whether registry entries should be mirrored into litellm's ``model_cost`` (default on)."""
+    return os.getenv(_SYNC_ENV_VAR, "1").strip().lower() not in _SYNC_DISABLED_VALUES
 
 
 class ModelRegistry:
@@ -37,6 +46,42 @@ class ModelRegistry:
                 continue
             self._models[key.lower()] = value
         logger.debug("ModelRegistry: loaded %d models from %s", len(self._models), path)
+        self.sync_to_litellm()
+
+    def sync_to_litellm(self) -> None:
+        """Gap-fill loaded registry entries into litellm's in-memory ``model_cost``.
+
+        For every loaded model litellm does NOT already recognize, register it so that
+        ``litellm.supports_function_calling`` and ``drop_params`` honor our metadata. Never
+        clobbers an entry litellm already knows. Per-process, non-persistent, exception-safe:
+        a missing or misbehaving litellm can never break ``import dynamiq``.
+        """
+        if not _sync_to_litellm_enabled() or not self._models:
+            return
+        try:
+            import litellm
+        except Exception as exc:
+            logger.debug("ModelRegistry: litellm unavailable, skipping sync: %s", exc)
+            return
+
+        registered = skipped = failed = 0
+        for key, info in self._models.items():
+            try:
+                existing = litellm.get_model_info(model=key)  # case-/prefix-tolerant lookup
+            except Exception:
+                existing = None
+            if existing:
+                skipped += 1
+                continue
+            try:
+                litellm.register_model({key: info})
+                registered += 1
+            except Exception as exc:
+                failed += 1
+                logger.debug("ModelRegistry: failed to register %s into litellm: %s", key, exc)
+
+        log = logger.warning if failed else logger.debug
+        log("ModelRegistry->litellm sync: registered=%d skipped=%d failed=%d", registered, skipped, failed)
 
     def register(self, model: str, info: dict[str, Any]) -> None:
         """Add or update a model entry.

--- a/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
+++ b/tests/integration_with_creds/agents/test_agent_e2e_hard_workflow.py
@@ -124,9 +124,9 @@ PROVIDERS = {
         ["SAMBANOVA_API_KEY"],
         _llm_factory(llms.SambaNova, conn.SambaNova, "Meta-Llama-3.3-70B-Instruct"),
     ),
-    "togetherai": (
+    "togetherai_kimi": (
         ["TOGETHER_API_KEY"],
-        _llm_factory(llms.TogetherAI, conn.TogetherAI, "meta-llama/Llama-3.3-70B-Instruct-Turbo"),
+        _llm_factory(llms.TogetherAI, conn.TogetherAI, "moonshotai/kimi-k2.6"),
     ),
     "vertexai": (VERTEXAI_ENV_KEYS, _llm_factory(llms.VertexAI, conn.VertexAI, "gemini-2.5-pro")),
     "watsonx": (
@@ -210,7 +210,7 @@ def test_e2e_hard_workflow_no_recovery(provider, inference_mode, run_config):
             id=f"e2e_hard_workflow_{provider}_{inference_mode.value}",
             llm=llm,
             role=AGENT_ROLE,
-            tools=[ExaTool(connection=conn.Exa())],
+            tools=[ExaTool(connection=conn.Exa(), include_full_content=True)],
             sandbox=SandboxConfig(enabled=True, backend=sandbox_backend),
             inference_mode=inference_mode,
             max_loops=25,

--- a/tests/unit/nodes/llms/test_model_registry.py
+++ b/tests/unit/nodes/llms/test_model_registry.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from dynamiq.nodes.llms.base import LLM_DEFAULT_MAX_TOKENS
-from dynamiq.nodes.llms.registry import ModelRegistry
+from dynamiq.nodes.llms.registry import ModelMetadata, ModelRegistry
 
 MODEL_A = "test-org/model-a"
 MODEL_B = "test-org/model-b"
@@ -293,6 +293,46 @@ def test_sync_respects_disable_env(monkeypatch):
 
     with pytest.raises(Exception):
         litellm.get_model_info(model=MODEL_A.lower())
+
+
+def test_sync_keeps_function_calling_params_under_drop_params(monkeypatch):
+    """Core fix: under ``drop_params=True`` litellm silently strips ``tools`` for a model it
+    doesn't know to support function calling, so FUNCTION_CALLING mode breaks. Once our
+    registry entry (marking the model FC-capable) is synced, litellm keeps ``tools``."""
+    import litellm
+
+    monkeypatch.setenv("DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM", "1")
+
+    # together_ai gates `tools` on per-model FC support, so an unknown model gets them
+    # dropped under drop_params (this is the bug this branch fixes).
+    model = "together_ai/unknown-fc-model"
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "noop", "description": "noop", "parameters": {"type": "object", "properties": {}}},
+        }
+    ]
+
+    def tools_survive() -> bool:
+        params = litellm.utils.get_optional_params(
+            model=model,
+            custom_llm_provider="together_ai",
+            tools=tools,
+            tool_choice="auto",
+            drop_params=True,
+        )
+        return "tools" in params
+
+    # Before sync: litellm doesn't know the model supports FC -> tools dropped.
+    assert tools_survive() is False
+
+    reg = ModelRegistry()
+    reg.sync_to_litellm(
+        models={model: ModelMetadata(supports_function_calling=True, mode="chat", litellm_provider="together_ai")}
+    )
+
+    # After sync: litellm now knows the model is FC-capable -> tools preserved.
+    assert tools_survive() is True
 
 
 def test_sync_is_exception_safe_without_litellm(monkeypatch):

--- a/tests/unit/nodes/llms/test_model_registry.py
+++ b/tests/unit/nodes/llms/test_model_registry.py
@@ -281,6 +281,23 @@ def test_sync_does_not_clobber_known_litellm_model(monkeypatch):
     assert after["max_input_tokens"] != 1
 
 
+def test_sync_disabled_still_registers_models_into_registry(monkeypatch):
+    """The disable env only gates the litellm gap-fill -- models passed to sync_to_litellm
+    must still be added to the registry itself, and must NOT leak into litellm."""
+    import litellm
+
+    monkeypatch.setenv("DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM", "false")
+
+    reg = ModelRegistry()
+    reg.sync_to_litellm(models={MODEL_B: ModelMetadata(**TEST_REGISTRY_DATA[MODEL_B])})
+
+    # Registry registration is unconditional.
+    assert reg.get_model_info(MODEL_B) is not None
+    assert reg.supports_function_calling(MODEL_B) is True
+    # ...but the litellm sync was skipped (check model_cost directly; get_model_info caches).
+    assert MODEL_B.lower() not in litellm.model_cost
+
+
 def test_sync_respects_disable_env(monkeypatch):
     """With the env var disabled, nothing is registered into litellm."""
     import litellm

--- a/tests/unit/nodes/llms/test_model_registry.py
+++ b/tests/unit/nodes/llms/test_model_registry.py
@@ -285,7 +285,7 @@ def test_sync_respects_disable_env(monkeypatch):
     """With the env var disabled, nothing is registered into litellm."""
     import litellm
 
-    monkeypatch.setenv("DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM", "off")
+    monkeypatch.setenv("DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM", "false")
 
     reg = ModelRegistry()
     reg._models = {MODEL_A.lower(): dict(TEST_REGISTRY_DATA[MODEL_A])}

--- a/tests/unit/nodes/llms/test_model_registry.py
+++ b/tests/unit/nodes/llms/test_model_registry.py
@@ -37,6 +37,17 @@ TEST_REGISTRY_DATA = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _restore_litellm_model_cost():
+    """Keep the suite hermetic: ``sync_to_litellm`` mutates the global ``litellm.model_cost``."""
+    import litellm
+
+    snapshot = dict(litellm.model_cost)
+    yield
+    litellm.model_cost.clear()
+    litellm.model_cost.update(snapshot)
+
+
 @pytest.fixture()
 def registry(tmp_path) -> ModelRegistry:
     path = tmp_path / "models.json"
@@ -224,3 +235,79 @@ def test_basellm_uses_litellm_when_model_is_known():
     ):
         assert llm.is_function_calling_supported is False
         mock_fc.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# sync_to_litellm: gap-fill registry entries into litellm.model_cost
+# ---------------------------------------------------------------------------
+
+
+def test_sync_registers_unknown_model_into_litellm(monkeypatch):
+    """After sync, a model litellm didn't know reports FC support via litellm itself."""
+    import litellm
+
+    monkeypatch.setenv("DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM", "1")
+
+    reg = ModelRegistry()
+    reg._models = {MODEL_B.lower(): dict(TEST_REGISTRY_DATA[MODEL_B])}
+
+    # Sanity: litellm must not already know this synthetic model.
+    with pytest.raises(Exception):
+        litellm.get_model_info(model=MODEL_B.lower())
+
+    reg.sync_to_litellm()
+
+    assert litellm.get_model_info(model=MODEL_B.lower())["supports_function_calling"] is True
+    # litellm's lookup is provider-prefix tolerant, so the prefixed form resolves too.
+    assert litellm.supports_function_calling(f"together_ai/{MODEL_B}") is True
+
+
+def test_sync_does_not_clobber_known_litellm_model(monkeypatch):
+    """A model litellm already knows must keep litellm's own metadata, not ours."""
+    import litellm
+
+    monkeypatch.setenv("DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM", "1")
+
+    known = "gpt-4o-mini"  # shipped in litellm's model map
+    original = dict(litellm.get_model_info(model=known))
+
+    reg = ModelRegistry()
+    # Deliberately poisoned metadata for a model litellm already knows.
+    reg._models = {known: {"max_input_tokens": 1, "supports_function_calling": False}}
+    reg.sync_to_litellm()
+
+    after = litellm.get_model_info(model=known)
+    assert after["max_input_tokens"] == original["max_input_tokens"]
+    assert after["max_input_tokens"] != 1
+
+
+def test_sync_respects_disable_env(monkeypatch):
+    """With the env var disabled, nothing is registered into litellm."""
+    import litellm
+
+    monkeypatch.setenv("DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM", "off")
+
+    reg = ModelRegistry()
+    reg._models = {MODEL_A.lower(): dict(TEST_REGISTRY_DATA[MODEL_A])}
+    reg.sync_to_litellm()
+
+    with pytest.raises(Exception):
+        litellm.get_model_info(model=MODEL_A.lower())
+
+
+def test_sync_is_exception_safe_without_litellm(monkeypatch):
+    """If importing litellm fails, sync must swallow it and not raise."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _boom(name, *args, **kwargs):
+        if name == "litellm":
+            raise ImportError("simulated")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _boom)
+
+    reg = ModelRegistry()
+    reg._models = {MODEL_A.lower(): dict(TEST_REGISTRY_DATA[MODEL_A])}
+    reg.sync_to_litellm()  # must not raise


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mutates global litellm `model_cost` at import/load time, which can affect all litellm calls in-process, though it only adds unknown models and is designed not to break imports.
> 
> **Overview**
> **Model registry entries are now mirrored into litellm’s in-memory `model_cost` on load**, so litellm’s own lookups (including `drop_params` stripping of `tools`) honor Dynamiq metadata for models litellm doesn’t ship. Sync is **gap-fill only** (never overwrites models litellm already knows), is **on by default** via `DYNAMIQ_SYNC_MODEL_REGISTRY_TO_LITELLM` (only `"false"` disables it), and is **exception-safe** if litellm is missing or fails.
> 
> `ModelMetadata` (Pydantic) types registry fields; `register` accepts it or dicts and merges partial updates. **`moonshotai/kimi-k2.6`** gains `litellm_provider: together_ai` in JSON.
> 
> E2E matrix: Together provider case renamed to **`togetherai_kimi`** using **`moonshotai/kimi-k2.6`**; **`ExaTool(..., include_full_content=True)`** in the hard workflow test. Unit tests cover sync, disable env, non-clobbering, FC/`tools` under `drop_params`, and litellm import failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041db131860cd8d5577f7b604498d77ca0c84c40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->