### PR TITLE
fix: upd converters

### DIFF
--- a/dynamiq/components/converters/excel.py
+++ b/dynamiq/components/converters/excel.py
@@ -1,0 +1,131 @@
+import copy
+import csv
+from io import BytesIO, StringIO
+from pathlib import Path
+from typing import Any, Literal
+
+from openpyxl import load_workbook
+
+from dynamiq.components.converters.base import BaseConverter
+from dynamiq.components.converters.utils import get_filename_for_bytesio
+from dynamiq.types import Document, DocumentCreationMode
+
+
+class ExcelFileConverter(BaseConverter):
+    """
+    A component for converting spreadsheet files (xlsx, csv, tsv) to Documents.
+
+    Excel workbooks are read with openpyxl and every sheet is rendered as a markdown
+    table (one section per sheet). CSV/TSV files are parsed with the stdlib csv module
+    and rendered as a single markdown table.
+
+    Args:
+        document_creation_mode (Literal["one-doc-per-file"], optional):
+            Determines how to create Documents from the spreadsheet content. Currently only
+            supports:
+            - `"one-doc-per-file"`: Creates one Document per file.
+            Defaults to `"one-doc-per-file"`.
+
+    Usage example:
+        ```python
+        from dynamiq.components.converters.excel import ExcelFileConverter
+
+        converter = ExcelFileConverter()
+        documents = converter.run(file_paths=["a/file/path.xlsx"])["documents"]
+        ```
+    """
+
+    document_creation_mode: Literal[DocumentCreationMode.ONE_DOC_PER_FILE] = DocumentCreationMode.ONE_DOC_PER_FILE
+
+    def _process_file(self, file: Path | BytesIO, metadata: dict[str, Any]) -> list[Any]:
+        """
+        Process a file and return a list of Documents.
+
+        Args:
+            file: Path to a file or BytesIO object
+            metadata: Metadata to attach to the documents
+
+        Returns:
+            List of Documents
+        """
+        if isinstance(file, BytesIO):
+            filepath = get_filename_for_bytesio(file)
+            file.seek(0)
+            data = file.read()
+            file.seek(0)
+        else:
+            filepath = str(file)
+            with open(file, "rb") as f:
+                data = f.read()
+
+        extension = Path(filepath).suffix.lower()
+        if extension in {".csv", ".tsv"}:
+            content = self._convert_delimited(data, delimiter="\t" if extension == ".tsv" else ",")
+        else:
+            content = self._convert_workbook(data)
+
+        return self._create_documents(
+            filepath=filepath,
+            content=content,
+            document_creation_mode=self.document_creation_mode,
+            metadata=metadata,
+        )
+
+    def _convert_workbook(self, data: bytes) -> str:
+        """Convert an Excel workbook to markdown, one table section per sheet."""
+        workbook = load_workbook(BytesIO(data), read_only=True, data_only=True)
+        try:
+            sections = []
+            for worksheet in workbook.worksheets:
+                rows = [
+                    ["" if cell is None else str(cell) for cell in row] for row in worksheet.iter_rows(values_only=True)
+                ]
+                table = self._to_markdown_table(rows)
+                if table:
+                    sections.append(f"## {worksheet.title}\n\n{table}" if len(workbook.worksheets) > 1 else table)
+            return "\n\n".join(sections)
+        finally:
+            workbook.close()
+
+    def _convert_delimited(self, data: bytes, delimiter: str) -> str:
+        """Convert CSV/TSV content to a markdown table."""
+        text = data.decode("utf-8-sig", errors="replace")
+        rows = list(csv.reader(StringIO(text), delimiter=delimiter))
+        return self._to_markdown_table(rows)
+
+    @staticmethod
+    def _to_markdown_table(rows: list[list[str]]) -> str:
+        """Render rows as a markdown table, treating the first row as the header."""
+        rows = [row for row in rows if any(cell.strip() for cell in row)]
+        if not rows:
+            return ""
+
+        width = max(len(row) for row in rows)
+
+        def render_row(row: list[str]) -> str:
+            padded = row + [""] * (width - len(row))
+            cells = [cell.replace("|", "\\|").replace("\n", " ") for cell in padded]
+            return "| " + " | ".join(cells) + " |"
+
+        lines = [render_row(rows[0]), "| " + " | ".join(["---"] * width) + " |"]
+        lines.extend(render_row(row) for row in rows[1:])
+        return "\n".join(lines)
+
+    def _create_documents(
+        self,
+        filepath: str,
+        content: str,
+        document_creation_mode: DocumentCreationMode,
+        metadata: dict[str, Any],
+        **kwargs,
+    ) -> list[Document]:
+        """
+        Create Documents from the spreadsheet content.
+        """
+        if document_creation_mode != DocumentCreationMode.ONE_DOC_PER_FILE:
+            raise ValueError("ExcelFileConverter only supports one-doc-per-file mode")
+
+        metadata = copy.deepcopy(metadata)
+        metadata["file_path"] = filepath
+
+        return [Document(content=content.strip(), metadata=metadata)]

--- a/dynamiq/components/converters/excel.py
+++ b/dynamiq/components/converters/excel.py
@@ -11,6 +11,9 @@ from dynamiq.components.converters.utils import get_filename_for_bytesio
 from dynamiq.types import Document, DocumentCreationMode
 
 
