### PR TITLE
fix: update output files parsing

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -2012,11 +2012,17 @@ class Agent(HistoryManagerMixin, BaseAgent):
     def _parse_output_files_csv(raw: str) -> list[str]:
         """Parse a comma-separated string of file paths into a list.
 
-        Strips whitespace from each entry and drops empty entries.
+        Strips whitespace from each entry and drops empty entries. Entries
+        containing angle brackets are dropped: the model occasionally bleeds a
+        control-token fragment (e.g. ``</antml：parameter>``, a fullwidth-colon
+        variant of the tool-call XML closing tag) into the ``output_files`` field,
+        and a real file path never contains ``<`` or ``>``. Letting such junk
+        through made it a phantom file request that failed resolution and forced a
+        wasted retry.
         """
         if not raw or not raw.strip():
             return []
-        return [p.strip() for p in raw.split(",") if p.strip()]
+        return [p.strip() for p in raw.split(",") if p.strip() and "<" not in p and ">" not in p]
 
     def _resolve_requested_output_files(self, *, strict: bool = True) -> None:
         """Resolve ``_requested_output_files`` against the file backend.

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -2012,17 +2012,11 @@ class Agent(HistoryManagerMixin, BaseAgent):
     def _parse_output_files_csv(raw: str) -> list[str]:
         """Parse a comma-separated string of file paths into a list.
 
-        Strips whitespace from each entry and drops empty entries. Entries
-        containing angle brackets are dropped: the model occasionally bleeds a
-        control-token fragment (e.g. ``</antml：parameter>``, a fullwidth-colon
-        variant of the tool-call XML closing tag) into the ``output_files`` field,
-        and a real file path never contains ``<`` or ``>``. Letting such junk
-        through made it a phantom file request that failed resolution and forced a
-        wasted retry.
+        Strips whitespace from each entry and drops empty entries.
         """
         if not raw or not raw.strip():
             return []
-        return [p.strip() for p in raw.split(",") if p.strip() and "<" not in p and ">" not in p]
+        return [p.strip() for p in raw.split(",") if p.strip()]
 
     def _resolve_requested_output_files(self, *, strict: bool = True) -> None:
         """Resolve ``_requested_output_files`` against the file backend.

--- a/dynamiq/nodes/agents/components/schema_generator.py
+++ b/dynamiq/nodes/agents/components/schema_generator.py
@@ -33,10 +33,10 @@ FINAL_ANSWER_FUNCTION_SCHEMA = {
                 "answer": {"type": "string", "description": "Answer on initial request."},
                 "output_files": {
                     "type": "string",
-                    "description": "Optional comma-separated file paths to return. Empty string if none.",
+                    "description": "Optional comma-separated file paths to return.",
                 },
             },
-            "required": ["thought", "answer", "output_files"],
+            "required": ["thought", "answer"],
             "additionalProperties": False,
         },
     },
@@ -86,10 +86,10 @@ def build_final_answer_function_schema(response_format: dict | type[BaseModel] |
             "answer": answer_schema,
             "output_files": {
                 "type": "string",
-                "description": "Optional comma-separated file paths to return. Empty string if none.",
+                "description": "Optional comma-separated file paths to return.",
             },
         },
-        "required": ["thought", "answer", "output_files"],
+        "required": ["thought", "answer"],
         "additionalProperties": False,
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small JSON-schema tweak for an optional agent field; runtime already treats missing `output_files` as empty.
> 
> **Overview**
> **Makes `output_files` optional** on the `provide_final_answer` function-calling schema in `schema_generator.py`, for both the static `FINAL_ANSWER_FUNCTION_SCHEMA` and the dynamic schema from `build_final_answer_function_schema`.
> 
> `required` now only includes `thought` and `answer`. The `output_files` property description no longer tells the model to send an empty string when there are no files.
> 
> This lines up with agent-side handling (`FinalAnswerArguments` defaults and `_coerce_output_files` / `_parse_output_files_csv`), so final answers without file paths are valid when the model omits the field instead of forcing an empty string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc87f25ce7e11cf1dca2375212e46a6020d9be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->