### PR TITLE
fix: detect sampling-param rejection by model family + version

### DIFF
--- a/dynamiq/nodes/llms/base.py
+++ b/dynamiq/nodes/llms/base.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import re
 import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, Union
@@ -168,13 +169,18 @@ class LLMCheckpointState(BaseCheckpointState):
 
 SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
 
-SAMPLING_UNSUPPORTED_MODEL_MARKERS: tuple[str, ...] = (
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-fable-5",
-    "claude-mythos-5",
-    "claude-mythos-preview",
-)
+# Model families where every version rejects sampling params.
+_SAMPLING_UNSUPPORTED_FAMILIES_ALL: frozenset[str] = frozenset({"mythos"})
+
+# Model families that reject sampling params at or above a (major, minor) version.
+_SAMPLING_UNSUPPORTED_MIN_VERSION: dict[str, tuple[int, int]] = {
+    "opus": (4, 7),
+    "sonnet": (5, 0),
+    "fable": (5, 0),
+}
+
+# Matches `claude-<family>-<major>[-<minor>]` anywhere in a model id
+_CLAUDE_MODEL_RE = re.compile(r"claude-(opus|sonnet|haiku|fable|mythos)(?:-(\d{1,2})(?!\d)(?:-(\d{1,2})(?!\d))?)?")
 
 _SAMPLING_UNSUPPORTED_INDICATORS: tuple[str, ...] = (
     "not permitted",
@@ -701,9 +707,25 @@ class BaseLLM(ConnectionNode):
         return response_format, tools
 
     def _model_rejects_sampling_params(self) -> bool:
-        """Whether self.model is known to reject sampling params with a 400."""
-        model_lower = self.model.lower()
-        return any(marker in model_lower for marker in SAMPLING_UNSUPPORTED_MODEL_MARKERS)
+        """Whether self.model is known to reject sampling params (temperature/top_p/top_k)
+        with a 400.
+
+        Recognizes Anthropic models by family and version, so future releases that follow
+        the existing naming scheme are handled without a code change (e.g. claude-opus-5 and
+        claude-sonnet-6 reject; claude-haiku-5 does not, matching current Haiku behavior).
+        Models not matched here that nonetheless reject are caught at runtime by
+        ``_recover_completion_params``.
+        """
+        match = _CLAUDE_MODEL_RE.search(self.model.lower())
+        if not match:
+            return False
+        family, major, minor = match.group(1), match.group(2), match.group(3)
+        if family in _SAMPLING_UNSUPPORTED_FAMILIES_ALL:
+            return True
+        cutoff = _SAMPLING_UNSUPPORTED_MIN_VERSION.get(family)
+        if cutoff is None or major is None:
+            return False
+        return (int(major), int(minor or 0)) >= cutoff
 
     def update_completion_params(self, params: dict[str, Any]) -> dict[str, Any]:
         """
@@ -895,7 +917,7 @@ class BaseLLM(ConnectionNode):
         re-raise the original error.
 
         Default implementation: backstop for models that reject sampling params with a 400
-        but are not yet listed in SAMPLING_UNSUPPORTED_MODEL_MARKERS. Returns the params
+        but are not matched by ``_model_rejects_sampling_params``. Returns the params
         with the sampling params stripped. Only fires when the error both names a present
         sampling param and looks like an unsupported-param error, so genuine validation
         errors (e.g. out-of-range temperature) still surface.
@@ -907,7 +929,7 @@ class BaseLLM(ConnectionNode):
         if present and references_param and looks_unsupported:
             logger.warning(
                 "LLM '%s': model '%s' rejected sampling params %s; retrying without them "
-                "(add the model to SAMPLING_UNSUPPORTED_MODEL_MARKERS to skip this failed attempt).",
+                "(extend _SAMPLING_UNSUPPORTED_MIN_VERSION/_FAMILIES_ALL to skip this failed attempt).",
                 self.name,
                 self.model,
                 present,

--- a/tests/unit/nodes/llms/test_sampling_params_unsupported.py
+++ b/tests/unit/nodes/llms/test_sampling_params_unsupported.py
@@ -6,7 +6,7 @@ from dynamiq.connections import AWS as AWSConnection
 from dynamiq.connections import Anthropic as AnthropicConnection
 from dynamiq.connections import HttpApiKey
 from dynamiq.nodes.llms.anthropic import Anthropic
-from dynamiq.nodes.llms.base import SAMPLING_PARAMS, SAMPLING_UNSUPPORTED_MODEL_MARKERS
+from dynamiq.nodes.llms.base import SAMPLING_PARAMS
 from dynamiq.nodes.llms.bedrock import Bedrock
 from dynamiq.nodes.llms.custom_llm import CustomLLM
 from dynamiq.prompts import Prompt
@@ -40,7 +40,24 @@ def anthropic_supported():
 
 
 class TestDetection:
-    @pytest.mark.parametrize("model", SAMPLING_UNSUPPORTED_MODEL_MARKERS)
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # Known rejecting generations.
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-sonnet-5",
+            "claude-fable-5",
+            "claude-mythos-5",
+            "claude-mythos-preview",
+            # Future versioned releases.
+            "claude-opus-4-9",
+            "claude-opus-4-10",
+            "claude-opus-5",
+            "claude-sonnet-5-1",
+            "claude-sonnet-6",
+        ],
+    )
     def test_unsupported_models_detected(self, model):
         llm = Anthropic(name="a", model=model, connection=AnthropicConnection(api_key="x"))
         assert llm._model_rejects_sampling_params() is True
@@ -50,12 +67,29 @@ class TestDetection:
         ["bedrock/eu.anthropic.{}-20251101-v1:0", "openrouter/anthropic/{}"],
     )
     def test_detection_is_provider_prefix_independent(self, template):
-        # A marker must be detected regardless of the provider prefix wrapped around it.
-        model = template.format(SAMPLING_UNSUPPORTED_MODEL_MARKERS[0])
+        # A rejecting model must be detected regardless of the provider prefix wrapped around it,
+        # including a trailing date suffix that must not be parsed as the minor version.
+        model = template.format("claude-sonnet-5")
         llm = Anthropic(name="a", model=model, connection=AnthropicConnection(api_key="x"))
         assert llm._model_rejects_sampling_params() is True
 
-    @pytest.mark.parametrize("model", ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-4o"])
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # Older Anthropic generations that still accept sampling params.
+            "claude-opus-4-5",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            # Dated full id for Opus 4.0 — the date must not be read as a minor version above the cutoff.
+            "claude-opus-4-20250514",
+            # No released Haiku rejects yet; a future one is left to the runtime backstop.
+            "claude-haiku-5",
+            # Retired pre-4 naming and non-Anthropic models must not false-positive.
+            "claude-3-5-sonnet-20241022",
+            "gpt-4o",
+        ],
+    )
     def test_supported_models_not_detected(self, model):
         llm = Anthropic(name="a", model=model, connection=AnthropicConnection(api_key="x"))
         assert llm._model_rejects_sampling_params() is False


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how completion params are built for Anthropic-style model ids; incorrect parsing could strip sampling on supported models or skip pre-strip on new rejectors, though runtime recovery mitigates the latter.
> 
> **Overview**
> Replaces the hardcoded list of model id substrings with **family + version rules** so `temperature` / `top_p` / `top_k` are stripped before completion for new Claude ids that follow the same naming pattern (e.g. future Opus/Sonnet) without another code change.
> 
> `_model_rejects_sampling_params` now parses `claude-<family>-<major>[-<minor>]` via regex inside the full model string (Bedrock/OpenRouter prefixes and trailing date segments are handled so dates are not mistaken for minor versions). **Mythos** always rejects sampling; **Opus** from 4.7+, **Sonnet** and **Fable** from 5.0+; **Haiku** is not pre-stripped (runtime `_recover_completion_params` still applies). Log hints point maintainers at `_SAMPLING_UNSUPPORTED_MIN_VERSION` / `_SAMPLING_UNSUPPORTED_FAMILIES_ALL` instead of the removed marker list.
> 
> Unit tests cover future versions, provider-prefixed ids, dated Opus ids, and models that must not false-positive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46377ccd26e3a20ba5aaa6e62dce171432e42bcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->