+SUPPORTED_EXCEL_EXTENSIONS = {".csv", ".tsv", ".xlsx"}
+
+
 class ExcelFileConverter(BaseConverter):
     """
     A component for converting spreadsheet files (xlsx, csv, tsv) to Documents.
@@ -59,6 +62,13 @@ class ExcelFileConverter(BaseConverter):
                 data = f.read()
 
         extension = Path(filepath).suffix.lower()
+        if extension and extension not in SUPPORTED_EXCEL_EXTENSIONS:
+            supported_extensions = ", ".join(sorted(SUPPORTED_EXCEL_EXTENSIONS))
+            raise ValueError(
+                f"Unsupported spreadsheet extension '{extension}'. "
+                f"ExcelFileConverter supports: {supported_extensions}."
+            )
+
         if extension in {".csv", ".tsv"}:
             content = self._convert_delimited(data, delimiter="\t" if extension == ".tsv" else ",")
         else:

--- a/dynamiq/components/converters/excel.py
+++ b/dynamiq/components/converters/excel.py
@@ -72,7 +72,8 @@ class ExcelFileConverter(BaseConverter):
         if extension in {".csv", ".tsv"}:
             content = self._convert_delimited(data, delimiter="\t" if extension == ".tsv" else ",")
         else:
-            content = self._convert_workbook(data)
+            delimiter = None if extension else self._detect_delimiter(data)
+            content = self._convert_delimited(data, delimiter=delimiter) if delimiter else self._convert_workbook(data)
 
         return self._create_documents(
             filepath=filepath,
@@ -102,6 +103,37 @@ class ExcelFileConverter(BaseConverter):
         text = data.decode("utf-8-sig", errors="replace")
         rows = list(csv.reader(StringIO(text), delimiter=delimiter))
         return self._to_markdown_table(rows)
+
+    @staticmethod
+    def _detect_delimiter(data: bytes) -> str | None:
+        """Detect extensionless CSV/TSV content without treating binary workbooks as text."""
+        if b"\x00" in data[:8192]:
+            return None
+        try:
+            text = data.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            return None
+
+        lines = [line for line in text.splitlines() if line.strip()]
+        if len(lines) < 2:
+            return None
+
+        sample = "\n".join(lines[:10])
+        for delimiter in (",", "\t"):
+            rows = list(csv.reader(StringIO(sample), delimiter=delimiter))
+            rows = [row for row in rows if any(cell.strip() for cell in row)]
+            if len(rows) < 2:
+                continue
+
+            widths = [len(row) for row in rows]
+            if max(widths) < 2:
+                continue
+
+            most_common_width = max(set(widths), key=widths.count)
+            if most_common_width >= 2 and widths.count(most_common_width) / len(widths) >= 0.8:
+                return delimiter
+
+        return None
 
     @staticmethod
     def _to_markdown_table(rows: list[list[str]]) -> str:

--- a/dynamiq/components/converters/html.py
+++ b/dynamiq/components/converters/html.py
@@ -14,6 +14,14 @@ from dynamiq.components.converters.utils import get_filename_for_bytesio
 from dynamiq.types import Document, DocumentCreationMode
 
 
+UNICODE_BOMS_WITH_NULL_BYTES = (
+    b"\xff\xfe",
+    b"\xfe\xff",
+    b"\xff\xfe\x00\x00",
+    b"\x00\x00\xfe\xff",
+)
+
+
 class HTMLConverter(BaseConverter):
     """
     A component for converting HTML files to Documents using lxml.
@@ -85,8 +93,9 @@ class HTMLConverter(BaseConverter):
         Returns:
             lxml HTML element
         """
-        if b"\x00" in html_content:
+        if b"\x00" in html_content and not html_content.startswith(UNICODE_BOMS_WITH_NULL_BYTES):
             raise ValueError("File content is binary, not HTML")
+
         try:
             # Bytes input lets lxml resolve the charset and encoding declaration itself;
             # a str input makes it reject pages starting with <?xml ... encoding=...?>.

--- a/dynamiq/components/converters/html.py
+++ b/dynamiq/components/converters/html.py
@@ -56,12 +56,12 @@ class HTMLConverter(BaseConverter):
         else:
             filepath = str(file)
 
-        # Read the file content
+        # Read the file content as bytes; decoding is delegated to lxml (see _parse_html_content)
         if isinstance(file, BytesIO):
             file.seek(0)
-            html_content = file.read().decode("utf-8")
+            html_content = file.read()
         else:
-            with open(file, encoding="utf-8") as f:
+            with open(file, "rb") as f:
                 html_content = f.read()
 
         # Parse the HTML content
@@ -75,7 +75,7 @@ class HTMLConverter(BaseConverter):
             metadata=metadata,
         )
 
-    def _parse_html_content(self, html_content: str) -> lxml_html.HtmlElement:
+    def _parse_html_content(self, html_content: bytes) -> lxml_html.HtmlElement:
         """
         Parse HTML content using lxml.
 
