### PR TITLE
feat: browser-takeover flag for HumanFeedbackTool

### DIFF
--- a/dynamiq/nodes/tools/human_feedback.py
+++ b/dynamiq/nodes/tools/human_feedback.py
@@ -126,7 +126,6 @@ Examples:
 
 Important:
 - Use 'ask' for approval, confirmation, clarification, or information.
-- The user can only provide text responses - they can not perform actions.
 - This tool should be used to gather information from user and send status updates during agent execution.
 """
     input_method: FeedbackMethod | InputMethodCallable = FeedbackMethod.CONSOLE
@@ -148,6 +147,14 @@ Important:
     @model_validator(mode="after")
     def update_description(self):
         msg_template = self.msg_template
+        if self.is_browser_takeover:
+            self.description += (
+                "\n- Browser takeover is ENABLED: the user interacts directly with a live browser session "
+                "(navigating, clicking, typing), not only text responses. Coordinate with the browser tool "
+                "and hand off control to the user when manual action is required."
+            )
+        else:
+            self.description += "\n- The user can only provide text responses - they can not perform actions."
         self.description += (
             f"\nMessage template: '{msg_template}'." " Parameters will be substituted based on the provided input data."
         )

--- a/dynamiq/nodes/tools/human_feedback.py
+++ b/dynamiq/nodes/tools/human_feedback.py
@@ -32,6 +32,7 @@ class HFStreamingInputEventMessage(StreamingEventMessage):
 class HFStreamingOutputEventMessageData(BaseModel):
     prompt: str
     action: HumanFeedbackAction = HumanFeedbackAction.ASK
+    is_browser_takeover: bool = False
 
 
 class HFStreamingOutputEventMessage(StreamingEventMessage):
@@ -136,6 +137,12 @@ Important:
     )
     input_schema: ClassVar[type[HumanFeedbackInputSchema]] = HumanFeedbackInputSchema
     msg_template: str = "{{input}}"
+    is_browser_takeover: bool = Field(
+        default=False,
+        description="If True, streamed feedback events are marked as a browser-takeover request so a chat UI can "
+        "render an interactive browser session instead of a plain text prompt. Requires a browser tool "
+        "(e.g. Stagehand with live view enabled) in the same run to provide the live session.",
+    )
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @model_validator(mode="after")
@@ -195,7 +202,9 @@ Important:
         event = HFStreamingOutputEventMessage(
             wf_run_id=config.run_id,
             entity_id=self.id,
-            data=HFStreamingOutputEventMessageData(prompt=prompt, action=HumanFeedbackAction.ASK),
+            data=HFStreamingOutputEventMessageData(
+                prompt=prompt, action=HumanFeedbackAction.ASK, is_browser_takeover=self.is_browser_takeover
+            ),
             event=streaming.event,
             source=StreamingEntitySource(
                 id=self.id,
@@ -237,7 +246,9 @@ Important:
         event = HFStreamingOutputEventMessage(
             wf_run_id=config.run_id,
             entity_id=self.id,
-            data=HFStreamingOutputEventMessageData(prompt=message, action=HumanFeedbackAction.INFO),
+            data=HFStreamingOutputEventMessageData(
+                prompt=message, action=HumanFeedbackAction.INFO, is_browser_takeover=self.is_browser_takeover
+            ),
             event=streaming.event,
             source=StreamingEntitySource(
                 id=self.id,

--- a/dynamiq/nodes/tools/human_feedback.py
+++ b/dynamiq/nodes/tools/human_feedback.py
@@ -144,19 +144,28 @@ Important:
     )
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    _GUIDANCE_ANCHOR: ClassVar[str] = "\nInteraction mode:"
+
     @model_validator(mode="after")
     def update_description(self):
-        msg_template = self.msg_template
+        # Strip any previously generated guidance before regenerating so repeated validation,
+        # serialization round-trips, and flag changes stay idempotent and never stack
+        # conflicting notes (e.g. both the takeover and the text-only line).
+        base = self.description.split(self._GUIDANCE_ANCHOR, 1)[0].rstrip()
+
         if self.is_browser_takeover:
-            self.description += (
-                "\n- Browser takeover is ENABLED: the user interacts directly with a live browser session "
-                "(navigating, clicking, typing), not only text responses. Coordinate with the browser tool "
-                "and hand off control to the user when manual action is required."
+            interaction = (
+                "Interaction mode: browser takeover is ENABLED - the user interacts directly with a live "
+                "browser session (navigating, clicking, typing), not only text responses. Coordinate with the "
+                "browser tool and hand off control to the user when manual action is required."
             )
         else:
-            self.description += "\n- The user can only provide text responses - they can not perform actions."
-        self.description += (
-            f"\nMessage template: '{msg_template}'." " Parameters will be substituted based on the provided input data."
+            interaction = "Interaction mode: the user can only provide text responses - they can not perform actions."
+
+        self.description = (
+            f"{base}\n{interaction}"
+            f"\nMessage template: '{self.msg_template}'."
+            " Parameters will be substituted based on the provided input data."
         )
         return self
 

--- a/tests/unit/nodes/tools/test_human_feedback.py
+++ b/tests/unit/nodes/tools/test_human_feedback.py
@@ -1,0 +1,90 @@
+"""Unit tests for HumanFeedbackTool streaming behaviour.
+
+Focus: the ``is_browser_takeover`` flag must travel in the streamed event data so a
+chat UI can render a browser-takeover interaction instead of a plain text prompt.
+"""
+
+from queue import Queue
+
+from dynamiq.callbacks.base import BaseCallbackHandler
+from dynamiq.nodes.tools.human_feedback import (
+    HFStreamingInputEventMessage,
+    HFStreamingInputEventMessageData,
+    HumanFeedbackTool,
+)
+from dynamiq.runnables import RunnableConfig
+from dynamiq.types.feedback import FeedbackMethod
+from dynamiq.types.streaming import STREAMING_EVENT, StreamingConfig
+
+
+class _CaptureStreamCallback(BaseCallbackHandler):
+    """Records the streaming events a node emits."""
+
+    def __init__(self):
+        self.events = []
+
+    def on_node_execute_stream(self, serialized, chunk=None, **kwargs):
+        event = kwargs.get("event")
+        if event is not None:
+            self.events.append(event)
+
+
+def _preloaded_queue(node_id: str, content: str = "done") -> Queue:
+    """A queue holding a single valid streaming-input reply, so the ASK path does not block."""
+    queue = Queue()
+    queue.put(
+        HFStreamingInputEventMessage(
+            entity_id=node_id,
+            event=STREAMING_EVENT,
+            data=HFStreamingInputEventMessageData(content=content),
+        ).model_dump_json()
+    )
+    return queue
+
+
+def test_ask_stream_event_includes_browser_takeover_flag():
+    node_id = "hf-takeover"
+    tool = HumanFeedbackTool(
+        id=node_id,
+        is_browser_takeover=True,
+        input_method=FeedbackMethod.STREAM,
+        output_method=FeedbackMethod.STREAM,
+        streaming=StreamingConfig(enabled=True, input_queue=_preloaded_queue(node_id)),
+    )
+    capture = _CaptureStreamCallback()
+
+    tool.input_method_streaming(prompt="Take over the browser", config=RunnableConfig(callbacks=[capture]))
+
+    assert capture.events, "expected the ASK prompt to be streamed to the UI"
+    assert capture.events[0].data.is_browser_takeover is True
+
+
+def test_info_stream_event_includes_browser_takeover_flag():
+    tool = HumanFeedbackTool(
+        id="hf-takeover",
+        is_browser_takeover=True,
+        output_method=FeedbackMethod.STREAM,
+        streaming=StreamingConfig(enabled=True),
+    )
+    capture = _CaptureStreamCallback()
+
+    tool.output_method_streaming(message="Browser ready for takeover", config=RunnableConfig(callbacks=[capture]))
+
+    assert capture.events, "expected the info message to be streamed to the UI"
+    assert capture.events[0].data.is_browser_takeover is True
+
+
+def test_ask_stream_event_browser_takeover_defaults_to_false():
+    node_id = "hf-plain"
+    tool = HumanFeedbackTool(
+        id=node_id,
+        input_method=FeedbackMethod.STREAM,
+        output_method=FeedbackMethod.STREAM,
+        streaming=StreamingConfig(enabled=True, input_queue=_preloaded_queue(node_id)),
+    )
+    capture = _CaptureStreamCallback()
+
+    tool.input_method_streaming(prompt="Approve?", config=RunnableConfig(callbacks=[capture]))
+
+    assert capture.events, "expected the ASK prompt to be streamed to the UI"
+    assert capture.events[0].data.is_browser_takeover is False

--- a/tests/unit/nodes/tools/test_human_feedback.py
+++ b/tests/unit/nodes/tools/test_human_feedback.py
@@ -104,3 +104,23 @@ def test_description_keeps_text_only_caveat_by_default():
     tool = HumanFeedbackTool()
 
     assert "can not perform actions" in tool.description.lower()
+
+
+def test_description_is_idempotent_across_rebuilds():
+    """Rebuilding from a serialized (already-generated) description must not stack guidance."""
+    tool = HumanFeedbackTool(is_browser_takeover=True)
+    rebuilt = HumanFeedbackTool(description=tool.description, is_browser_takeover=True)
+
+    assert rebuilt.description == tool.description, "description must be stable across round-trips"
+    assert rebuilt.description.lower().count("browser takeover is enabled") == 1
+    assert rebuilt.description.count("Message template:") == 1
+
+
+def test_description_flag_flip_does_not_stack_conflicting_notes():
+    """Rebuilding a takeover-flavored description with the flag off must drop the takeover note."""
+    takeover = HumanFeedbackTool(is_browser_takeover=True)
+    flipped = HumanFeedbackTool(description=takeover.description, is_browser_takeover=False)
+    desc = flipped.description.lower()
+
+    assert "browser takeover is enabled" not in desc
+    assert "can not perform actions" in desc

--- a/tests/unit/nodes/tools/test_human_feedback.py
+++ b/tests/unit/nodes/tools/test_human_feedback.py
@@ -88,3 +88,19 @@ def test_ask_stream_event_browser_takeover_defaults_to_false():
 
     assert capture.events, "expected the ASK prompt to be streamed to the UI"
     assert capture.events[0].data.is_browser_takeover is False
+
+
+def test_description_reflects_browser_takeover_when_enabled():
+    """In takeover mode the agent-facing description must not claim the user can only reply with text."""
+    tool = HumanFeedbackTool(is_browser_takeover=True)
+    description = tool.description.lower()
+
+    assert "can not perform actions" not in description, "text-only caveat contradicts browser takeover"
+    assert "browser" in description, "description should tell the agent the user acts in a live browser"
+
+
+def test_description_keeps_text_only_caveat_by_default():
+    """Without takeover the existing text-only guidance for the agent is preserved."""
+    tool = HumanFeedbackTool()
+
+    assert "can not perform actions" in tool.description.lower()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive optional field and streaming metadata with backward-compatible defaults; no auth or data-path changes.
> 
> **Overview**
> **HumanFeedbackTool** gains an optional **`is_browser_takeover`** flag (default `false`) so streaming UIs can show an interactive browser session when a browser tool is in the same run.
> 
> Streamed **ASK** and **INFO** events now include **`is_browser_takeover`** on `HFStreamingOutputEventMessageData`. Agent-facing **description** text is rebuilt via an **Interaction mode** section: takeover mode explains live browser control; default mode keeps the text-only caveat. Description updates strip prior guidance first so serialization round-trips and flag changes do not stack conflicting notes.
> 
> New unit tests cover streaming payloads, defaults, and description idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5dca5b554ff054a171812395298fcb811698039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->