### PR TITLE
feat: add Novita AI LLM provider

### DIFF
--- a/dynamiq/connections/connections.py
+++ b/dynamiq/connections/connections.py
@@ -999,6 +999,13 @@ class SambaNova(BaseApiKeyConnection):
         pass
 
 
+class Novita(BaseApiKeyConnection):
+    api_key: str = Field(default_factory=partial(get_env_var, "NOVITA_API_KEY"))
+
+    def connect(self):
+        pass
+
+
 class MilvusDeploymentType(str, enum.Enum):
     """
     Defines general deployment types for Milvus deployments.

--- a/dynamiq/nodes/llms/__init__.py
+++ b/dynamiq/nodes/llms/__init__.py
@@ -15,6 +15,7 @@ from .gemini import Gemini
 from .groq import Groq
 from .huggingface import HuggingFace
 from .mistral import Mistral
+from .novita import Novita
 from .nvidia_nim import NvidiaNIM
 from .ollama import Ollama
 from .openai import OpenAI

--- a/dynamiq/nodes/llms/novita.py
+++ b/dynamiq/nodes/llms/novita.py
@@ -1,0 +1,26 @@
+from dynamiq.connections import Novita as NovitaConnection
+from dynamiq.nodes.llms.base import BaseLLM
+
+
+class Novita(BaseLLM):
+    """Novita AI LLM node.
+
+    This class provides an implementation for the Novita AI Language Model node.
+
+    Attributes:
+        connection (NovitaConnection | None): The connection to use for the Novita AI LLM.
+        MODEL_PREFIX (str): The prefix for the Novita AI model name.
+    """
+
+    connection: NovitaConnection | None = None
+    MODEL_PREFIX = "novita/"
+
+    def __init__(self, **kwargs):
+        """Initialize the Novita AI LLM node.
+
+        Args:
+            **kwargs: Additional keyword arguments.
+        """
+        if kwargs.get("client") is None and kwargs.get("connection") is None:
+            kwargs["connection"] = NovitaConnection()
+        super().__init__(**kwargs)

--- a/examples/llm_setup.py
+++ b/examples/llm_setup.py
@@ -2,11 +2,13 @@ from dynamiq.connections import Anthropic as AnthropicConnection
 from dynamiq.connections import Cohere as CohereConnection
 from dynamiq.connections import Gemini as GeminiConnection
 from dynamiq.connections import Groq as GroqConnection
+from dynamiq.connections import Novita as NovitaConnection
 from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.nodes.llms.anthropic import Anthropic
 from dynamiq.nodes.llms.cohere import Cohere
 from dynamiq.nodes.llms.gemini import Gemini
 from dynamiq.nodes.llms.groq import Groq
+from dynamiq.nodes.llms.novita import Novita
 from dynamiq.nodes.llms.openai import OpenAI
 
 MODEL_NAME_GPT = "gpt-4o"
@@ -14,6 +16,7 @@ MODEL_NAME_CLAUDE = "claude-3-5-sonnet-20240620"
 MODEL_NAME_COHERE = "command-r-plus"
 MODEL_NAME_GROQ = "groq/llama3-70b-8192"
 MODEL_NAME_GEMINI = "gemini/gemini-1.5-pro-latest"
+MODEL_NAME_NOVITA = "novita/deepseek/deepseek-v3.2"
 MODEL_PROVIDER = "gpt"
 MODEL_NAME = MODEL_NAME_GPT
 TEMPERATURE = 0.1
@@ -74,6 +77,14 @@ def setup_llm(
         return Gemini(
             name="Gemini LLM",
             connection=GeminiConnection(),
+            model=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+    elif model_provider == "novita":
+        return Novita(
+            name="Novita LLM",
+            connection=NovitaConnection(),
             model=model_name,
             temperature=temperature,
             max_tokens=max_tokens,

--- a/tests/integration/nodes/llms/test_novita.py
+++ b/tests/integration/nodes/llms/test_novita.py
@@ -1,0 +1,89 @@
+import uuid
+
+import pytest
+
+from dynamiq import Workflow, connections
+from dynamiq.callbacks import TracingCallbackHandler
+from dynamiq.flows import Flow
+from dynamiq.nodes.llms import Novita
+from dynamiq.prompts import Message, Prompt
+from dynamiq.runnables import RunnableConfig, RunnableResult, RunnableStatus
+
+
+def get_novita_workflow(
+    model: str,
+    connection: connections.Novita,
+):
+    wf_novita = Workflow(
+        id=str(uuid.uuid4()),
+        flow=Flow(
+            nodes=[
+                Novita(
+                    name="Novita",
+                    model=model,
+                    connection=connection,
+                    prompt=Prompt(
+                        messages=[
+                            Message(
+                                role="user",
+                                content="What is LLM?",
+                            ),
+                        ],
+                    ),
+                    temperature=0.1,
+                ),
+            ],
+        ),
+    )
+
+    return wf_novita
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_model"),
+    [
+        ("novita/deepseek/deepseek-v3.2", "novita/deepseek/deepseek-v3.2"),
+        ("deepseek/deepseek-v3.2", "novita/deepseek/deepseek-v3.2"),
+    ],
+)
+def test_workflow_with_novita_llm(mock_llm_response_text, mock_llm_executor, model, expected_model):
+    connection = connections.Novita(
+        id=str(uuid.uuid4()),
+        api_key="api_key",
+    )
+    wf_novita = get_novita_workflow(model=model, connection=connection)
+
+    response = wf_novita.run(
+        input_data={},
+        config=RunnableConfig(callbacks=[TracingCallbackHandler()]),
+    )
+
+    expected_result = RunnableResult(
+        status=RunnableStatus.SUCCESS,
+        input={},
+        output={"content": mock_llm_response_text},
+    ).to_dict()
+    expected_output = {wf_novita.flow.nodes[0].id: expected_result}
+    assert response == RunnableResult(
+        status=RunnableStatus.SUCCESS,
+        input={},
+        output=expected_output,
+    )
+    assert response.output == expected_output
+    mock_llm_executor.assert_called_once_with(
+        tools=None,
+        tool_choice=None,
+        model=expected_model,
+        messages=wf_novita.flow.nodes[0].prompt.format_messages(),
+        stream=False,
+        temperature=0.1,
+        max_tokens=None,
+        stop=None,
+        seed=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        top_p=None,
+        api_key=connection.api_key,
+        response_format=None,
+        drop_params=True,
+    )

--- a/tests/smoke/test_agent_e2e_hard_workflow.py
+++ b/tests/smoke/test_agent_e2e_hard_workflow.py
@@ -108,6 +108,7 @@ PROVIDERS = {
         _llm_factory(llms.HuggingFace, conn.HuggingFace, "meta-llama/Meta-Llama-3.1-70B-Instruct"),
     ),
     "mistral": (["MISTRAL_API_KEY"], _llm_factory(llms.Mistral, conn.Mistral, "mistral-large-latest")),
+    "novita": (["NOVITA_API_KEY"], _llm_factory(llms.Novita, conn.Novita, "deepseek/deepseek-v3.2")),
     "nvidia_nim": (
         ["NVIDIA_NIM_API_KEY", "NVIDIA_NIM_URL"],
         _llm_factory(llms.NvidiaNIM, conn.NvidiaNIM, "meta/llama-3.3-70b-instruct"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive provider registration with no changes to shared LLM execution paths beyond a new connection and node class.
> 
> **Overview**
> Adds **Novita AI** as a first-class LLM provider, following the same pattern as other API-key backends (e.g. SambaNova).
> 
> A `Novita` connection reads **`NOVITA_API_KEY`**, and a thin **`Novita`** LLM node extends `BaseLLM` with **`MODEL_PREFIX = "novita/"`** so bare model IDs get normalized (covered in integration tests). The provider is exported from `dynamiq.nodes.llms`, wired in **`examples/llm_setup.py`** via a `novita` branch, and included in the smoke **provider matrix** for optional e2e runs when creds are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f88290bd2b4a821ab879a26dcf75a5064dbe5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->