@@ -85,12 +85,16 @@ class HTMLConverter(BaseConverter):
         Returns:
             lxml HTML element
         """
+        if b"\x00" in html_content:
+            raise ValueError("File content is binary, not HTML")
         try:
+            # Bytes input lets lxml resolve the charset and encoding declaration itself;
+            # a str input makes it reject pages starting with <?xml ... encoding=...?>.
             return lxml_html.fromstring(html_content)
         except etree.ParserError:
             # Handle malformed HTML by cleaning it first
-            html_content = self._clean_html(html_content)
-            return lxml_html.fromstring(html_content)
+            cleaned = self._clean_html(html_content.decode("utf-8", errors="replace"))
+            return lxml_html.fromstring(cleaned)
 
     @staticmethod
     def _clean_html(html_content: str) -> str:

--- a/dynamiq/nodes/converters/__init__.py
+++ b/dynamiq/nodes/converters/__init__.py
@@ -1,5 +1,6 @@
 from .csv import CSVConverter
 from .docx import DOCXFileConverter
+from .excel import ExcelFileConverter
 from .html import HTMLConverter
 from .llm_text_extractor import LLMImageConverter, LLMPDFConverter
 from .multi_file_type_converter import MultiFileTypeConverter

--- a/dynamiq/nodes/converters/excel.py
+++ b/dynamiq/nodes/converters/excel.py
@@ -1,0 +1,101 @@
+from io import BytesIO
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from dynamiq.components.converters.excel import ExcelFileConverter as ExcelFileConverterComponent
+from dynamiq.connections.managers import ConnectionManager
+from dynamiq.nodes.node import ErrorHandling, Node, NodeGroup, ensure_config
+from dynamiq.runnables import RunnableConfig
+from dynamiq.utils.logger import logger
+
+
+class ExcelFileConverterInputSchema(BaseModel):
+    file_paths: list[str] = Field(default=None, description="Parameter to provide path to files.")
+    files: list[BytesIO] = Field(default=None, description="Parameter to provide files.")
+    metadata: dict | list = Field(default=None, description="Parameter to provide metadata.")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @model_validator(mode="after")
+    def validate_file_source(self):
+        """Validate that either `file_paths` or `files` is specified"""
+        if not self.file_paths and not self.files:
+            raise ValueError("Either `file_paths` or `files` must be provided.")
+        return self
+
+
+class ExcelFileConverter(Node):
+    """
+    A component for converting spreadsheet files (xlsx, csv, tsv) to Documents with markdown tables.
+    """
+
+    group: Literal[NodeGroup.CONVERTERS] = NodeGroup.CONVERTERS
+    name: str = "excel-file-converter"
+    error_handling: ErrorHandling = Field(
+        default_factory=lambda: ErrorHandling(timeout_seconds=60.0),
+        description="Default execution timeout. Set timeout_seconds to None to disable.",
+    )
+    file_converter: ExcelFileConverterComponent | None = None
+    input_schema: ClassVar[type[ExcelFileConverterInputSchema]] = ExcelFileConverterInputSchema
+
+    @property
+    def to_dict_exclude_params(self):
+        return super().to_dict_exclude_params | {"file_converter": True}
+
+    def init_components(self, connection_manager: ConnectionManager | None = None):
+        """
+        Initialize the components of the ExcelFileConverter.
+
+        Args:
+            connection_manager (ConnectionManager, optional): The connection manager to use.
+                Defaults to a new ConnectionManager instance.
+        """
+        connection_manager = connection_manager or ConnectionManager()
+        super().init_components(connection_manager)
+        if self.file_converter is None:
+            self.file_converter = ExcelFileConverterComponent()
+
+    def execute(
+        self, input_data: ExcelFileConverterInputSchema, config: RunnableConfig | None = None, **kwargs
+    ) -> dict[str, list[Any]]:
+        """
+        Execute the ExcelFileConverter to convert files to Documents.
+
+        Args:
+            input_data (ExcelFileConverterInputSchema): An instance containing 'file_paths', 'files',
+                and/or 'metadata'.
+            config (RunnableConfig): Optional configuration for the execution.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            Dict with 'documents' key containing a list of converted Documents.
+
+        Raises:
+            KeyError: If required keys are missing in input_data.
+
+        Example:
+            input_data = {
+                "file_paths": ["/path/to/file1.xlsx"],
+                "files": [BytesIO(b"file content")],
+                "metadata": {"source": "user_upload"}
+            }
+        """
+        config = ensure_config(config)
+        self.run_on_node_execute_run(config.callbacks, **kwargs)
+
+        file_paths = input_data.file_paths
+        files = input_data.files
+        metadata = input_data.metadata
+
+        output = self.file_converter.run(file_paths=file_paths, files=files, metadata=metadata)
+        documents = output["documents"]
+
+        count_file_paths = len(file_paths) if file_paths else 0
+        count_files = len(files) if files else 0
+
+        logger.debug(
+            f"Converted {count_file_paths} file paths and {count_files} file objects " f"to {len(documents)} Documents."
+        )
+
+        return {"documents": documents}

--- a/dynamiq/nodes/converters/multi_file_type_converter.py
+++ b/dynamiq/nodes/converters/multi_file_type_converter.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from dynamiq.connections.managers import ConnectionManager
 from dynamiq.executors.context import ContextAwareThreadPoolExecutor
 from dynamiq.nodes.converters.docx import DOCXFileConverter
+from dynamiq.nodes.converters.excel import ExcelFileConverter
 from dynamiq.nodes.converters.html import HTMLConverter
 from dynamiq.nodes.converters.llm_text_extractor import LLMImageConverter, LLMPDFConverter
 from dynamiq.nodes.converters.pptx import PPTXFileConverter
@@ -30,6 +31,7 @@ DEFAULT_FILE_TYPE_TO_CONVERTER_CLASS_MAP = {
     FileType.PDF: PyPDFConverter,
     FileType.DOCUMENT: DOCXFileConverter,
     FileType.PRESENTATION: PPTXFileConverter,
+    FileType.SPREADSHEET: ExcelFileConverter,
     FileType.HTML: HTMLConverter,
     FileType.TEXT: TextFileConverter,
     FileType.MARKDOWN: TextFileConverter,
@@ -40,6 +42,7 @@ FILE_TYPE_TO_SUPPORTED_CONVERTER_CLASS_MAP = {
     FileType.IMAGE: (LLMImageConverter,),
     FileType.DOCUMENT: (DOCXFileConverter,),
     FileType.PRESENTATION: (PPTXFileConverter,),
+    FileType.SPREADSHEET: (ExcelFileConverter,),
     FileType.HTML: (HTMLConverter,),
     FileType.TEXT: (TextFileConverter,),
     FileType.MARKDOWN: (TextFileConverter,),
@@ -79,6 +82,7 @@ class MultiFileTypeConverter(Node):
         - LLMPDFConverter
         - DOCXFileConverter
         - PPTXFileConverter
+        - ExcelFileConverter
         - HTMLConverter
         - UnstructuredFileConverter (fallback)
     """

--- a/dynamiq/nodes/extractors/extractors.py
+++ b/dynamiq/nodes/extractors/extractors.py
@@ -358,8 +358,7 @@ class FileTypeExtractor(Node):
         # ZIP container: covers OOXML, ODF, epub and plain archives.
         if header.startswith(b"PK"):
             zip_type = cls._guess_type_from_zip(file)
-            if zip_type is not None:
-                return zip_type
+            return zip_type
 
         # Other binary formats with a stable magic-byte signature.
         extension = filetype.guess_extension(header)

