### PR TITLE
fix: Update prompt for SO

### DIFF
--- a/dynamiq/nodes/agents/prompts/react/instructions.py
+++ b/dynamiq/nodes/agents/prompts/react/instructions.py
@@ -175,6 +175,8 @@ IMPORTANT RULES:
 - ALWAYS populate the "thought" field FIRST before any other field (particularly "action_input") in your response.
 - Each tool has a specific input format you must strictly follow
 - In action_input field, provide properly formatted JSON with double quotes
+- action_input MUST always be a JSON object mapping the tool's argument names to values, even for a
+  single argument — never a bare value. Example: action_input: "{\\"query\\": \\"latest sales\\", \\"limit\\": 5}".
 - When action_input contains multi-line content (e.g. shell commands, code), you MUST escape newlines as \\n within the JSON string — do NOT use literal line breaks inside JSON string values.
 - Json has to be parsable with json.loads() in Python.
 - Do not use markdown code blocks around your JSON


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Prompt-only change to agent instructions; no runtime logic or security paths modified.
> 
> **Overview**
> Tightens the **structured JSON ReAct** agent instructions so `action_input` must always be a **JSON object** whose keys match the tool’s argument names, not a bare string or scalar.
> 
> Adds an explicit rule plus an example (`{"query": "...", "limit": 5}`) alongside the existing `json.loads()` guidance, aimed at reducing flaky structured-output behavior when models wrap or simplify tool inputs incorrectly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b57e281046b1121eeb949199d32c15ea8f401c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->