--- a/dynamiq/nodes/extractors/extractors.py
+++ b/dynamiq/nodes/extractors/extractors.py
@@ -140,7 +140,7 @@ EXTENSION_MAP = {
     },
     FileType.DOCUMENT: {"doc", "docx", "odt", "rtf"},
     FileType.PDF: {"pdf"},
-    FileType.SPREADSHEET: {"xls", "xlsx", "csv", "tsv", "ods"},
+    FileType.SPREADSHEET: {"xlsx", "csv", "tsv"},
     FileType.PRESENTATION: {"ppt", "pptx", "odp"},
     FileType.ARCHIVE: {
         "zip",

--- a/dynamiq/nodes/extractors/extractors.py
+++ b/dynamiq/nodes/extractors/extractors.py
@@ -1,6 +1,7 @@
+import csv
 import enum
 import re
-from io import BytesIO
+from io import BytesIO, StringIO
 from typing import Any, ClassVar, Literal
 
 import filetype
@@ -176,6 +177,11 @@ EXTENSION_MAP = {
 }
 
 CONTENT_PROBE_SIZE = 8192
+UNSUPPORTED_SPREADSHEET_EXTENSIONS = {"xls", "ods"}
+HTML_START_RE = re.compile(
+    r"^\s*(?:<!doctype\s+html\b|<html(?:\s|>|/)|<\?xml[^>]*\?>\s*(?:<!doctype\s+html\b|<html(?:\s|>|/)))",
+    re.IGNORECASE,
+)
 
 
 class FileTypeExtractorInputSchema(BaseModel):
@@ -221,6 +227,8 @@ class FileTypeExtractor(Node):
                     if file_ext in extensions:
                         result = category
                         break
+                if result is None and file_ext in UNSUPPORTED_SPREADSHEET_EXTENSIONS:
+                    return {"type": None}
 
             if result is None and file is not None:
                 result = self._detect_type_from_content(file)
@@ -259,7 +267,32 @@ class FileTypeExtractor(Node):
             except UnicodeDecodeError:
                 return None
 
-        lowered = text.lstrip().lower()
-        if lowered.startswith(("<!doctype html", "<html")) or "<html" in lowered:
+        if HTML_START_RE.match(text):
             return FileType.HTML
+        if FileTypeExtractor._looks_like_delimited_table(text):
+            return FileType.SPREADSHEET
         return FileType.TEXT if text.strip() else None
+
+    @staticmethod
+    def _looks_like_delimited_table(text: str) -> bool:
+        """Return True for simple CSV/TSV-style text with multiple consistent rows."""
+        lines = [line for line in text.strip("\ufeff").splitlines() if line.strip()]
+        if len(lines) < 2:
+            return False
+
+        sample = "\n".join(lines[:10])
+        for delimiter in (",", "\t"):
+            rows = list(csv.reader(StringIO(sample), delimiter=delimiter))
+            rows = [row for row in rows if any(cell.strip() for cell in row)]
+            if len(rows) < 2:
+                continue
+
+            widths = [len(row) for row in rows]
+            if max(widths) < 2:
+                continue
+
+            most_common_width = max(set(widths), key=widths.count)
+            if most_common_width >= 2 and widths.count(most_common_width) / len(widths) >= 0.8:
+                return True
+
+        return False

--- a/dynamiq/nodes/extractors/extractors.py
+++ b/dynamiq/nodes/extractors/extractors.py
@@ -3,6 +3,7 @@ import re
 from io import BytesIO
 from typing import Any, ClassVar, Literal
 
+import filetype
 from pydantic import BaseModel, ConfigDict, Field
 
 from dynamiq.nodes import Node, NodeGroup
@@ -139,7 +140,7 @@ EXTENSION_MAP = {
     },
     FileType.DOCUMENT: {"doc", "docx", "odt", "rtf"},
     FileType.PDF: {"pdf"},
-    FileType.SPREADSHEET: {"xls", "xlsx", "csv", "ods"},
+    FileType.SPREADSHEET: {"xls", "xlsx", "csv", "tsv", "ods"},
     FileType.PRESENTATION: {"ppt", "pptx", "odp"},
     FileType.ARCHIVE: {
         "zip",
@@ -169,10 +170,12 @@ EXTENSION_MAP = {
     FileType.EXECUTABLE: {"exe"},
     FileType.DATABASE: {"sqlite"},
     FileType.EBOOK: {"epub"},
-    FileType.HTML: {"html"},
-    FileType.TEXT: {"txt"},
-    FileType.MARKDOWN: {"md"},
+    FileType.HTML: {"html", "htm", "xhtml"},
+    FileType.TEXT: {"txt", "json", "xml", "yaml", "yml", "log", "rst"},
+    FileType.MARKDOWN: {"md", "markdown"},
 }
+
+CONTENT_PROBE_SIZE = 8192
 
 
 class FileTypeExtractorInputSchema(BaseModel):
@@ -184,7 +187,7 @@ class FileTypeExtractorInputSchema(BaseModel):
 class FileTypeExtractor(Node):
     group: Literal[NodeGroup.EXTRACTORS] = NodeGroup.EXTRACTORS
     name: str = "file-type-extractor"
-    description: str = "Node that extract file category based on file extension"
+    description: str = "Node that extracts file category based on file extension, falling back to file content"
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -210,17 +213,53 @@ class FileTypeExtractor(Node):
         filename = input_data.filename
         try:
             filename = (getattr(file, "name", None) or filename) if file else filename
-            if not filename:
-                return {"type": None}
-            file_ext = filename.split(".")[-1] if "." in filename else ""
-            file_ext = file_ext.lower()
+            file_ext = filename.split(".")[-1].lower() if filename and "." in filename else ""
 
             result = None
-            for category, extensions in EXTENSION_MAP.items():
-                if file_ext in extensions:
-                    result = category
-                    break
+            if file_ext:
+                for category, extensions in EXTENSION_MAP.items():
+                    if file_ext in extensions:
+                        result = category
+                        break
+
+            if result is None and file is not None:
+                result = self._detect_type_from_content(file)
 
             return {"type": result}
         except Exception as e:
             raise ValueError(f"Encountered an error while performing extension extraction. \nError details: {e}")
+
+    @staticmethod
+    def _detect_type_from_content(file: BytesIO) -> FileType | None:
+        """Detect the file category from content when the extension is missing or unknown.
+
+        Binary formats (pdf, docx, xlsx, pptx, images, archives, ...) are detected via magic
+        bytes; the remainder is classified as HTML or plain text if it decodes as UTF-8.
+        """
+        file.seek(0)
+        head = file.read(CONTENT_PROBE_SIZE)
+        file.seek(0)
+        if not head:
+            return None
+
+        kind = filetype.guess(head)
+        if kind:
+            for category, extensions in EXTENSION_MAP.items():
+                if kind.extension in extensions:
+                    return category
+            return None
+
+        if b"\x00" in head:
+            return None
+        try:
+            text = head.decode("utf-8")
+        except UnicodeDecodeError:
+            try:
+                text = head[:-3].decode("utf-8")
+            except UnicodeDecodeError:
+                return None
+
+        lowered = text.lstrip().lower()
+        if lowered.startswith(("<!doctype html", "<html")) or "<html" in lowered:
+            return FileType.HTML
+        return FileType.TEXT if text.strip() else None

--- a/dynamiq/nodes/extractors/extractors.py
+++ b/dynamiq/nodes/extractors/extractors.py
@@ -200,9 +200,9 @@ ZIP_DIRECTORY_MAP = {
 ZIP_MIMETYPE_MAP = {
     "application/epub+zip": FileType.EBOOK,
     "application/vnd.oasis.opendocument.text": FileType.DOCUMENT,
-    "application/vnd.oasis.opendocument.spreadsheet": FileType.SPREADSHEET,
     "application/vnd.oasis.opendocument.presentation": FileType.PRESENTATION,
 }
+UNSUPPORTED_ZIP_MIMETYPES = {"application/vnd.oasis.opendocument.spreadsheet"}
 
 _MARKDOWN_RE = re.compile(
     r"""
@@ -295,6 +295,8 @@ class FileTypeExtractor(Node):
                 names = archive.namelist()
                 if "mimetype" in names:
                     mimetype = archive.read("mimetype").decode("utf-8", errors="ignore").strip().lower()
+                    if mimetype in UNSUPPORTED_ZIP_MIMETYPES:
+                        return None
                     file_type = ZIP_MIMETYPE_MAP.get(mimetype)
                     if file_type is not None:
                         return file_type

--- a/dynamiq/utils/file_types.py
+++ b/dynamiq/utils/file_types.py
@@ -45,7 +45,7 @@ EXTENSION_MAP = {
     FileType.DOCX_DOCUMENT: {"docx"},
     FileType.DOCUMENT: {"doc", "docx", "odt", "rtf"},
     FileType.PDF: {"pdf"},
-    FileType.SPREADSHEET: {"xls", "xlsx", "csv", "ods"},
+    FileType.SPREADSHEET: {"xlsx", "csv", "tsv"},
     FileType.PRESENTATION: {"ppt", "pptx", "odp"},
     FileType.PPTX_PRESENTATION: {"pptx"},
     FileType.ARCHIVE: {

--- a/tests/integration/nodes/converters/test_excel.py
+++ b/tests/integration/nodes/converters/test_excel.py
@@ -57,6 +57,15 @@ def test_excel_converter_with_csv():
     assert "| Alice | 30 |" in content
 
 
+def test_excel_converter_with_extensionless_csv():
+    documents = run_and_get_documents(ExcelFileConverter(), [build_csv_bytesio("extensionless-item-id")])
+
+    assert len(documents) == 1
+    content = documents[0]["content"]
+    assert "| name | age |" in content
+    assert "| Alice | 30 |" in content
+
+
 @pytest.mark.parametrize("filename", ["legacy.xls", "open_document.ods"])
 def test_excel_converter_rejects_unsupported_spreadsheet_extensions(filename):
     buffer = BytesIO(b"legacy spreadsheet bytes")
@@ -82,7 +91,7 @@ def test_multi_file_converter_routes_spreadsheets_locally():
 
 
 def test_multi_file_converter_does_not_route_legacy_spreadsheet_to_excel():
-    buffer = BytesIO(b"\x00\x01legacy spreadsheet bytes")
+    buffer = BytesIO(b"name,age\nAlice,30\n")
     buffer.name = "legacy.xls"
 
     workflow = Workflow(flow=Flow(nodes=[MultiFileTypeConverter()]))
@@ -91,6 +100,15 @@ def test_multi_file_converter_does_not_route_legacy_spreadsheet_to_excel():
     assert response.status == RunnableStatus.FAILURE
     node_id = workflow.flow.nodes[0].id
     assert "Unsupported file type: None" in response.output[node_id]["error"]["message"]
+
+
+def test_multi_file_converter_routes_extensionless_csv_to_excel():
+    documents = run_and_get_documents(MultiFileTypeConverter(), [build_csv_bytesio("extensionless-item-id")])
+
+    assert len(documents) == 1
+    content = documents[0]["content"]
+    assert "| name | age |" in content
+    assert "| Alice | 30 |" in content
 
 
 def test_multi_file_converter_detects_type_without_extension():

--- a/tests/integration/nodes/converters/test_excel.py
+++ b/tests/integration/nodes/converters/test_excel.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 
+import pytest
 from openpyxl import Workbook as ExcelWorkbook
 
 from dynamiq import Workflow
@@ -56,6 +57,19 @@ def test_excel_converter_with_csv():
     assert "| Alice | 30 |" in content
 
 
+@pytest.mark.parametrize("filename", ["legacy.xls", "open_document.ods"])
+def test_excel_converter_rejects_unsupported_spreadsheet_extensions(filename):
+    buffer = BytesIO(b"legacy spreadsheet bytes")
+    buffer.name = filename
+
+    workflow = Workflow(flow=Flow(nodes=[ExcelFileConverter()]))
+    response = workflow.run(input_data={"files": [buffer]})
+
+    assert response.status == RunnableStatus.FAILURE
+    node_id = workflow.flow.nodes[0].id
+    assert "Unsupported spreadsheet extension" in response.output[node_id]["error"]["message"]
+
+
 def test_multi_file_converter_routes_spreadsheets_locally():
     documents = run_and_get_documents(
         MultiFileTypeConverter(),
@@ -65,6 +79,18 @@ def test_multi_file_converter_routes_spreadsheets_locally():
     assert len(documents) == 2
     for document in documents:
         assert "| Alice | 30 |" in document["content"]
+
+
+def test_multi_file_converter_does_not_route_legacy_spreadsheet_to_excel():
+    buffer = BytesIO(b"\x00\x01legacy spreadsheet bytes")
+    buffer.name = "legacy.xls"
+
+    workflow = Workflow(flow=Flow(nodes=[MultiFileTypeConverter()]))
+    response = workflow.run(input_data={"files": [buffer]})
+
+    assert response.status == RunnableStatus.FAILURE
+    node_id = workflow.flow.nodes[0].id
+    assert "Unsupported file type: None" in response.output[node_id]["error"]["message"]
 
 
 def test_multi_file_converter_detects_type_without_extension():

--- a/tests/integration/nodes/converters/test_excel.py
+++ b/tests/integration/nodes/converters/test_excel.py
@@ -1,0 +1,80 @@
+from io import BytesIO
+
+from openpyxl import Workbook as ExcelWorkbook
+
+from dynamiq import Workflow
+from dynamiq.flows import Flow
+from dynamiq.nodes.converters.excel import ExcelFileConverter
+from dynamiq.nodes.converters.multi_file_type_converter import MultiFileTypeConverter
+from dynamiq.runnables import RunnableStatus
+
+
+def build_xlsx_bytesio(filename: str = "test.xlsx") -> BytesIO:
+    workbook = ExcelWorkbook()
+    sheet = workbook.active
+    sheet.title = "People"
+    sheet.append(["name", "age"])
+    sheet.append(["Alice", 30])
+    sheet.append(["Bob", 25])
+    buffer = BytesIO()
+    workbook.save(buffer)
+    buffer.seek(0)
+    buffer.name = filename
+    return buffer
+
+
+def build_csv_bytesio(filename: str = "test.csv") -> BytesIO:
+    buffer = BytesIO(b"name,age\nAlice,30\nBob,25\n")
+    buffer.name = filename
+    return buffer
+
+
+def run_and_get_documents(node, files):
+    workflow = Workflow(flow=Flow(nodes=[node]))
+    response = workflow.run(input_data={"files": files})
+    assert response.status == RunnableStatus.SUCCESS
+    return response.output[node.id]["output"]["documents"]
+
+
+def test_excel_converter_with_xlsx():
+    documents = run_and_get_documents(ExcelFileConverter(), [build_xlsx_bytesio()])
+
+    assert len(documents) == 1
+    content = documents[0]["content"]
+    assert "| name | age |" in content
+    assert "| Alice | 30 |" in content
+    assert "| Bob | 25 |" in content
+    assert documents[0]["metadata"]["file_path"] == "test.xlsx"
+
+
+def test_excel_converter_with_csv():
+    documents = run_and_get_documents(ExcelFileConverter(), [build_csv_bytesio()])
+
+    assert len(documents) == 1
+    content = documents[0]["content"]
+    assert "| name | age |" in content
+    assert "| Alice | 30 |" in content
+
+
+def test_multi_file_converter_routes_spreadsheets_locally():
+    documents = run_and_get_documents(
+        MultiFileTypeConverter(),
+        [build_xlsx_bytesio("routed.xlsx"), build_csv_bytesio("routed.csv")],
+    )
+
+    assert len(documents) == 2
+    for document in documents:
+        assert "| Alice | 30 |" in document["content"]
+
+
+def test_multi_file_converter_detects_type_without_extension():
+    # No extension in the name and no filename metadata: content sniffing routes xlsx/text.
+    xlsx_file = build_xlsx_bytesio("extensionless-item-id")
+    text_file = BytesIO(b"Plain text knowledge base item without extension.")
+    text_file.name = "another-extensionless-item-id"
+
+    documents = run_and_get_documents(MultiFileTypeConverter(), [xlsx_file, text_file])
+
+    assert len(documents) == 2
+    assert "| Alice | 30 |" in documents[0]["content"]
+    assert "Plain text knowledge base item" in documents[1]["content"]

--- a/tests/integration/nodes/converters/test_excel.py
+++ b/tests/integration/nodes/converters/test_excel.py
@@ -1,3 +1,4 @@
+import zipfile
 from io import BytesIO
 
 import pytest
@@ -26,6 +27,16 @@ def build_xlsx_bytesio(filename: str = "test.xlsx") -> BytesIO:
 
 def build_csv_bytesio(filename: str = "test.csv") -> BytesIO:
     buffer = BytesIO(b"name,age\nAlice,30\nBob,25\n")
+    buffer.name = filename
+    return buffer
+
+
+def build_ods_bytesio(filename: str = "extensionless-ods") -> BytesIO:
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("mimetype", "application/vnd.oasis.opendocument.spreadsheet")
+        archive.writestr("content.xml", "<office:document-content/>")
+    buffer.seek(0)
     buffer.name = filename
     return buffer
 
@@ -100,6 +111,17 @@ def test_multi_file_converter_does_not_route_legacy_spreadsheet_to_excel():
     assert response.status == RunnableStatus.FAILURE
     node_id = workflow.flow.nodes[0].id
     assert "Unsupported file type: None" in response.output[node_id]["error"]["message"]
+    assert "ExcelFileConverter" not in response.output[node_id]["error"]["message"]
+
+
+def test_multi_file_converter_does_not_route_extensionless_ods_to_excel():
+    workflow = Workflow(flow=Flow(nodes=[MultiFileTypeConverter()]))
+    response = workflow.run(input_data={"files": [build_ods_bytesio()]})
+
+    assert response.status == RunnableStatus.FAILURE
+    node_id = workflow.flow.nodes[0].id
+    assert "Unsupported file type: None" in response.output[node_id]["error"]["message"]
+    assert "ExcelFileConverter" not in response.output[node_id]["error"]["message"]
 
 
 def test_multi_file_converter_routes_extensionless_csv_to_excel():

--- a/tests/integration/nodes/converters/test_html.py
+++ b/tests/integration/nodes/converters/test_html.py
@@ -135,7 +135,7 @@ def complex_html_bytesio(complex_html_content):
 
 @pytest.fixture
 def invalid_html_content():
-    return b"\x00\x01\x02\x03\x04This is not valid HTML content\xFF\xFE"
+    return b"\x00\x01\x02\x03\x04This is not valid HTML content\xff\xfe"
 
 
 @pytest.fixture
@@ -242,6 +242,34 @@ def test_html_converter_with_complex_content(request, input_type, input_fixture)
 
     expected_source = html_input if input_type == "file_paths" else html_input.name
     assert document["metadata"]["file_path"] == expected_source
+
+
+def test_html_converter_with_xml_declaration():
+    content = b'<?xml version="1.0" encoding="UTF-8"?><html><body><p>Declared page</p></body></html>'
+    html_buffer = BytesIO(content)
+    html_buffer.name = "declared.html"
+
+    wf_html = Workflow(flow=Flow(nodes=[HTMLConverter()]))
+    response = wf_html.run(input_data={"files": [html_buffer]})
+
+    assert response.status == RunnableStatus.SUCCESS
+    node_id = wf_html.flow.nodes[0].id
+    document = response.output[node_id]["output"]["documents"][0]
+    assert "Declared page" in document["content"]
+
+
+def test_html_converter_with_non_utf8_charset():
+    content = '<html><head><meta charset="iso-8859-1"></head><body><p>café</p></body></html>'.encode("iso-8859-1")
+    html_buffer = BytesIO(content)
+    html_buffer.name = "latin1.html"
+
+    wf_html = Workflow(flow=Flow(nodes=[HTMLConverter()]))
+    response = wf_html.run(input_data={"files": [html_buffer]})
+
+    assert response.status == RunnableStatus.SUCCESS
+    node_id = wf_html.flow.nodes[0].id
+    document = response.output[node_id]["output"]["documents"][0]
+    assert "café" in document["content"]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/nodes/converters/test_html.py
+++ b/tests/integration/nodes/converters/test_html.py
@@ -272,6 +272,20 @@ def test_html_converter_with_non_utf8_charset():
     assert "café" in document["content"]
 
 
+def test_html_converter_with_utf16_charset():
+    content = "<html><body><p>UTF-16 page</p></body></html>".encode("utf-16")
+    html_buffer = BytesIO(content)
+    html_buffer.name = "utf16.html"
+
+    wf_html = Workflow(flow=Flow(nodes=[HTMLConverter()]))
+    response = wf_html.run(input_data={"files": [html_buffer]})
+
+    assert response.status == RunnableStatus.SUCCESS
+    node_id = wf_html.flow.nodes[0].id
+    document = response.output[node_id]["output"]["documents"][0]
+    assert "UTF-16 page" in document["content"]
+
+
 @pytest.mark.parametrize(
     "input_type,input_fixture",
     [

--- a/tests/integration/nodes/extractors/test_extractors.py
+++ b/tests/integration/nodes/extractors/test_extractors.py
@@ -153,11 +153,21 @@ def create_pptx_content():
     return buffer.getvalue()
 
 
+def create_ods_content():
+    """Minimal OpenDocument spreadsheet ZIP with the ODS mimetype marker."""
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("mimetype", "application/vnd.oasis.opendocument.spreadsheet")
+        archive.writestr("content.xml", "<office:document-content/>")
+    return buffer.getvalue()
+
+
 PDF_CONTENT = b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n"
 TEXT_CONTENT = b"This is a plain text document.\nIt has a couple of lines.\n"
 MARKDOWN_CONTENT = b"# Heading\n\nParagraph with **bold** and a [link](https://example.com).\n"
 HTML_CONTENT = b"<!DOCTYPE html>\n<html><head><title>Page</title></head><body><p>Hi</p></body></html>\n"
 BINARY_CONTENT = b"\x00\x01\x02\x03\xff\xfe\xfd\xfc" * 128
+ODS_CONTENT = create_ods_content()
 
 
 @pytest.mark.parametrize(
@@ -168,12 +178,14 @@ BINARY_CONTENT = b"\x00\x01\x02\x03\xff\xfe\xfd\xfc" * 128
         (None, create_bytesio_without_extension(MARKDOWN_CONTENT), "markdown"),
         (None, create_bytesio_without_extension(HTML_CONTENT), "html"),
         (None, create_bytesio_without_extension(create_pptx_content()), "presentation"),
+        (None, create_bytesio_without_extension(ODS_CONTENT), None),
         (None, create_bytesio_without_extension(BINARY_CONTENT), None),  # binary -> unidentified
         ("document", create_bytesio_without_extension(PDF_CONTENT), "pdf"),
         ("notes", create_bytesio_without_extension(TEXT_CONTENT), "text"),
         ("readme", create_bytesio_without_extension(MARKDOWN_CONTENT), "markdown"),
         ("page", create_bytesio_without_extension(HTML_CONTENT), "html"),
         ("slides", create_bytesio_without_extension(create_pptx_content()), "presentation"),
+        ("open_document", create_bytesio_without_extension(ODS_CONTENT), None),
         ("blob", create_bytesio_without_extension(BINARY_CONTENT), None),  # binary -> unidentified
         (None, create_bytesio_without_extension(PDF_CONTENT, "document"), "pdf"),
         (None, create_bytesio_without_extension(create_pptx_content(), "slides"), "presentation"),

--- a/tests/integration/nodes/extractors/test_extractors.py
+++ b/tests/integration/nodes/extractors/test_extractors.py
@@ -75,6 +75,8 @@ def create_bytesio_with_name(content, name):
         ("presentation.pptx", None, "presentation"),
         ("file.pdf", None, "pdf"),
         ("spreadsheet.xlsx", None, "spreadsheet"),
+        ("legacy.xls", None, None),
+        ("open_document.ods", None, None),
         ("archive.zip", None, "archive"),
         ("audio.mp3", None, "audio"),
         ("video.mp4", None, "video"),

--- a/tests/integration/nodes/extractors/test_extractors.py
+++ b/tests/integration/nodes/extractors/test_extractors.py
@@ -212,6 +212,15 @@ def test_file_type_extraction_from_content(filename, file, result):
     )
 
 
+def test_unsupported_zip_mimetype_does_not_fall_back_to_archive(monkeypatch):
+    monkeypatch.setattr(
+        "dynamiq.nodes.extractors.extractors.filetype.guess_extension",
+        lambda _: "zip",
+    )
+
+    assert FileTypeExtractor._guess_type_from_content(ODS_CONTENT) is None
+
+
 @pytest.mark.parametrize(
     "value, pattern, result",
     [

--- a/tests/integration/nodes/extractors/test_extractors.py
+++ b/tests/integration/nodes/extractors/test_extractors.py
@@ -80,7 +80,8 @@ def create_bytesio_with_name(content, name):
         ("video.mp4", None, "video"),
         ("image.gif", None, "image"),
         ("unknownfile.xyz", None, None),
-        (None, create_bytesio_with_name(b"file content with name", "unknownfile.xyz"), None),
+        # Unknown extension, but readable text content: detected from content.
+        (None, create_bytesio_with_name(b"file content with name", "unknownfile.xyz"), "text"),
         (None, create_bytesio_with_name(b"image content", "file_with_name.jpg"), "image"),
         (None, create_bytesio_with_name(b"spreadsheet content", "test.xlsx"), "spreadsheet"),
         (None, create_bytesio_with_name(b"presentation content", "test.pptx"), "presentation"),
@@ -96,9 +97,14 @@ def create_bytesio_with_name(content, name):
         (None, create_bytesio_with_name(b"font content", "test.otf"), "font"),
         (None, create_bytesio_with_name(b"executable content", "test.exe"), "executable"),
         (None, create_bytesio_with_name(b"ebook content", "test.epub"), "ebook"),
-        (None, create_bytesio_with_name(b"unknown content", "unknownfile.xyz"), None),
-        ("file_0", create_bytesio_with_name(b"content", ""), None),
-        (None, create_bytesio_with_name(b"content", ""), None),
+        # Missing or unknown extension: type is detected from content.
+        (None, create_bytesio_with_name(b"unknown content", "unknownfile.xyz"), "text"),
+        ("file_0", create_bytesio_with_name(b"content", ""), "text"),
+        (None, create_bytesio_with_name(b"content", ""), "text"),
+        (None, create_bytesio_with_name(b"%PDF-1.4 fake pdf body", ""), "pdf"),
+        (None, create_bytesio_with_name(b"<!DOCTYPE html><html><body>hi</body></html>", ""), "html"),
+        (None, create_bytesio_with_name(b"\x00\x01\x02 binary garbage \xff\xfe", ""), None),
+        (None, create_bytesio_with_name(b"", ""), None),
         ("", None, None),
     ],
 )

--- a/tests/integration/nodes/extractors/test_extractors.py
+++ b/tests/integration/nodes/extractors/test_extractors.py
@@ -101,6 +101,10 @@ def create_bytesio_with_name(content, name):
         (None, create_bytesio_with_name(b"ebook content", "test.epub"), "ebook"),
         # Missing or unknown extension: type is detected from content.
         (None, create_bytesio_with_name(b"unknown content", "unknownfile.xyz"), "text"),
+        (None, create_bytesio_with_name(b"name,age\nAlice,30\nBob,25\n", ""), "spreadsheet"),
+        (None, create_bytesio_with_name(b"name\tage\nAlice\t30\nBob\t25\n", ""), "spreadsheet"),
+        (None, create_bytesio_with_name(b"name,age\nAlice,30\n", "legacy.xls"), None),
+        (None, create_bytesio_with_name(b'Text log mentioning <html but not starting with it', ""), "text"),
         ("file_0", create_bytesio_with_name(b"content", ""), "text"),
         (None, create_bytesio_with_name(b"content", ""), "text"),
         (None, create_bytesio_with_name(b"%PDF-1.4 fake pdf body", ""), "pdf"),

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ wheels = [
 
 [[package]]
 name = "dynamiq"
-version = "0.55.0"
+version = "0.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Spreadsheet support is narrowed (xls/ODS no longer route to a converter), and HTML/file sniffing behavior changes may affect uploads that previously misclassified or partially converted.
> 
> **Overview**
> Adds **local spreadsheet ingestion** for `xlsx`, `csv`, and `tsv` via a new `ExcelFileConverter` (markdown tables per sheet or file) and wires it into `MultiFileTypeConverter` for `FileType.SPREADSHEET`.
> 
> **File-type detection** is tightened: supported spreadsheet extensions are now `xlsx`/`csv`/`tsv` only—`xls` and `ods` resolve to **no type** (including extensionless ODS ZIPs), extensionless CSV/TSV can be sniffed from content, and HTML detection uses a stricter start pattern. More extensions map to HTML/text/markdown (e.g. `htm`, `json`, `yaml`).
> 
> **HTML conversion** reads files as **bytes** so `lxml` can honor declared charsets (XML prolog, Latin-1, UTF-16) and rejects obvious binary payloads unless a Unicode BOM is present.
> 
> Integration tests cover spreadsheet routing, legacy/ODS rejection, and HTML encoding cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db71639eb28557513e6bdcb2c678852131045abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->