### PR TITLE
feat: improvement kg

### DIFF
--- a/dynamiq/nodes/extractors/entity_extractor.py
+++ b/dynamiq/nodes/extractors/entity_extractor.py
@@ -29,12 +29,33 @@ ENTITY_LABEL = "Entity"
 ENTITY_NAME_FULLTEXT_INDEX = "entity_name"
 # Range index on the entity id (Neo4j) so GraphRetriever can seek when seeding traversal by resolved id.
 ENTITY_ID_INDEX = "entity_id"
+# Vector index on the entity name embedding (Neo4j >= 5.11) so GraphRetriever can seed traversal by
+# semantic similarity instead of surface-form overlap. Only present when a writer embeds entities.
+ENTITY_EMBEDDING_VECTOR_INDEX = "entity_embedding"
 
 # Metadata key under which the resolved, unique entity ids a chunk mentions are attached to that chunk —
 # done by KnowledgeGraphWriter (which alone has the post-resolution durable ids). Lets a hybrid retriever
 # seed graph traversal by id (unique, variant-proof), not by ambiguous entity name. ``kg_`` prefixed to
 # avoid colliding with a caller's own document metadata.
 KG_ENTITY_IDS_KEY = "kg_entity_ids"
+
+
+def normalize_name(name: str) -> str:
+    """Canonical form of an entity name for identity & matching: lowercased, non-alphanumerics stripped,
+    whitespace collapsed. Single source of truth so "Acme", "acme", and "ACME  Corp" converge — used both
+    for the deterministic node id (``uuid5(label:normalize_name(name))``) and the trigram similarity input.
+    """
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9 ]", "", (name or "").lower())).strip()
+
+
+def build_fact_text(src_name: str, rel_label: str, dst_name: str, description: str | None = None) -> str:
+    """The natural-language triplet embedded onto an edge for semantic rerank: ``"{src} {rel} {dst}[: {desc}]"``.
+
+    ``rel_label`` is the attribute key for ``HAS_ATTRIBUTE`` edges, else the relationship type (mirrors how
+    ``GraphRetriever`` renders a one-hop fact), so the embedded text matches the rendered fact.
+    """
+    text = f"{src_name} {rel_label} {dst_name}"
+    return f"{text}: {description}" if description else text
 
 
 def build_attribute_value_id(owner_id: str, attr_key: str, document_id: str | None) -> str:

--- a/dynamiq/nodes/extractors/entity_extractor.py
+++ b/dynamiq/nodes/extractors/entity_extractor.py
@@ -620,6 +620,10 @@ class EntityExtractor(Node):
         """
         doc_suffix = f"@{document.id}" if document is not None and document.id is not None else ""
         id_to_label: dict[str, str] = {}
+        # Endpoint names snapshotted onto each edge below (src_name/dst_name). Rendering reads these
+        # ACL-bearing edge props instead of the shared, merged entity node, so a node name written by a
+        # differently-scoped document can never leak to a caller entitled only to THIS document's edge.
+        id_to_name: dict[str, str] = {}
         nodes: list[dict] = []
         attribute_relationships: list[dict] = []
         for entity in entities:
@@ -630,6 +634,8 @@ class EntityExtractor(Node):
             label = self._sanitize_identifier(str(entity_type))
             entity_id = str(entity_id)
             id_to_label[entity_id] = label
+            if entity.get("name") is not None:
+                id_to_name[entity_id] = entity["name"]
             wiring_id = f"{entity_id}{doc_suffix}"
 
             emitted = dict(entity.get("properties") or {})
@@ -659,6 +665,9 @@ class EntityExtractor(Node):
                 # composite string. Sibling key (not in `properties`) so the store never persists it.
                 value_node["attr_ref"] = {"owner": wiring_id, "key": attr_key, "doc": doc_id}
                 nodes.append(value_node)
+                # src_name/dst_name snapshot the rendered endpoints onto the edge: the owner entity's name
+                # and the value itself (the AttributeValue node carries the value, but rendering reads it
+                # from the ACL-bearing edge so it is never dereferenced from a shared node).
                 attribute_relationships.append(
                     GraphRelationship(
                         type=HAS_ATTRIBUTE_TYPE,
@@ -666,7 +675,7 @@ class EntityExtractor(Node):
                         end_label=ATTRIBUTE_VALUE_LABEL,
                         start_identity=wiring_id,
                         end_identity=value_id,
-                        properties={"key": attr_key},
+                        properties={"key": attr_key, "src_name": entity.get("name"), "dst_name": attr_value},
                     ).model_dump()
                 )
 
@@ -686,6 +695,11 @@ class EntityExtractor(Node):
             rel_props = dict(rel.get("properties") or {})
             if rel.get("description") is not None:
                 rel_props["description"] = rel["description"]
+            # Snapshot endpoint names onto the edge so rendering never reads them from the shared node.
+            if source_id in id_to_name:
+                rel_props["src_name"] = id_to_name[source_id]
+            if target_id in id_to_name:
+                rel_props["dst_name"] = id_to_name[target_id]
             graph_relationships.append(
                 GraphRelationship(
                     type=self._sanitize_identifier(str(rel_type)),

--- a/dynamiq/nodes/extractors/entity_extractor.py
+++ b/dynamiq/nodes/extractors/entity_extractor.py
@@ -290,19 +290,16 @@ class EntityExtractor(Node):
         entities_debug: list[dict] = []
         raw_relationships_debug: list[dict] = []
 
-        # Process each document independently and stamp its metadata onto every element it produces. A
-        # per-document LLM failure skips only that chunk (like an unparseable response) so one transient
-        # error can't discard the whole batch -- but if EVERY document fails, that's systemic (e.g. bad
-        # credentials), so we raise rather than silently report an empty graph as success.
+        # Process each document independently, stamping its metadata onto everything it produces. One
+        # document's LLM failure skips only that chunk; if EVERY document fails it's systemic (bad creds),
+        # so we raise rather than report an empty graph as success.
         failed = 0
         documents: list[Document] = []
         for document in input_data.documents:
             check_cancellation(config)
-            # A document id scopes EVERYTHING per-document: node wiring ids, attribute ids, and the
-            # source_doc_id ACL merge discriminator. A missing id silently collapses all three -- id-less
-            # docs alias each other's nodes and their edges merge, overwriting allowed_principals. Assign a
-            # stable id up front so the whole pipeline (and the returned documents) keys off a real value.
-            # Copy rather than mutate in place so callers holding the input list don't see ids change.
+            # The document id scopes everything per-document: node wiring ids, attribute ids, and the
+            # source_doc_id ACL discriminator. Without it, id-less docs alias each other and merge edges
+            # (overwriting allowed_principals). Assign a stable id up front (copy, don't mutate the input).
             if document.id is None:
                 document = document.model_copy(update={"id": uuid.uuid4().hex})
             documents.append(document)
@@ -344,20 +341,15 @@ class EntityExtractor(Node):
     def _apply_document_metadata(self, relationships: list[dict], document: Document) -> None:
         """Copy the document's metadata + provenance onto every RELATIONSHIP it produced.
 
-        Entity nodes (and ``AttributeValue`` value-nodes) deliberately carry NO access metadata — they are
-        pure identity. All ACL/provenance lives on the edges, so a node is visible exactly when the user can
-        reach it through a visible edge. This keeps entity merge a no-op on the node (just attach edges) and
-        removes the whole class of node-ACL union/leak bugs.
+        Nodes carry NO access metadata (pure identity); all ACL/provenance lives on edges, so a node is
+        visible exactly when reachable through a visible edge. This makes entity merge a no-op on the node
+        and avoids node-ACL leak bugs.
 
-        Generic and ACL-agnostic — whatever keys are in ``document.metadata`` (``allowed_principals``,
-        ``acl_workspace_id``, timestamps, custom fields) ride along, exactly like the splitter copies a
-        document's metadata onto each chunk. A provenance pointer ``source_doc_ids=[document.id]`` is added
-        too. Each edge's own keys (e.g. the attribute ``key``) take precedence over metadata keys.
-
-        The document id is also stamped as a scalar ``source_doc_id`` and declared in ``identity_keys`` so
-        the store includes it in the relationship MERGE: the SAME fact asserted by two documents stays two
-        SEPARATE edges, each keeping its own ACL/provenance, instead of merging and overwriting (which would
-        leak — a public document could overwrite a confidential document's ``allowed_principals``).
+        Any keys in ``document.metadata`` (``allowed_principals``, timestamps, custom fields) ride along;
+        each edge's own keys (e.g. attribute ``key``) win over metadata keys. The document id is also
+        stamped as ``source_doc_id`` and declared in ``identity_keys`` so it enters the relationship MERGE:
+        the same fact from two documents stays two edges with their own ACLs, rather than merging and
+        overwriting (a public doc overwriting a confidential doc's ``allowed_principals``).
         """
         doc_props = self._flatten_metadata(dict(document.metadata or {}))
         identity_keys: list[str] = []
@@ -512,10 +504,9 @@ class EntityExtractor(Node):
             for t in o.triples
         }
 
-        # 1) Keep entity nodes whose label is in the ontology. AttributeValue nodes are held aside, NOT
-        #    committed yet: an attribute value carries its access scope on its HAS_ATTRIBUTE edge, so it
-        #    may only survive if that edge survives (step 3). Committing it here would orphan it -- a
-        #    sensitive value left as a disconnected node with no edge ACL -- when its owner is dropped.
+        # 1) Keep entity nodes whose label is in the ontology. AttributeValue nodes are held aside (not
+        #    committed yet): a value's ACL lives on its HAS_ATTRIBUTE edge, so it survives only if that edge
+        #    does (step 3) -- committing here would orphan a sensitive value with no ACL if its owner drops.
         kept_nodes: list[dict] = []
         kept_ids: set[str] = set()
         attribute_nodes: dict[str, dict] = {}
@@ -533,9 +524,9 @@ class EntityExtractor(Node):
         # entity ids so the endpoint check below can vet HAS_ATTRIBUTE edges without committing the values.
         valid_endpoint_ids = kept_ids | attribute_nodes.keys()
 
-        # 2) Keep only relationships with a legal type, surviving endpoints, and (when triples
-        #    are defined) a legal (source_label, type, target_label) pattern. HAS_ATTRIBUTE edges are
-        #    system-generated (declared attributes) — kept as long as their endpoints survive.
+        # 2) Keep relationships with a legal type, surviving endpoints, and (when triples are defined) a
+        #    legal (source, type, target) pattern. HAS_ATTRIBUTE edges are system-generated -> kept if
+        #    their endpoints survive.
         kept_rels: list[dict] = []
         for rel in relationships:
             rel_type, start_label, end_label = rel["type"], rel["start_label"], rel["end_label"]
@@ -555,9 +546,8 @@ class EntityExtractor(Node):
                 f"EntityExtractor: dropping relationship ({start_label})-[{rel_type}]->({end_label}): {reason}"
             )
 
-        # 3) Commit only the AttributeValue nodes still reached by a surviving HAS_ATTRIBUTE edge. Any value
-        #    whose owning entity was dropped lost its edge in step 2, so it is dropped here too -- never left
-        #    as an orphan node holding a value with no ACL.
+        # 3) Commit only AttributeValue nodes still reached by a surviving HAS_ATTRIBUTE edge -- one whose
+        #    owner was dropped lost its edge in step 2, so it is dropped here too, never orphaned with no ACL.
         referenced_attr_ids = {r["end_identity"] for r in kept_rels if r["type"] == HAS_ATTRIBUTE_TYPE}
         for attr_id in attribute_nodes.keys() - referenced_attr_ids:
             logger.debug(f"EntityExtractor: dropping orphaned AttributeValue id={attr_id!r} (owner removed)")
@@ -603,20 +593,17 @@ class EntityExtractor(Node):
     ) -> tuple[list[dict], list[dict]]:
         """Convert LLM-friendly entities/relationships into the write_graph node/relationship shape.
 
-        Entity nodes carry ONLY identity (``id`` + ``name``) — never the LLM's free-form ``properties``.
-        Nodes are merged by name and hold no ACL, so any inline property would be readable by anyone who can
-        reach the shared node; keeping nodes identity-only removes that leak. Ontology-declared attributes
-        (``Ontology.attributes``) are instead promoted to a separate
-        ``(entity)-[:HAS_ATTRIBUTE {key}]->(:AttributeValue {value})`` relationship so their visibility is
-        scoped independently of the (shared) entity node; any other emitted property is dropped. Value-node
-        ids are scoped per source document (``{wiring_id}::{key}::{document_id}``): the same attribute asserted
-        by two documents yields two value nodes, each on its own edge carrying its own document's
-        ACL/provenance metadata, while re-ingesting the same document updates the same value node.
+        Entity nodes carry ONLY identity (``id`` + ``name``), never the LLM's free-form properties: nodes
+        are merged by name and hold no ACL, so an inline property would leak to anyone who can reach the
+        shared node. Ontology-declared attributes (``Ontology.attributes``) are instead promoted to a
+        ``(entity)-[:HAS_ATTRIBUTE {key}]->(:AttributeValue {value})`` edge so their visibility is scoped
+        independently; any other emitted property is dropped. Value-node ids are doc-scoped
+        (``{wiring_id}::{key}::{document_id}``) so the same attribute from two documents yields two value
+        nodes, each on its own ACL-bearing edge, while re-ingesting a document updates the same node.
 
-        Entity ids are emitted doc-scoped too (``{llm_id}@{document_id}``): LLM ids are only unique within
-        one response, so two documents using the same id for DIFFERENT concepts must not alias once the
-        per-document payloads are pooled. The wiring id carries no identity — entity identity is assigned
-        by name resolution in ``KnowledgeGraphWriter``.
+        Entity ids are doc-scoped too (``{llm_id}@{document_id}``): LLM ids are unique only within one
+        response, so identical ids from different documents must not alias when pooled. The wiring id
+        carries no identity -- that is assigned by name resolution in ``KnowledgeGraphWriter``.
         """
         doc_suffix = f"@{document.id}" if document is not None and document.id is not None else ""
         id_to_label: dict[str, str] = {}

--- a/dynamiq/nodes/extractors/entity_extractor.py
+++ b/dynamiq/nodes/extractors/entity_extractor.py
@@ -41,11 +41,12 @@ KG_ENTITY_IDS_KEY = "kg_entity_ids"
 
 
 def normalize_name(name: str) -> str:
-    """Canonical form of an entity name for identity & matching: lowercased, non-alphanumerics stripped,
-    whitespace collapsed. Single source of truth so "Acme", "acme", and "ACME  Corp" converge — used both
-    for the deterministic node id (``uuid5(label:normalize_name(name))``) and the trigram similarity input.
+    """Canonical form of an entity name for identity & matching: whitespace collapsed, lower-cased,
+    spaces -> underscores, apostrophes dropped. Unicode-safe (non-Latin scripts are preserved instead
+    of being stripped to an empty string). Used for both the deterministic node id and the trigram input.
     """
-    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9 ]", "", (name or "").lower())).strip()
+    collapsed = re.sub(r"\s+", " ", (name or "")).strip()
+    return collapsed.lower().replace(" ", "_").replace("'", "")
 
 
 def build_fact_text(src_name: str, rel_label: str, dst_name: str, description: str | None = None) -> str:

--- a/dynamiq/nodes/extractors/knowledge_graph.py
+++ b/dynamiq/nodes/extractors/knowledge_graph.py
@@ -1,21 +1,26 @@
 import re
 from typing import Any, ClassVar, Literal
+from uuid import NAMESPACE_DNS, uuid5
 
 from pydantic import BaseModel, Field, PrivateAttr
 
 from dynamiq.connections import ApacheAGE, AWSNeptune, Neo4j
 from dynamiq.connections.managers import ConnectionManager
+from dynamiq.nodes.embedders.base import DocumentEmbedder
 from dynamiq.nodes.extractors.entity_extractor import (
     ATTRIBUTE_VALUE_LABEL,
+    ENTITY_EMBEDDING_VECTOR_INDEX,
     ENTITY_ID_INDEX,
     ENTITY_LABEL,
     ENTITY_NAME_FULLTEXT_INDEX,
     HAS_ATTRIBUTE_TYPE,
     KG_ENTITY_IDS_KEY,
     build_attribute_value_id,
+    build_fact_text,
+    normalize_name,
 )
 from dynamiq.nodes.node import Node, NodeGroup, ensure_config
-from dynamiq.runnables import RunnableConfig
+from dynamiq.runnables import RunnableConfig, RunnableStatus
 from dynamiq.storages.graph.age import ApacheAgeGraphStore
 from dynamiq.storages.graph.base import BaseGraphStore
 from dynamiq.storages.graph.neo4j import Neo4jGraphStore
@@ -25,14 +30,25 @@ from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils import generate_uuid
 from dynamiq.utils.logger import logger
 
-# Cypher identifier guard (Neo4j/openCypher label syntax used by the resolution read query).
-_LABEL_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Fixed namespace for deterministic entity ids: uuid5(_KG_NAMESPACE, f"{label}:{normalize_name(name)}").
+# A stable constant so the same (type, name) always hashes to the same id, across machines and runs.
+_KG_NAMESPACE = uuid5(NAMESPACE_DNS, "dynamiq.knowledge-graph.entity")
 
 
 def _trigrams(text: str) -> set[str]:
     """Padded character trigrams of a normalized name (pg_trgm-style)."""
-    norm = " " + re.sub(r"\s+", " ", re.sub(r"[^a-z0-9 ]", "", text.lower())).strip() + " "
+    norm = " " + normalize_name(text) + " "
     return {norm[i : i + 3] for i in range(len(norm) - 2)} if len(norm) >= 3 else set()
+
+
+def _lucene_or_query(text: str) -> str:
+    """Fuzzy Lucene OR-query over a name's word tokens (``tok~ OR tok~``) for full-text blocking.
+
+    Keeps only word tokens so Lucene special characters can't break the parser; ``~`` adds edit-distance
+    fuzziness. Returns "" when there are no usable tokens.
+    """
+    terms = re.findall(r"[A-Za-z0-9]+", text or "")
+    return " OR ".join(f"{t}~" for t in terms)
 
 
 def _trigram_similarity(a: str, b: str) -> float:
@@ -112,6 +128,20 @@ class KnowledgeGraphWriter(Node):
         graph_name (str | None): Graph name (Apache AGE).
         create_graph_if_not_exists (bool): Create the AGE graph if missing.
         similarity_threshold (float): Trigram similarity above which two names are the same entity.
+        fuzzy_matching (bool): Identity always uses the deterministic id ``uuid5(label:normalize_name(name))``
+            so identical (normalized) names collapse for free with no graph read (idempotent). This flag
+            only toggles the OPTIONAL fuzzy tier on top: when ``True`` (default), spelling variants
+            ("Acme" ≈ "Acme LLC") are additionally merged by pulling a bounded set of near candidates from
+            an index (entity vector index if embeddings are on, else the entity-name full-text index) and
+            confirming with trigram — embeddings only *find* candidates, trigram *decides*, so distinct
+            same-category names ("John Smith" vs "John Doe") are never fused. ``False`` = deterministic only.
+        resolution_top_k (int): Max candidates pulled from the index per name during fuzzy matching.
+        entity_embedder (DocumentEmbedder | None): Optional embedder (Neo4j only). When set: (1) each
+            entity's name is embedded onto the node with a vector index, so ``GraphRetriever`` can seed
+            traversal by semantic similarity; and (2) each relationship's triplet ("src rel dst: desc") is
+            embedded onto the EDGE as ``embedding`` (no new node, ACL stays on the edge), so the retriever
+            can rerank retrieved facts by relevance. Off by default. Use the SAME embedding model on the
+            retriever so vector dimensions match.
     """
 
     group: Literal[NodeGroup.EXTRACTORS] = NodeGroup.EXTRACTORS
@@ -121,15 +151,32 @@ class KnowledgeGraphWriter(Node):
     graph_name: str | None = None
     create_graph_if_not_exists: bool = False
     similarity_threshold: float = 0.6
+    fuzzy_matching: bool = True  # deterministic id is always the base; this toggles the optional fuzzy tier
+    resolution_top_k: int = 10
+    entity_embedder: DocumentEmbedder | None = None
 
     input_schema: ClassVar[type[KnowledgeGraphWriterInputSchema]] = KnowledgeGraphWriterInputSchema
     _graph_store: BaseGraphStore | None = PrivateAttr(default=None)
-    _existing_cache: dict[str, list[tuple[str, str]]] = PrivateAttr(default_factory=dict)
+    # Vector indexes ensured this process (by name) — created lazily on first embed from the real embedding
+    # length so a dimension can never mismatch the embedder's model.
+    _vector_indexes_ready: set[str] = PrivateAttr(default_factory=set)
+
+    @property
+    def to_dict_exclude_params(self) -> dict:
+        return super().to_dict_exclude_params | {"entity_embedder": True}
+
+    def to_dict(self, **kwargs) -> dict:
+        data = super().to_dict(**kwargs)
+        if self.entity_embedder:
+            data["entity_embedder"] = self.entity_embedder.to_dict(**kwargs)
+        return data
 
     def init_components(self, connection_manager: ConnectionManager | None = None) -> None:
         """Select the graph store for the connection and ensure the entity indexes exist."""
         connection_manager = connection_manager or ConnectionManager()
         super().init_components(connection_manager)
+        if self.entity_embedder and self.entity_embedder.is_postponed_component_init:
+            self.entity_embedder.init_components(connection_manager)
         if self._graph_store is None:
             self._graph_store = self._build_graph_store()
         self._ensure_entity_index()
@@ -158,6 +205,123 @@ class KnowledgeGraphWriter(Node):
                 self._graph_store.run_cypher(statement, database=self.database)
             except Exception as e:
                 logger.warning(f"Node {self.name} - {self.id}: could not create entity {what} index: {e}")
+
+    def _embed_texts(self, texts: list[str], config: RunnableConfig, **kwargs) -> dict[str, list[float]]:
+        """Embed a list of texts in ONE embedder call → ``{text: vector}``; ``{}`` when disabled or on failure.
+
+        Neo4j + ``entity_embedder`` gated (embeddings back a Neo4j vector index, so a raw vector on any other
+        backend is unqueryable dead weight). Best-effort: any embedder failure is logged and returns ``{}`` so
+        the write proceeds without embeddings.
+        """
+        if not self.entity_embedder or not isinstance(self._graph_store, Neo4jGraphStore):
+            return {}
+        texts = [t for t in dict.fromkeys(texts) if (t or "").strip()]
+        if not texts:
+            return {}
+        try:
+            run_kwargs = kwargs | {"parent_run_id": kwargs.get("run_id")}
+            run_kwargs.pop("run_depends", None)
+            result = self.entity_embedder.run(
+                input_data={"documents": [Document(content=t) for t in texts]}, config=config, **run_kwargs
+            )
+            if result.status != RunnableStatus.SUCCESS:
+                logger.warning(f"Node {self.name} - {self.id}: embedder failed ({result.error}); skipping embeddings.")
+                return {}
+            return {
+                doc.content: doc.embedding
+                for doc in (result.output.get("documents") or [])
+                if doc.embedding is not None
+            }
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Node {self.name} - {self.id}: embedding error: {e}; skipping embeddings.")
+            return {}
+
+    def _embed_entity_names(self, nodes: list[dict], config: RunnableConfig, **kwargs) -> dict[str, list[float]]:
+        """Embed every entity node's NAME (one call) → ``{name: vector}``. Reused for the fuzzy candidate
+        lookup (Tier 2 of resolution) and node storage. ``AttributeValue`` holders are doc-scoped values, not
+        entities that get seeded/matched on, so they're skipped."""
+        names = [
+            n["properties"]["name"]
+            for n in nodes
+            if n["labels"][0] != ATTRIBUTE_VALUE_LABEL and (n["properties"].get("name") or "").strip()
+        ]
+        return self._embed_texts(names, config, **kwargs)
+
+    @staticmethod
+    def _attach_embeddings(nodes: list[dict], name_vectors: dict[str, list[float]]) -> list[dict]:
+        """Attach each entity node's precomputed name embedding (from ``_embed_entity_names``) as a property.
+
+        Runs after resolution on the deduped node set. No-op when there are no embeddings.
+        """
+        if not name_vectors:
+            return nodes
+        for node in nodes:
+            if node["labels"][0] == ATTRIBUTE_VALUE_LABEL:
+                continue
+            embedding = name_vectors.get(node["properties"].get("name"))
+            if embedding is not None:
+                node["properties"]["embedding"] = embedding
+        return nodes
+
+    @staticmethod
+    def _edge_triplet_text(rel: dict) -> str | None:
+        """The triplet text to embed for an edge, or ``None`` when it can't be rendered (missing names).
+
+        Mirrors ``GraphRetriever``'s render: the attribute KEY is the relation for ``HAS_ATTRIBUTE`` edges,
+        else the relationship type; the edge's own ``src_name``/``dst_name`` snapshots are the endpoints.
+        """
+        props = rel.get("properties") or {}
+        rel_type = rel.get("type") or ""
+        src_name, dst_name = props.get("src_name"), props.get("dst_name")
+        if not (rel_type and src_name and dst_name):
+            return None
+        rel_label = props["key"] if rel_type == HAS_ATTRIBUTE_TYPE and props.get("key") else rel_type
+        return build_fact_text(src_name, rel_label, dst_name, props.get("description"))
+
+    def _maybe_embed_edges(self, relationships: list[dict], config: RunnableConfig, **kwargs) -> None:
+        """Embed each relationship's triplet and store it on the EDGE (``properties['embedding']``), in place.
+
+        No-op without an embedder / non-Neo4j store (``_embed_texts`` returns ``{}``). The embedding rides
+        through the existing edge write path (``SET r += props``); the retriever uses it to rerank facts and
+        strips it from output. ACL stays on the edge — no new node, no new access-control surface.
+        """
+        if not relationships:
+            return
+        texts = {id(rel): self._edge_triplet_text(rel) for rel in relationships}
+        vectors = self._embed_texts([t for t in texts.values() if t], config, **kwargs)
+        if not vectors:
+            return
+        for rel in relationships:
+            text = texts[id(rel)]
+            vector = vectors.get(text) if text else None
+            if vector is not None:
+                # New props dict (not in-place): `_resolve_against_graph` shallow-copies rels, so the
+                # properties dict is shared with the caller's input — replacing the ref keeps input pristine.
+                rel["properties"] = {**(rel.get("properties") or {}), "embedding": vector}
+
+    def _ensure_vector_index(self, index_name: str, label: str, dimension: int) -> None:
+        """Create a Neo4j (>= 5.11) vector index ``index_name`` on ``(:label).embedding``, once per process.
+
+        Lazy from the REAL embedding length so the dimension can never mismatch the model. Idempotent
+        (``IF NOT EXISTS``), best-effort (logged not raised), Neo4j-only.
+        """
+        if index_name in self._vector_indexes_ready or not isinstance(self._graph_store, Neo4jGraphStore):
+            return
+        statement = (
+            f"CREATE VECTOR INDEX {index_name} IF NOT EXISTS "
+            f"FOR (n:{label}) ON n.embedding "
+            f"OPTIONS {{indexConfig: {{`vector.dimensions`: {int(dimension)}, "
+            "`vector.similarity_function`: 'cosine'}}"
+        )
+        try:
+            self._graph_store.run_cypher(statement, database=self.database)
+            self._vector_indexes_ready.add(index_name)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Node {self.name} - {self.id}: could not create vector index {index_name!r}: {e}")
+
+    def _ensure_entity_vector_index(self, dimension: int) -> None:
+        """Create the entity-name vector index so ``GraphRetriever`` can seed by similarity."""
+        self._ensure_vector_index(ENTITY_EMBEDDING_VECTOR_INDEX, ENTITY_LABEL, dimension)
 
     def _build_graph_store(self) -> BaseGraphStore:
         """Pick the concrete store from the connection type (same dispatch as CypherExecutor)."""
@@ -193,7 +357,6 @@ class KnowledgeGraphWriter(Node):
                 f"{type(self._graph_store).__name__}. Only Neo4j currently implements write_graph."
             )
 
-        self._existing_cache = {}
         nodes, relationships = input_data.nodes, input_data.relationships
 
         # Resolution only rewrites endpoints found among `nodes`. An endpoint absent from `nodes` can't be
@@ -212,7 +375,15 @@ class KnowledgeGraphWriter(Node):
                 )
 
         if nodes:
-            nodes, relationships = self._resolve_against_graph(nodes, relationships)
+            # Embed BEFORE resolving so one embed call serves both: the fuzzy candidate lookup (Tier 2)
+            # and node storage. Ensure the vector index up front so resolution can query it this write.
+            name_vectors = self._embed_entity_names(nodes, config, **kwargs)
+            if name_vectors:
+                self._ensure_entity_vector_index(len(next(iter(name_vectors.values()))))
+            nodes, relationships = self._resolve_against_graph(nodes, relationships, name_vectors)
+            nodes = self._attach_embeddings(nodes, name_vectors)
+            # Embed each relationship's triplet onto the edge (for fact reranking at retrieval time).
+            self._maybe_embed_edges(relationships, config, **kwargs)
 
         if nodes or relationships:
             write_result = self._graph_store.write_graph(
@@ -261,36 +432,157 @@ class KnowledgeGraphWriter(Node):
             enriched.append(document.model_copy(update={"metadata": metadata}))
         return enriched
 
-    def _existing_nodes(self, label: str) -> list[tuple[str, str]]:
-        """All (id, name) of existing nodes with the given label, cached per execute() call."""
-        if label in self._existing_cache:
-            return self._existing_cache[label]
-        rows: list[tuple[str, str]] = []
-        if _LABEL_PATTERN.match(label):
+    @staticmethod
+    def _deterministic_id(label: str, name: str) -> str:
+        """Content-addressed node id: ``uuid5(_KG_NAMESPACE, f"{label}:{normalize_name(name)}")``.
+
+        Same (type, normalized name) → same id, on every machine and run — so identical names collapse
+        under ``MERGE`` with no read (Tier 1), and re-ingestion is idempotent. The label is in the hashed
+        string, so an "Apple" Organization and an "Apple" Product never collide.
+        """
+        return str(uuid5(_KG_NAMESPACE, f"{label}:{normalize_name(name)}"))
+
+    def _existing_ids(self, ids: list[str]) -> set[str]:
+        """Which of ``ids`` are already saved as ``:Entity`` nodes — one batched, index-backed lookup.
+
+        Uses the entity-id range index (``entity_id``), so it's a b-tree seek per id, not a scan. Lets
+        resolution skip the fuzzy tier for entities that already exist exactly. Best-effort and Neo4j-only:
+        on any other backend or any failure it returns an empty set, so fuzzy simply runs (never blocks
+        the write).
+        """
+        if not ids or not isinstance(self._graph_store, Neo4jGraphStore):
+            return set()
+        try:
             records, _, _ = self._graph_store.run_cypher(
-                f"MATCH (n:`{label}`) WHERE n.name IS NOT NULL RETURN n.id AS id, n.name AS name",
+                f"UNWIND $ids AS id MATCH (n:{ENTITY_LABEL} {{id: id}}) RETURN n.id AS id",
+                parameters={"ids": list(dict.fromkeys(ids))},
                 database=self.database,
             )
-            rows = [(r.get("id"), r.get("name")) for r in self._graph_store.format_records(records)]
-        self._existing_cache[label] = rows
-        return rows
+            return {r.get("id") for r in self._graph_store.format_records(records)}
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Node {self.name} - {self.id}: existing-id lookup failed ({e}); running fuzzy.")
+            return set()
 
-    def _resolve_against_graph(self, nodes: list[dict], relationships: list[dict]) -> tuple[list[dict], list[dict]]:
-        """Assign graph identity to every extracted entity by name similarity ONLY.
+    def _blocking_candidates(self, label: str, name: str, vector: list[float] | None) -> list[tuple[str, str]]:
+        """Bounded set of existing same-label entities near ``name`` for fuzzy resolution (Neo4j only).
 
-        LLM-produced ids are ephemeral wiring: they link edges to entities within one extraction
-        and never participate in identity. Every entity either adopts the id of the best
-        trigram-matching existing node (same label, score >= ``similarity_threshold``) or gets a
-        fresh UUID. Newly assigned entities are added to the per-call candidate cache so later
-        entities in the same batch converge onto them too. ``AttributeValue`` node ids are
-        re-derived from their owner's resolved id (``{owner_id}::{attr_key}::{doc_id}``).
-
-        Works on copies of the caller's dicts: this rewrites ``properties["id"]`` and strips the
-        transient ``attr_ref`` below, so mutating the input in place would leave the same payload
-        unwritable a second time (attribute ids could no longer be rebuilt).
+        Replaces the old full-label scan with an index seek: the entity vector index when a name embedding
+        is available (catches synonyms), else the entity-name full-text index. Best-effort — any failure
+        (e.g. the index doesn't exist yet on the first write) yields no candidates, so resolution simply
+        keeps the deterministic id. Returns ``(id, name)`` pairs.
         """
+        try:
+            if vector is not None:
+                # Over-fetch (queryNodes returns nearest across ALL types) then keep this label's.
+                records, _, _ = self._graph_store.run_cypher(
+                    "CALL db.index.vector.queryNodes($index, $k, $vec) YIELD node "
+                    "WHERE $label IN labels(node) AND node.name IS NOT NULL "
+                    "RETURN node.id AS id, node.name AS name",
+                    parameters={
+                        "index": ENTITY_EMBEDDING_VECTOR_INDEX,
+                        "k": max(self.resolution_top_k * 5, self.resolution_top_k),
+                        "vec": vector,
+                        "label": label,
+                    },
+                    database=self.database,
+                )
+            else:
+                lucene = _lucene_or_query(name)
+                if not lucene:
+                    return []
+                records, _, _ = self._graph_store.run_cypher(
+                    "CALL db.index.fulltext.queryNodes($index, $q) YIELD node "
+                    "WHERE $label IN labels(node) AND node.name IS NOT NULL "
+                    "RETURN node.id AS id, node.name AS name LIMIT $k",
+                    parameters={
+                        "index": ENTITY_NAME_FULLTEXT_INDEX,
+                        "q": lucene,
+                        "label": label,
+                        "k": self.resolution_top_k,
+                    },
+                    database=self.database,
+                )
+            return [(r.get("id"), r.get("name")) for r in self._graph_store.format_records(records)]
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"Node {self.name} - {self.id}: fuzzy candidate lookup failed ({e}); using deterministic id."
+            )
+            return []
+
+    def _find_canonical(
+        self,
+        label: str,
+        name: str,
+        det_id: str,
+        vector: list[float] | None,
+        batch_candidates: list[tuple[str, str]],
+        use_db: bool,
+    ) -> str | None:
+        """Tier 2: return the id of an existing/earlier entity that is a trigram near-dup of ``name``.
+
+        Candidates come from the index (``_blocking_candidates``, Neo4j) plus this-write entities already
+        resolved (``batch_candidates``). The merge decision is ALWAYS trigram ≥ ``similarity_threshold`` —
+        embeddings/full-text only propose candidates, so distinct same-category names ("John Smith" vs
+        "John Doe") are never fused. Returns ``None`` when nothing clears the threshold (keep ``det_id``).
+        """
+        candidates = list(batch_candidates)
+        if use_db:
+            candidates += self._blocking_candidates(label, name, vector)
+
+        best_id, best_score = None, 0.0
+        for cand_id, cand_name in candidates:
+            if not cand_id or not cand_name or cand_id == det_id:
+                continue  # skip self: an exact-normalized dup already shares det_id
+            score = _trigram_similarity(name, cand_name)
+            if score >= self.similarity_threshold and score > best_score:
+                best_id, best_score = cand_id, score
+        if best_id:
+            logger.info(
+                f"Node {self.name} - {self.id}: linking {name!r} -> existing node {best_id!r} "
+                f"(trigram={best_score:.2f})"
+            )
+        return best_id
+
+    def _resolve_against_graph(
+        self, nodes: list[dict], relationships: list[dict], name_vectors: dict[str, list[float]] | None = None
+    ) -> tuple[list[dict], list[dict]]:
+        """Assign durable identity to every extracted entity — deterministic base + optional fuzzy tier.
+
+        LLM-produced ids are ephemeral wiring. Each entity ALWAYS gets a **deterministic** id
+        ``uuid5(label:normalize_name(name))`` (Tier 1) — identical names collapse under ``MERGE`` with no
+        graph read, and re-ingestion is idempotent. When ``fuzzy_matching`` is on (default), spelling
+        variants are additionally merged (Tier 2, optional): for entities whose deterministic id is not
+        already saved, a bounded index-backed candidate lookup + trigram confirm may adopt an existing
+        entity's id instead. ``AttributeValue`` ids are re-derived from their owner's resolved id.
+
+        Works on copies of the caller's dicts (rewrites ``properties["id"]``, strips the transient
+        ``attr_ref``), so the input stays writable a second time.
+        """
+        name_vectors = name_vectors or {}
         nodes = [{**node, "properties": {**node["properties"]}} for node in nodes]
         relationships = [{**rel} for rel in relationships]
+
+        fuzzy = self.fuzzy_matching
+        use_db = fuzzy and isinstance(self._graph_store, Neo4jGraphStore)
+
+        # Tier 1: deterministic id per named entity (nameless ones get a fresh uuid). One pass, so the
+        # existence check below can be batched over the whole set.
+        det_by_old: dict[str, str] = {}
+        for node in nodes:
+            if node["labels"][0] == ATTRIBUTE_VALUE_LABEL:
+                continue
+            old_id = node["properties"]["id"]
+            if old_id in det_by_old:
+                continue  # wiring ids are doc-scoped, so a repeat means the same in-document entity
+            name = node["properties"].get("name")
+            det_by_old[old_id] = self._deterministic_id(node["labels"][0], name) if name else generate_uuid()
+
+        # Tier 2 GATE: an entity whose deterministic id is ALREADY in the graph is an established exact
+        # node — keep it and skip fuzzy, so re-ingestion is a no-op and fuzzy can never re-merge it into a
+        # similar-but-different node. One batched, index-backed existence lookup answers this for all ids.
+        already_saved = self._existing_ids(list(det_by_old.values())) if fuzzy else set()
+        # This-write candidates so variants within one batch converge (brand-new ids aren't indexed yet).
+        batch_candidates: dict[str, list[tuple[str, str]]] = {}
 
         id_remap: dict[str, str] = {}
         for node in nodes:
@@ -299,26 +591,19 @@ class KnowledgeGraphWriter(Node):
                 continue
             old_id = node["properties"]["id"]
             if old_id in id_remap:
-                continue  # wiring ids are doc-scoped, so a repeat means the same in-document entity
+                continue
             name = node["properties"].get("name")
-
-            best_id, best_score = None, 0.0
-            for ex_id, ex_name in self._existing_nodes(label) if name else []:
-                score = _trigram_similarity(name, ex_name)
-                if score >= self.similarity_threshold and score > best_score:
-                    best_id, best_score = ex_id, score
-
-            if best_id:
-                id_remap[old_id] = best_id
-                logger.info(
-                    f"Node {self.name} - {self.id}: linking {name!r} -> existing node "
-                    f"{best_id!r} (trigram={best_score:.2f})"
+            det_id = det_by_old[old_id]
+            resolved = det_id
+            if fuzzy and name and det_id not in already_saved:
+                match = self._find_canonical(
+                    label, name, det_id, name_vectors.get(name), batch_candidates.get(label, []), use_db
                 )
-            else:
-                id_remap[old_id] = generate_uuid()
-                if name:
-                    # Make the new node a match candidate for the rest of this batch.
-                    self._existing_cache.setdefault(label, []).append((id_remap[old_id], name))
+                if match:
+                    resolved = match
+            id_remap[old_id] = resolved
+            if name:
+                batch_candidates.setdefault(label, []).append((resolved, name))
 
         # AttributeValue ids derive from their owner so re-ingestion updates the same node. Rebuild the id
         # from the (owner, key, doc) parts on the node via build_attribute_value_id (no string parsing, so

--- a/dynamiq/nodes/extractors/knowledge_graph.py
+++ b/dynamiq/nodes/extractors/knowledge_graph.py
@@ -196,9 +196,8 @@ class KnowledgeGraphWriter(Node):
         self._existing_cache = {}
         nodes, relationships = input_data.nodes, input_data.relationships
 
-        # Relationship endpoints reference node wiring ids; resolution (below) only rewrites endpoints found
-        # among `nodes`. An endpoint absent from `nodes` can never be resolved -- it would be written with an
-        # ephemeral id that MATCHes no graph node (creating no edge) and would mis-tag chunks with that id.
+        # Resolution only rewrites endpoints found among `nodes`. An endpoint absent from `nodes` can't be
+        # resolved -- it would get an ephemeral id that matches no graph node (no edge) and mis-tags chunks.
         # Reject such payloads instead of silently writing nothing useful.
         if relationships:
             node_ids = {n["properties"]["id"] for n in nodes}
@@ -321,10 +320,9 @@ class KnowledgeGraphWriter(Node):
                     # Make the new node a match candidate for the rest of this batch.
                     self._existing_cache.setdefault(label, []).append((id_remap[old_id], name))
 
-        # AttributeValue ids derive from their owner entity so re-ingestion updates the same value
-        # node. The structured (owner, key, doc) parts ride on the node, so we rebuild the resolved
-        # id directly via build_attribute_value_id — no string parsing, so an LLM id containing "::"
-        # can't corrupt the split. Pop the transient ref so it never reaches the store.
+        # AttributeValue ids derive from their owner so re-ingestion updates the same node. Rebuild the id
+        # from the (owner, key, doc) parts on the node via build_attribute_value_id (no string parsing, so
+        # an LLM id containing "::" can't corrupt it). Pop the transient ref so it never reaches the store.
         for node in nodes:
             if node["labels"][0] != ATTRIBUTE_VALUE_LABEL:
                 continue

--- a/dynamiq/nodes/extractors/knowledge_graph.py
+++ b/dynamiq/nodes/extractors/knowledge_graph.py
@@ -466,46 +466,71 @@ class KnowledgeGraphWriter(Node):
     def _blocking_candidates(self, label: str, name: str, vector: list[float] | None) -> list[tuple[str, str]]:
         """Bounded set of existing same-label entities near ``name`` for fuzzy resolution (Neo4j only).
 
-        Replaces the old full-label scan with an index seek: the entity vector index when a name embedding
-        is available (catches synonyms), else the entity-name full-text index. Best-effort — any failure
-        (e.g. the index doesn't exist yet on the first write) yields no candidates, so resolution simply
-        keeps the deterministic id. Returns ``(id, name)`` pairs.
+        Prefers the entity vector index when a name embedding is available (catches synonyms). If that
+        query FAILS (missing / dim-mismatched vector index, permissions), it degrades to the entity-name
+        full-text index rather than silently returning nothing — otherwise a transient vector-index fault
+        would blind resolution to existing nodes and write duplicate entities. Best-effort throughout: any
+        remaining failure yields no candidates, so resolution keeps the deterministic id. Returns
+        ``(id, name)`` pairs.
+        """
+        if vector is not None:
+            candidates = self._vector_candidates(label, vector)
+            if candidates is not None:  # vector query ran (may legitimately be empty) — trust it
+                return candidates
+            # vector index errored -> degrade to the lexical full-text path instead of returning []
+        return self._fulltext_candidates(label, name)
+
+    def _vector_candidates(self, label: str, vector: list[float]) -> list[tuple[str, str]] | None:
+        """Nearest same-label entities by name embedding (semantic near-dups). Returns ``None`` on query
+        failure so the caller can fall back to full-text; an empty list means the query ran but matched
+        nothing.
         """
         try:
-            if vector is not None:
-                # Over-fetch (queryNodes returns nearest across ALL types) then keep this label's.
-                records, _, _ = self._graph_store.run_cypher(
-                    "CALL db.index.vector.queryNodes($index, $k, $vec) YIELD node "
-                    "WHERE $label IN labels(node) AND node.name IS NOT NULL "
-                    "RETURN node.id AS id, node.name AS name",
-                    parameters={
-                        "index": ENTITY_EMBEDDING_VECTOR_INDEX,
-                        "k": max(self.resolution_top_k * 5, self.resolution_top_k),
-                        "vec": vector,
-                        "label": label,
-                    },
-                    database=self.database,
-                )
-            else:
-                lucene = _lucene_or_query(name)
-                if not lucene:
-                    return []
-                records, _, _ = self._graph_store.run_cypher(
-                    "CALL db.index.fulltext.queryNodes($index, $q) YIELD node "
-                    "WHERE $label IN labels(node) AND node.name IS NOT NULL "
-                    "RETURN node.id AS id, node.name AS name LIMIT $k",
-                    parameters={
-                        "index": ENTITY_NAME_FULLTEXT_INDEX,
-                        "q": lucene,
-                        "label": label,
-                        "k": self.resolution_top_k,
-                    },
-                    database=self.database,
-                )
+            # Over-fetch (queryNodes returns nearest across ALL types) then keep this label's.
+            records, _, _ = self._graph_store.run_cypher(
+                "CALL db.index.vector.queryNodes($index, $k, $vec) YIELD node "
+                "WHERE $label IN labels(node) AND node.name IS NOT NULL "
+                "RETURN node.id AS id, node.name AS name",
+                parameters={
+                    "index": ENTITY_EMBEDDING_VECTOR_INDEX,
+                    "k": max(self.resolution_top_k * 5, self.resolution_top_k),
+                    "vec": vector,
+                    "label": label,
+                },
+                database=self.database,
+            )
             return [(r.get("id"), r.get("name")) for r in self._graph_store.format_records(records)]
         except Exception as e:  # noqa: BLE001
             logger.warning(
-                f"Node {self.name} - {self.id}: fuzzy candidate lookup failed ({e}); using deterministic id."
+                f"Node {self.name} - {self.id}: vector candidate lookup failed ({e}); " "falling back to full-text."
+            )
+            return None
+
+    def _fulltext_candidates(self, label: str, name: str) -> list[tuple[str, str]]:
+        """Same-label entities lexically near ``name`` via the entity-name full-text index. Best-effort:
+        any failure (e.g. the index doesn't exist yet on the first write) yields no candidates, so
+        resolution keeps the deterministic id.
+        """
+        lucene = _lucene_or_query(name)
+        if not lucene:
+            return []
+        try:
+            records, _, _ = self._graph_store.run_cypher(
+                "CALL db.index.fulltext.queryNodes($index, $q) YIELD node "
+                "WHERE $label IN labels(node) AND node.name IS NOT NULL "
+                "RETURN node.id AS id, node.name AS name LIMIT $k",
+                parameters={
+                    "index": ENTITY_NAME_FULLTEXT_INDEX,
+                    "q": lucene,
+                    "label": label,
+                    "k": self.resolution_top_k,
+                },
+                database=self.database,
+            )
+            return [(r.get("id"), r.get("name")) for r in self._graph_store.format_records(records)]
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"Node {self.name} - {self.id}: full-text candidate lookup failed ({e}); " "using deterministic id."
             )
             return []
 
@@ -575,7 +600,11 @@ class KnowledgeGraphWriter(Node):
             if old_id in det_by_old:
                 continue  # wiring ids are doc-scoped, so a repeat means the same in-document entity
             name = node["properties"].get("name")
-            det_by_old[old_id] = self._deterministic_id(node["labels"][0], name) if name else generate_uuid()
+            # Gate on the NORMALIZED name: a name that is only whitespace/apostrophes normalizes to "" and
+            # must stay nameless (fresh uuid), else every such entity would collide on the "{label}:" id.
+            det_by_old[old_id] = (
+                self._deterministic_id(node["labels"][0], name) if name and normalize_name(name) else generate_uuid()
+            )
 
         # Tier 2 GATE: an entity whose deterministic id is ALREADY in the graph is an established exact
         # node — keep it and skip fuzzy, so re-ingestion is a no-op and fuzzy can never re-merge it into a

--- a/dynamiq/nodes/retrievers/graph.py
+++ b/dynamiq/nodes/retrievers/graph.py
@@ -7,7 +7,9 @@ from dynamiq.connections import ApacheAGE, AWSNeptune, Neo4j
 from dynamiq.connections.managers import ConnectionManager
 from dynamiq.nodes import ErrorHandling
 from dynamiq.nodes.agents.exceptions import ToolExecutionException
+from dynamiq.nodes.embedders.base import TextEmbedder
 from dynamiq.nodes.extractors.entity_extractor import (
+    ENTITY_EMBEDDING_VECTOR_INDEX,
     ENTITY_LABEL,
     ENTITY_NAME_FULLTEXT_INDEX,
     HAS_ATTRIBUTE_TYPE,
@@ -225,6 +227,15 @@ class GraphRetriever(ConnectionNode):
     filters: dict[str, Any] | None = None  # LOCKED: always applied; not overridable from the input schema
     top_k: int = 50
     document_reranker: Node | None = None  # optional rerank of rendered facts; top_k here = candidate pool
+    # Optional semantic seeding: when set AND the entity vector index exists, entry entities are found by
+    # embedding the query's entity names and vector-searching, instead of the full-text/CONTAINS name match.
+    # Use the SAME embedding model as the writer's `entity_embedder` so vector dimensions match.
+    text_embedder: TextEmbedder | None = None
+    vector_top_k: int = 5  # candidate entities pulled from the vector index per seed name
+    # When True (and vector seeding is available), skip LLM entity extraction and seed the top-k entities by
+    # the WHOLE question embedding — simpler, no LLM, context-preserving. Facts are then reranked by the same
+    # vector. Off by default (keeps entity-anchored extraction). Requires a text_embedder + entity index.
+    seed_by_query: bool = False
     # optional grounding source: any object with get_documents_by_ids(ids) -> list[Document]
     document_retriever: Any = None
     # when True, LLM-compose an answer from the retrieved context; when False (default) return raw facts/source
@@ -234,6 +245,7 @@ class GraphRetriever(ConnectionNode):
 
     _graph_store: BaseGraphStore | None = PrivateAttr(default=None)
     _use_fulltext: bool = PrivateAttr(default=False)
+    _use_vector: bool = PrivateAttr(default=False)
     _run_depends: list = PrivateAttr(default_factory=list)
 
     def reset_run_state(self) -> None:
@@ -241,13 +253,20 @@ class GraphRetriever(ConnectionNode):
 
     @property
     def to_dict_exclude_params(self) -> dict:
-        return super().to_dict_exclude_params | {"llm": True, "document_reranker": True, "document_retriever": True}
+        return super().to_dict_exclude_params | {
+            "llm": True,
+            "document_reranker": True,
+            "document_retriever": True,
+            "text_embedder": True,
+        }
 
     def to_dict(self, **kwargs) -> dict:
         data = super().to_dict(**kwargs)
         data["llm"] = self.llm.to_dict(**kwargs)
         if self.document_reranker:
             data["document_reranker"] = self.document_reranker.to_dict(**kwargs)
+        if self.text_embedder:
+            data["text_embedder"] = self.text_embedder.to_dict(**kwargs)
         if self.document_retriever is not None and hasattr(self.document_retriever, "to_dict"):
             data["document_retriever"] = self.document_retriever.to_dict(**kwargs)
         return data
@@ -264,9 +283,12 @@ class GraphRetriever(ConnectionNode):
             self.document_retriever, "is_postponed_component_init", False
         ):
             self.document_retriever.init_components(connection_manager)
+        if self.text_embedder and self.text_embedder.is_postponed_component_init:
+            self.text_embedder.init_components(connection_manager)
         if self._graph_store is None:
             self._graph_store = self._build_graph_store()
         self._use_fulltext = self._probe_fulltext()
+        self._use_vector = self._probe_vector()
 
     def _probe_fulltext(self) -> bool:
         """Whether the entity-name full-text index exists (Neo4j only). Read-only; failure -> scan fallback.
@@ -286,6 +308,27 @@ class GraphRetriever(ConnectionNode):
             return bool(rows and (rows[0].get("c") or 0) > 0)
         except Exception as e:
             logger.warning(f"Node {self.name} - {self.id}: full-text index probe failed, using scan: {e}")
+            return False
+
+    def _probe_vector(self) -> bool:
+        """Whether semantic seeding is available: a ``text_embedder`` is set AND the entity vector index
+        exists (Neo4j only). Read-only; any failure -> ``False`` so the retriever falls back to full-text/scan.
+
+        Backend-agnostic: without an embedder, or on a non-Neo4j store, or before the writer has embedded any
+        entity (so no vector index), this returns ``False`` and the existing name-match path is used.
+        """
+        if not self.text_embedder or not isinstance(self._graph_store, Neo4jGraphStore):
+            return False
+        try:
+            records, _, _ = self._graph_store.run_cypher(
+                "SHOW INDEXES YIELD name, type WHERE name = $n AND type = 'VECTOR' RETURN count(*) AS c",
+                parameters={"n": ENTITY_EMBEDDING_VECTOR_INDEX},
+                database=self.database,
+            )
+            rows = self._graph_store.format_records(records)
+            return bool(rows and (rows[0].get("c") or 0) > 0)
+        except Exception as e:
+            logger.warning(f"Node {self.name} - {self.id}: vector index probe failed, using name match: {e}")
             return False
 
     def _build_graph_store(self) -> BaseGraphStore:
@@ -351,23 +394,88 @@ class GraphRetriever(ConnectionNode):
 
         - explicit ``entities`` -> used as the seed names directly, **skipping LLM extraction**.
         - explicit ``entity_ids`` -> ``[]`` (anchored exactly by id in ``_entry``, not by name).
+        - ``seed_by_query`` -> ``[]`` (no names; seed on the WHOLE question vector, no LLM extraction).
         - otherwise -> extracted from the question by the LLM.
 
-        An empty list means "no seed names" -> ``_entry`` falls back to the raw query.
+        An empty list means "no seed names" -> ``_entry`` seeds on the whole-query vector (or the raw query).
         """
-        if input_data.entity_ids:
+        if input_data.entity_ids or self.seed_by_query:
             return []
         if input_data.entities:
             return input_data.entities
         return self._extract_entity_names(input_data.query, config, **kwargs)
 
+    def _embed_query(self, text: str, config: RunnableConfig, **kwargs) -> list[float] | None:
+        """Embed one text via ``text_embedder``; ``None`` on any failure. One call, reused for the whole-query
+        rank vector and per-name seed vectors."""
+        try:
+            embed_kwargs = kwargs | {"parent_run_id": kwargs.get("run_id")}
+            embed_kwargs.pop("run_depends", None)
+            result = self.text_embedder.run(
+                input_data={"query": text}, run_depends=self._run_depends, config=config, **embed_kwargs
+            )
+            if result.status != RunnableStatus.SUCCESS:
+                return None
+            self._run_depends = [NodeDependency(node=self.text_embedder).to_dict(for_tracing=True)]
+            return result.output.get("embedding") or None
+        except Exception as e:
+            logger.warning(f"Node {self.name} - {self.id}: query embed failed: {e}")
+            return None
+
+    def _query_vector(self, query: str, config: RunnableConfig, **kwargs) -> list[float] | None:
+        """Embed the WHOLE query ONCE (when ``_use_vector``) → reused for BOTH server-side fact reranking
+        (``$qvec``) and the no-entity-names seed vector (incl. ``seed_by_query``). ``None`` disables both.
+
+        ``_use_vector`` is true only when the entity vector index exists, which — created with the 5.15+
+        ``CREATE VECTOR INDEX`` syntax — also guarantees the ``vector.similarity.cosine`` function the rank
+        uses. Best-effort: any failure returns ``None``."""
+        if not self._use_vector or not query:
+            return None
+        return self._embed_query(query, config, **kwargs)
+
+    def _seed_vectors(
+        self,
+        input_data: GraphRetrieverInputSchema,
+        seed_names: list[str],
+        query_vector: list[float] | None,
+        config: RunnableConfig,
+        **kwargs,
+    ) -> list[list[float]] | None:
+        """Vectors to seed entity search on, or ``None`` to fall back to the full-text/scan path.
+
+        ``None`` when semantic seeding is off (``_use_vector`` False) or the search is anchored by explicit
+        ``entity_ids``. With entity names, each is embedded separately (a multi-entity question seeds on each
+        independently); with NO names (extraction found none, or ``seed_by_query``), the already-computed
+        ``query_vector`` is reused — the whole query is embedded once and serves both seeding and reranking.
+        Any embedder failure → ``None`` (name match).
+        """
+        if not self._use_vector or input_data.entity_ids:
+            return None
+        if not seed_names:
+            return [query_vector] if query_vector else None
+        vectors: list[list[float]] = []
+        for name in seed_names:
+            vector = self._embed_query(name, config, **kwargs)
+            if vector is None:
+                logger.warning(f"Node {self.name} - {self.id}: seed-name embed failed; using name match.")
+                return None
+            vectors.append(vector)
+        return vectors or None
+
     def _entry(
-        self, input_data: GraphRetrieverInputSchema, params: dict[str, Any], seed_names: list[str] | None
+        self,
+        input_data: GraphRetrieverInputSchema,
+        params: dict[str, Any],
+        seed_names: list[str] | None,
+        seed_vectors: list[list[float]] | None = None,
     ) -> tuple[list[str], str | None, bool]:
         """Pick the entry-point strategy. Returns (lead_lines, entry_where, anchored).
 
         - explicit ``entity_ids`` -> anchor on ``:Entity`` nodes by exact id (the precise hybrid/iterative
           seed; takes precedence and skips name matching entirely).
+        - else, ``seed_vectors`` present (a ``text_embedder`` is set and the entity vector index exists)
+          -> anchor on the nearest entities by embedding similarity (``db.index.vector.queryNodes``), one
+          lookup per seed vector. Semantic seeding: matches "car" to an entity named "automobile".
         - else, seed by NAME (``seed_names`` = explicit ``entities`` or LLM-extracted names), matched
           fuzzily: on Neo4j with the index, a full-text seek over ``(tok AND tok) OR (...)``; otherwise a
           portable ``CONTAINS`` scan. With no names, falls back to a recall-y OR over the raw query.
@@ -379,6 +487,18 @@ class GraphRetriever(ConnectionNode):
         if input_data.entity_ids:
             params["entity_ids"] = input_data.entity_ids
             return [f"MATCH (a:{ENTITY_LABEL})"], "a.id IN $entity_ids", True
+
+        if seed_vectors:
+            params["qvecs"] = seed_vectors
+            params["vk"] = self.vector_top_k
+            return (
+                [
+                    "UNWIND $qvecs AS qv",
+                    f"CALL db.index.vector.queryNodes('{ENTITY_EMBEDDING_VECTOR_INDEX}', $vk, qv) YIELD node AS a",
+                ],
+                None,
+                True,
+            )
 
         # Explicit entities and extracted names are matched the same way; `seed_names` carries either.
         # (`seed_names is None` only on direct _build_query calls -> derive from the input's entities.)
@@ -398,15 +518,24 @@ class GraphRetriever(ConnectionNode):
         return [], "(toLower($q) CONTAINS toLower(a.name) OR toLower($q) CONTAINS toLower(b.name))", False
 
     def _build_query(
-        self, input_data: GraphRetrieverInputSchema, limit: int, seed_names: list[str] | None = None
+        self,
+        input_data: GraphRetrieverInputSchema,
+        limit: int,
+        seed_names: list[str] | None = None,
+        seed_vectors: list[list[float]] | None = None,
+        query_vector: list[float] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Build the single parameterized one-hop Cypher query and its parameters.
 
         ``seed_names`` are the extracted entity names computed in ``execute``; ``None`` (the default when
-        called directly) means seed on the raw query (the pre-extraction behavior).
+        called directly) means seed on the raw query (the pre-extraction behavior). ``seed_vectors`` are the
+        embedded seed names (when semantic seeding is active) — when present they take precedence over names.
+        ``query_vector`` is the embedded query — when present the neighbourhood is ranked server-side by the
+        cosine of each edge's ``r.embedding`` so only the top ``limit`` MOST RELEVANT facts come back (a hub
+        no longer returns an arbitrary slice), and the embeddings never cross the wire.
         """
         params: dict[str, Any] = {"limit": limit}
-        lead, entry_where, anchored = self._entry(input_data, params, seed_names)
+        lead, entry_where, anchored = self._entry(input_data, params, seed_names, seed_vectors)
         # Anchored expansion is undirected (catch edges into and out of the seed); direction is recovered
         # in RETURN via startNode/endNode. The scan keeps the directed pattern with a=source, b=target.
         arrow = "-[{rel}]-" if anchored else "-[{rel}]->"
@@ -431,7 +560,16 @@ class GraphRetriever(ConnectionNode):
         lines = [*lead, f"MATCH (a){arrow.format(rel='r')}(b)"]
         if where:
             lines.append(f"WHERE {where}")
-        lines += [ret, "LIMIT $limit"]
+        lines.append(ret)
+        if query_vector:
+            # Rank the whole matched neighbourhood by fact relevance, then LIMIT — so the top_k returned are
+            # the MOST relevant, not an arbitrary slice. Edges without an embedding sort last (score -1).
+            params["qvec"] = query_vector
+            lines.append(
+                "ORDER BY CASE WHEN r.embedding IS NULL THEN -1.0 "
+                "ELSE vector.similarity.cosine(r.embedding, $qvec) END DESC"
+            )
+        lines.append("LIMIT $limit")
         return "\n".join(lines), params
 
     def _edge_predicates(self, rel_var: str, user_filters: dict[str, Any] | None) -> tuple[list[str], dict[str, Any]]:
@@ -460,7 +598,11 @@ class GraphRetriever(ConnectionNode):
         limit = input_data.top_k or self.top_k
         try:
             seed_names = self._seed_entity_names(input_data, config, **kwargs)
-            query, params = self._build_query(input_data, limit, seed_names)
+            # Embed the whole question once (when vectors are on): reused as the fact-rank vector AND, when
+            # there are no seed names, the seed vector — so seeding and reranking share one embedding.
+            query_vector = self._query_vector(input_data.query, config, **kwargs)
+            seed_vectors = self._seed_vectors(input_data, seed_names, query_vector, config, **kwargs)
+            query, params = self._build_query(input_data, limit, seed_names, seed_vectors, query_vector)
             records, _, _ = self._graph_store.run_cypher(query, parameters=params, database=self.database)
             rows = self._graph_store.format_records(records)
             documents = self._render_single_hop(rows)
@@ -568,6 +710,7 @@ class GraphRetriever(ConnectionNode):
             # already surfaced as source/target below -> drop from raw props to avoid metadata duplication.
             rprops.pop("src_name", None)
             rprops.pop("dst_name", None)
+            rprops.pop("embedding", None)  # edge embedding is used server-side for ranking, never surfaced
             # Attribute edges reify a "key -> value" pair; HAS_ATTRIBUTE is just the bookkeeping type, so
             # render the attribute KEY as the relation -- otherwise the fact is a bare value ("$250,000")
             # with no hint of WHICH attribute it is.

--- a/dynamiq/nodes/retrievers/graph.py
+++ b/dynamiq/nodes/retrievers/graph.py
@@ -420,16 +420,19 @@ class GraphRetriever(ConnectionNode):
         rel_clauses, filter_params = self._edge_predicates("r", input_data.filters)
         params.update(filter_params)
         where = " AND ".join([t for t in [entry_where, *rel_clauses] if t])
+        # Endpoint names are read from the edge's own ACL-bearing snapshot (r.src_name/r.dst_name), never
+        # from the shared, merged entity node -- so a node name written by a differently-scoped document
+        # cannot leak. Node ids (opaque UUIDs) are still taken from the nodes for next-hop iteration.
         if anchored:
             ret = (
-                "RETURN coalesce(startNode(r).name, startNode(r).value) AS a_name, startNode(r).id AS a_id, "
+                "RETURN r.src_name AS a_name, startNode(r).id AS a_id, "
                 "type(r) AS rel, properties(r) AS rprops, "
-                "coalesce(endNode(r).name, endNode(r).value) AS b_name, endNode(r).id AS b_id"
+                "r.dst_name AS b_name, endNode(r).id AS b_id"
             )
         else:
             ret = (
-                "RETURN coalesce(a.name, a.value) AS a_name, a.id AS a_id, type(r) AS rel, "
-                "properties(r) AS rprops, coalesce(b.name, b.value) AS b_name, b.id AS b_id"
+                "RETURN r.src_name AS a_name, a.id AS a_id, type(r) AS rel, "
+                "properties(r) AS rprops, r.dst_name AS b_name, b.id AS b_id"
             )
         lines = [*lead, f"MATCH (a){arrow.format(rel='r')}(b)"]
         if where:
@@ -568,6 +571,10 @@ class GraphRetriever(ConnectionNode):
             if source is None or target is None or not rel:
                 continue
             rprops = dict(row.get("rprops") or {})
+            # src_name/dst_name are the edge's endpoint-name snapshot, already surfaced as source/target
+            # below -- drop them from the raw props so they are not duplicated in the document metadata.
+            rprops.pop("src_name", None)
+            rprops.pop("dst_name", None)
             # Attribute edges reify a "key -> value" pair; HAS_ATTRIBUTE is just the bookkeeping type, so
             # render the attribute KEY as the relation -- otherwise the fact is a bare value ("$250,000")
             # with no hint of WHICH attribute it is.

--- a/dynamiq/nodes/retrievers/graph.py
+++ b/dynamiq/nodes/retrievers/graph.py
@@ -26,14 +26,11 @@ from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.json_parser import parse_llm_json_output
 from dynamiq.utils.logger import logger
 
-# Property keys interpolated into Cypher text (label/property identifiers) must match this — the safe
-# identifier subset shared by openCypher backends. Filter VALUES are always passed as bound parameters;
-# only KEYS are validated here, so a malicious filter key cannot smuggle Cypher.
+# Only filter KEYS are validated against this (VALUES are always bound params), so a key can't inject Cypher.
 _IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-# LLM pre-step (LangChain-style): pull the entities a QUESTION is about, constrained to the same ontology
-# entity types used at ingestion, so the graph search seeds on those names (precise) rather than every
-# word in the question (noisy). The structured output is just a list of names.
+# LLM pre-step: extract the entities a QUESTION is about (constrained to ontology types) so the graph
+# seeds on those names rather than every word. Structured output is just a list of names.
 _QUERY_ENTITY_PROMPT = (
     "You identify which named entities a QUESTION is about, so they can be looked up in a knowledge graph. "
     "Return ONLY a JSON object of the form {\"names\": [\"...\"]} -- the entity names exactly as they appear "
@@ -73,9 +70,8 @@ _FILTER_OPERATORS: dict[str, Any] = {
     "$lte": lambda c, p: f"{c} <= ${p}",
     "$contains": lambda c, p: f"{c} CONTAINS ${p}",  # substring (string properties)
     "$any": lambda c, p: f"${p} IN {c}",  # membership (scalar value in a list property)
-    # list-list intersection (default-deny): keep the edge only if its list property shares >=1 element
-    # with the parameter list. This is how ACL is expressed — `{"allowed_principals": {"$intersects": [...]}}`
-    # — a missing/null property coalesces to [] and is therefore excluded.
+    # list-list intersection (default-deny): keep the edge only if its list shares >=1 element with the
+    # param list. How ACL is expressed: {"allowed_principals": {"$intersects": [...]}}. Null -> [] -> excluded.
     "$intersects": lambda c, p: f"size([x IN coalesce({c}, []) WHERE x IN ${p}]) > 0",
 }
 
@@ -101,12 +97,10 @@ def _lucene_query(text: str) -> str:
 
 
 def _grouped_lucene_query(names: list[str]) -> str:
-    """Fuzzy Lucene query for a list of entity names: AND the tokens WITHIN a name, OR ACROSS names.
+    """Fuzzy Lucene query: AND tokens WITHIN a name, OR ACROSS names.
 
-    A multi-word name like ``"Alice Smith"`` becomes ``(Alice~ AND Smith~)`` — so it matches "Alice Smith"
-    (and typos) but NOT "Alice Tem", which only shares one token. Multiple extracted entities are OR-ed
-    (``(Alice~ AND Smith~) OR (Helios~)``) so a question about several entities still finds them all.
-    Returns "" when no name yields a usable token.
+    ``"Alice Smith"`` -> ``(Alice~ AND Smith~)`` (matches the full name and typos, not a one-token overlap);
+    multiple names are OR-ed. Returns "" when no name yields a usable token.
     """
     groups: list[str] = []
     for name in names:
@@ -420,9 +414,9 @@ class GraphRetriever(ConnectionNode):
         rel_clauses, filter_params = self._edge_predicates("r", input_data.filters)
         params.update(filter_params)
         where = " AND ".join([t for t in [entry_where, *rel_clauses] if t])
-        # Endpoint names are read from the edge's own ACL-bearing snapshot (r.src_name/r.dst_name), never
-        # from the shared, merged entity node -- so a node name written by a differently-scoped document
-        # cannot leak. Node ids (opaque UUIDs) are still taken from the nodes for next-hop iteration.
+        # Names come from the edge's own ACL-bearing snapshot (r.src_name/r.dst_name), never the shared
+        # merged node, so a differently-scoped name can't leak. Node ids still come from the nodes (for
+        # next-hop iteration).
         if anchored:
             ret = (
                 "RETURN r.src_name AS a_name, startNode(r).id AS a_id, "
@@ -571,8 +565,7 @@ class GraphRetriever(ConnectionNode):
             if source is None or target is None or not rel:
                 continue
             rprops = dict(row.get("rprops") or {})
-            # src_name/dst_name are the edge's endpoint-name snapshot, already surfaced as source/target
-            # below -- drop them from the raw props so they are not duplicated in the document metadata.
+            # already surfaced as source/target below -> drop from raw props to avoid metadata duplication.
             rprops.pop("src_name", None)
             rprops.pop("dst_name", None)
             # Attribute edges reify a "key -> value" pair; HAS_ATTRIBUTE is just the bookkeeping type, so

--- a/dynamiq/nodes/retrievers/graph.py
+++ b/dynamiq/nodes/retrievers/graph.py
@@ -53,6 +53,13 @@ _QUERY_ENTITY_RESPONSE_FORMAT: dict[str, Any] = {
     },
 }
 
+# Prompt for the optional `summarize` step: compose the retrieved context into a written answer.
+_SUMMARIZE_PROMPT = (
+    "Answer the QUESTION using ONLY the CONTEXT below (facts and/or passages retrieved from a knowledge "
+    "graph). If the context is insufficient, say what is missing. Be concise.\n\n"
+    "CONTEXT:\n{{context}}\n\nQUESTION:\n{{query}}"
+)
+
 # Supported edge-filter operators -> Cypher predicate builders. `c` is the qualified property
 # (e.g. ``r.source_url``); `p` is the bound-parameter name.
 _FILTER_OPERATORS: dict[str, Any] = {
@@ -224,6 +231,10 @@ class GraphRetriever(ConnectionNode):
     filters: dict[str, Any] | None = None  # LOCKED: always applied; not overridable from the input schema
     top_k: int = 50
     document_reranker: Node | None = None  # optional rerank of rendered facts; top_k here = candidate pool
+    # optional grounding source: any object with get_documents_by_ids(ids) -> list[Document]
+    document_retriever: Any = None
+    # when True, LLM-compose an answer from the retrieved context; when False (default) return raw facts/source
+    summarize: bool = False
 
     input_schema: ClassVar[type[GraphRetrieverInputSchema]] = GraphRetrieverInputSchema
 
@@ -236,13 +247,15 @@ class GraphRetriever(ConnectionNode):
 
     @property
     def to_dict_exclude_params(self) -> dict:
-        return super().to_dict_exclude_params | {"llm": True, "document_reranker": True}
+        return super().to_dict_exclude_params | {"llm": True, "document_reranker": True, "document_retriever": True}
 
     def to_dict(self, **kwargs) -> dict:
         data = super().to_dict(**kwargs)
         data["llm"] = self.llm.to_dict(**kwargs)
         if self.document_reranker:
             data["document_reranker"] = self.document_reranker.to_dict(**kwargs)
+        if self.document_retriever is not None and hasattr(self.document_retriever, "to_dict"):
+            data["document_retriever"] = self.document_retriever.to_dict(**kwargs)
         return data
 
     def init_components(self, connection_manager: ConnectionManager | None = None) -> None:
@@ -253,6 +266,10 @@ class GraphRetriever(ConnectionNode):
             self.llm.init_components(connection_manager)
         if self.document_reranker and self.document_reranker.is_postponed_component_init:
             self.document_reranker.init_components(connection_manager)
+        if self.document_retriever is not None and getattr(
+            self.document_retriever, "is_postponed_component_init", False
+        ):
+            self.document_retriever.init_components(connection_manager)
         if self._graph_store is None:
             self._graph_store = self._build_graph_store()
         self._use_fulltext = self._probe_fulltext()
@@ -453,7 +470,19 @@ class GraphRetriever(ConnectionNode):
             logger.info(f"Tool {self.name} - {self.id}: retrieved {len(documents)} fact(s).")
             documents = self._maybe_rerank(documents, input_data.query, config, **kwargs)
             content = "\n".join(f"- {d.content}" for d in documents) or "No matching facts found."
-            return {"content": content, "documents": documents}
+            output = {"content": content, "documents": documents}
+            source_documents = self._fetch_source_documents(documents)
+            if source_documents:
+                # Replace triples with verbatim source text. ACL-safe with no extra check: each source_doc_id
+                # came from an ACL-visible edge whose ACL equals its source document's. `facts` keeps the triples.
+                output["source_documents"] = source_documents
+                output["facts"] = content
+                output["content"] = "\n\n".join(d.content for d in source_documents if d.content) or content
+            if self.summarize and documents:
+                # keep the raw retrieval under `context`; `content` becomes the composed answer
+                output["context"] = output["content"]
+                output["content"] = self._summarize(input_data.query, output["context"], config, **kwargs)
+            return output
         except Exception as e:
             logger.error(f"Tool {self.name} - {self.id}: execution error: {e}", exc_info=True)
             raise ToolExecutionException(
@@ -485,6 +514,50 @@ class GraphRetriever(ConnectionNode):
         reranked = result.output.get("documents", documents)
         logger.info(f"Tool {self.name} - {self.id}: reranked {before} -> {len(reranked)} fact(s).")
         return reranked
+
+    def _fetch_source_documents(self, documents: list[Document]) -> list[Document]:
+        """Fetch the verbatim source documents behind the retrieved facts (optional grounding).
+
+        Each fact came from an ACL-visible edge whose ACL equals its source document's, so the caller is
+        already entitled to those documents; the distinct ``source_doc_id`` values are pulled via the
+        ``document_retriever``'s ``get_documents_by_ids`` with no extra ACL check. Returns ``[]`` when no
+        retriever is set, no fact carries a ``source_doc_id``, or the fetch fails.
+        """
+        if not self.document_retriever or not hasattr(self.document_retriever, "get_documents_by_ids"):
+            return []
+        ids = list(dict.fromkeys(d.metadata.get("source_doc_id") for d in documents if d.metadata.get("source_doc_id")))
+        if not ids:
+            return []
+        try:
+            return self.document_retriever.get_documents_by_ids(ids)
+        except Exception as e:
+            logger.warning(f"Tool {self.name} - {self.id}: source-document fetch failed: {e}")
+            return []
+
+    def _summarize(self, query: str, context: str, config: RunnableConfig, **kwargs) -> str:
+        """LLM-compose an answer from the retrieved context, reusing this node's ``llm``.
+
+        Degrades to the raw context on any failure, so this optional step never fails the read.
+        """
+        try:
+            prompt = Prompt(messages=[Message(role="user", content=_SUMMARIZE_PROMPT)])
+            run_kwargs = kwargs | {"parent_run_id": kwargs.get("run_id")}
+            run_kwargs.pop("run_depends", None)
+            result = self.llm.run(
+                input_data={"query": query, "context": context},
+                prompt=prompt,
+                config=config,
+                run_depends=self._run_depends,
+                **run_kwargs,
+            )
+            self._run_depends = [NodeDependency(node=self.llm).to_dict(for_tracing=True)]
+            if result.status != RunnableStatus.SUCCESS:
+                logger.warning(f"Tool {self.name} - {self.id}: summarization failed; returning raw context.")
+                return context
+            return result.output.get("content") or context
+        except Exception as e:
+            logger.warning(f"Tool {self.name} - {self.id}: summarization error: {e}; returning raw context.")
+            return context
 
     @staticmethod
     def _render_single_hop(rows: list[dict[str, Any]]) -> list[Document]:

--- a/dynamiq/storages/graph/neo4j/neo4j.py
+++ b/dynamiq/storages/graph/neo4j/neo4j.py
@@ -8,9 +8,8 @@ from dynamiq.connections import Neo4j as Neo4jConnection
 from dynamiq.storages.graph.base import BaseGraphStore
 from dynamiq.utils.logger import logger
 
-# Labels / relationship types / property keys must match this pattern — the safe identifier subset.
-# These are spliced into Cypher text (structure cannot be parameterized), so they are validated, never
-# escaped. Anything else is rejected.
+# Labels / relationship types / property keys are spliced into Cypher text (structure can't be
+# parameterized), so they must match this safe-identifier pattern; anything else is rejected.
 LABEL_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 PROPERTY_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 

--- a/tests/integration_with_creds/nodes/retrievers/test_graph_retriever_name_leak_e2e.py
+++ b/tests/integration_with_creds/nodes/retrievers/test_graph_retriever_name_leak_e2e.py
@@ -22,7 +22,9 @@ import pytest
 
 from dynamiq.connections import Neo4j as Neo4jConnection
 from dynamiq.connections import OpenAI as OpenAIConnection
-from dynamiq.nodes.extractors import Ontology
+from dynamiq.nodes.embedders import OpenAIDocumentEmbedder, OpenAITextEmbedder
+from dynamiq.nodes.extractors import KnowledgeGraphWriter, Ontology
+from dynamiq.nodes.extractors.entity_extractor import ENTITY_EMBEDDING_VECTOR_INDEX
 from dynamiq.nodes.llms.openai import OpenAI
 from dynamiq.nodes.retrievers import GraphRetriever
 from dynamiq.nodes.retrievers.graph import GraphRetrieverInputSchema
@@ -117,3 +119,96 @@ def test_secret_caller_sees_its_own_edge(shared_node_graph, graph_connection):
 def test_unknown_principal_sees_nothing(shared_node_graph, graph_connection):
     content = _facts_for(graph_connection, ["group:nobody"])
     assert SYS_PUBLIC not in content and SYS_SECRET not in content, f"unknown principal must see nothing: {content}"
+
+
+# --- Semantic (embedding) seeding -------------------------------------------------------------------
+# When the writer is given an `entity_embedder`, each entity's NAME is embedded and a Neo4j vector index
+# is created; a retriever with a matching `text_embedder` then seeds entry entities by embedding
+# similarity. This proves a PARAPHRASED seed ("automaker") reaches an entity named "Car Manufacturer" —
+# a match the full-text/CONTAINS name path cannot make.
+
+VEC_ORG_NAME = "Car Manufacturer"
+VEC_SYS_NAME = "Assembly Robotics"
+VEC_DOC = "docV"
+
+
+@pytest.fixture(scope="module")
+def embedded_graph(graph_connection):
+    """Wipe, then ingest ONE org->system fact through the writer WITH an entity embedder (real OpenAI).
+
+    Exercises the real write path: ``_embed_nodes`` (name embedding) + ``_ensure_entity_vector_index``.
+    """
+    store = Neo4jGraphStore(connection=graph_connection, client=graph_connection.connect())
+    store.run_cypher("MATCH (n) DETACH DELETE n")  # clean slate
+
+    nodes = [
+        {
+            "labels": ["Organization", "Entity"],
+            "identity_key": "id",
+            "properties": {"id": "vec-org", "name": VEC_ORG_NAME},
+        },
+        {"labels": ["System", "Entity"], "identity_key": "id", "properties": {"id": "vec-sys", "name": VEC_SYS_NAME}},
+    ]
+    relationships = [
+        {
+            "type": "USES",
+            "start_label": "Organization",
+            "end_label": "System",
+            "start_identity": "vec-org",
+            "end_identity": "vec-sys",
+            "start_identity_key": "id",
+            "end_identity_key": "id",
+            "identity_keys": ["source_doc_id"],
+            "properties": {
+                "src_name": VEC_ORG_NAME,
+                "dst_name": VEC_SYS_NAME,
+                "allowed_principals": [GROUP_PUBLIC],
+                "source_doc_id": VEC_DOC,
+            },
+        }
+    ]
+
+    writer = KnowledgeGraphWriter(
+        connection=graph_connection,
+        entity_embedder=OpenAIDocumentEmbedder(connection=OpenAIConnection()),
+    )
+    writer.init_components()
+    try:
+        writer.execute(KnowledgeGraphWriter.input_schema(nodes=nodes, relationships=relationships))
+    finally:
+        writer._graph_store.close()
+    yield
+    store.close()
+
+
+def test_vector_index_created_and_entities_embedded(embedded_graph, graph_connection):
+    store = Neo4jGraphStore(connection=graph_connection, client=graph_connection.connect())
+    try:
+        rows, _, _ = store.run_cypher(
+            "SHOW INDEXES YIELD name, type WHERE name = $n AND type = 'VECTOR' RETURN count(*) AS c",
+            parameters={"n": ENTITY_EMBEDDING_VECTOR_INDEX},
+        )
+        assert store.format_records(rows)[0]["c"] == 1, "entity vector index should have been created"
+        embedded, _, _ = store.run_cypher("MATCH (n:Entity) WHERE n.embedding IS NOT NULL RETURN count(n) AS c")
+        assert store.format_records(embedded)[0]["c"] >= 2, "entity nodes should carry an embedding"
+    finally:
+        store.close()
+
+
+def test_paraphrased_query_seeds_via_vector_similarity(embedded_graph, graph_connection):
+    # "automaker" never appears as a stored name; only a semantic (vector) seed can reach "Car Manufacturer".
+    retriever = GraphRetriever(
+        connection=graph_connection,
+        llm=OpenAI(connection=OpenAIConnection(), model="gpt-4o-mini", temperature=0),
+        text_embedder=OpenAITextEmbedder(connection=OpenAIConnection()),
+        ontology=ONTOLOGY,
+        filters={"allowed_principals": {"$intersects": [GROUP_PUBLIC]}},
+    )
+    retriever.init_components()
+    assert retriever._use_vector, "vector seeding should be active (embedder set + vector index present)"
+    try:
+        # `entities` skips LLM extraction so the seed term is fixed; it is embedded and vector-matched.
+        out = retriever.execute(GraphRetrieverInputSchema(query="What does the automaker use?", entities=["automaker"]))
+        assert VEC_SYS_NAME in out["content"], f"paraphrased vector seed should reach the fact: {out['content']}"
+    finally:
+        retriever._graph_store.close()

--- a/tests/integration_with_creds/nodes/retrievers/test_graph_retriever_name_leak_e2e.py
+++ b/tests/integration_with_creds/nodes/retrievers/test_graph_retriever_name_leak_e2e.py
@@ -1,0 +1,118 @@
+"""E2E regression for the shared-node NAME leak (case B2) against a real Neo4j.
+
+Entity nodes are shared/merged and carry a single, first-writer-wins ``name``; all ACL lives on edges.
+Before the fix, the retriever rendered endpoint names by dereferencing that shared node, so a caller
+entitled only to a *public* edge could see a name written by a *differently-scoped* document (e.g. a
+secret-encoded variant). The fix snapshots each edge's endpoint names onto the edge itself
+(``src_name``/``dst_name``), which inherit the edge's ACL, and the retriever renders from those.
+
+This test builds the situation deterministically at the store level: ONE shared organisation node whose
+stored name is the SECRET variant (first/only writer), referenced by two USES edges with DIFFERENT
+per-document name snapshots and DIFFERENT ``allowed_principals``. It then asserts a ``group:public``
+caller renders the edge's own ``Acme`` snapshot and NEVER the shared node's ``Acme Secret Division`` name
+nor the secret system. Seeding is by ``entity_ids`` (anchored) so the assertion is LLM-free and stable.
+
+Requires NEO4J_URI / NEO4J_USERNAME / NEO4J_PASSWORD and OPENAI_API_KEY. Skipped otherwise. Wipes the
+graph first — run serially against a dedicated test instance, not a shared one.
+"""
+
+import os
+
+import pytest
+
+from dynamiq.connections import Neo4j as Neo4jConnection
+from dynamiq.connections import OpenAI as OpenAIConnection
+from dynamiq.nodes.extractors import Ontology
+from dynamiq.nodes.llms.openai import OpenAI
+from dynamiq.nodes.retrievers import GraphRetriever
+from dynamiq.nodes.retrievers.graph import GraphRetrieverInputSchema
+from dynamiq.storages.graph.neo4j import Neo4jGraphStore
+
+ORG_ID = "org-1"
+NODE_NAME = "Acme Secret Division"  # the shared node's stored (secret-encoded) name — MUST NOT leak
+PUBLIC_NAME = "Acme"  # the public edge's own name snapshot — what a public caller should see
+SYS_PUBLIC = "Helios"  # group:public may see this
+SYS_SECRET = "Borealis"  # group:secret only
+GROUP_PUBLIC = "group:public"
+GROUP_SECRET = "group:secret"
+
+ONTOLOGY = Ontology(entity_types=["Organization", "System"], relationship_types=["USES"])
+
+
+@pytest.fixture(scope="module")
+def graph_connection():
+    if not (os.getenv("OPENAI_API_KEY") and os.getenv("NEO4J_URI")):
+        pytest.skip("OPENAI_API_KEY and NEO4J_URI required; skipping credentials-required test.")
+    return Neo4jConnection()
+
+
+@pytest.fixture(scope="module")
+def shared_node_graph(graph_connection):
+    """Wipe, then write ONE shared org node + two USES edges with distinct name snapshots and ACLs."""
+    store = Neo4jGraphStore(connection=graph_connection, client=graph_connection.connect())
+    store.run_cypher("MATCH (n) DETACH DELETE n")  # clean slate
+
+    nodes = [
+        {"labels": ["Organization", "Entity"], "identity_key": "id",
+         "properties": {"id": ORG_ID, "name": NODE_NAME}},
+        {"labels": ["System", "Entity"], "identity_key": "id",
+         "properties": {"id": "sys-pub", "name": SYS_PUBLIC}},
+        {"labels": ["System", "Entity"], "identity_key": "id",
+         "properties": {"id": "sys-sec", "name": SYS_SECRET}},
+    ]
+    # Both edges start at the SAME shared org node; each carries its own per-document name snapshot + ACL.
+    def _edge(dst, src_name, dst_name, principal, doc_id):
+        return {
+            "type": "USES", "start_label": "Organization", "end_label": "System",
+            "start_identity": ORG_ID, "end_identity": dst,
+            "start_identity_key": "id", "end_identity_key": "id",
+            "identity_keys": ["source_doc_id"],
+            "properties": {
+                "src_name": src_name, "dst_name": dst_name,
+                "allowed_principals": [principal], "source_doc_id": doc_id,
+            },
+        }
+
+    relationships = [
+        _edge("sys-pub", PUBLIC_NAME, SYS_PUBLIC, GROUP_PUBLIC, "docP"),
+        _edge("sys-sec", NODE_NAME, SYS_SECRET, GROUP_SECRET, "docS"),
+    ]
+    store.write_graph(nodes=nodes, relationships=relationships)
+    yield
+    store.close()
+
+
+def _facts_for(graph_connection, principals):
+    retriever = GraphRetriever(
+        connection=graph_connection,
+        llm=OpenAI(connection=OpenAIConnection(), model="gpt-4o-mini", temperature=0),
+        ontology=ONTOLOGY,
+        filters={"allowed_principals": {"$intersects": principals}},
+    )
+    retriever.init_components()
+    try:
+        # Anchor by id (skips LLM entity extraction) so the assertion is deterministic.
+        out = retriever.execute(GraphRetrieverInputSchema(query="What does the org use?", entity_ids=[ORG_ID]))
+        return out["content"]
+    finally:
+        retriever._graph_store.close()
+
+
+def test_public_caller_sees_edge_snapshot_not_shared_node_name(shared_node_graph, graph_connection):
+    content = _facts_for(graph_connection, [GROUP_PUBLIC])
+    assert SYS_PUBLIC in content, f"public caller should see its own system {SYS_PUBLIC}: {content}"
+    assert PUBLIC_NAME in content, f"public caller should render its edge's own name snapshot: {content}"
+    # The shared node's stored (secret-encoded) name must never reach a public-only caller.
+    assert NODE_NAME not in content, f"LEAK: shared-node name {NODE_NAME!r} surfaced to public caller: {content}"
+    assert SYS_SECRET not in content, f"LEAK: public caller must not see secret system {SYS_SECRET}: {content}"
+
+
+def test_secret_caller_sees_its_own_edge(shared_node_graph, graph_connection):
+    content = _facts_for(graph_connection, [GROUP_SECRET])
+    assert SYS_SECRET in content
+    assert SYS_PUBLIC not in content, f"LEAK: secret caller must not see public system {SYS_PUBLIC}: {content}"
+
+
+def test_unknown_principal_sees_nothing(shared_node_graph, graph_connection):
+    content = _facts_for(graph_connection, ["group:nobody"])
+    assert SYS_PUBLIC not in content and SYS_SECRET not in content, f"unknown principal must see nothing: {content}"

--- a/tests/integration_with_creds/nodes/retrievers/test_graph_retriever_name_leak_e2e.py
+++ b/tests/integration_with_creds/nodes/retrievers/test_graph_retriever_name_leak_e2e.py
@@ -61,6 +61,7 @@ def shared_node_graph(graph_connection):
          "properties": {"id": "sys-sec", "name": SYS_SECRET}},
     ]
     # Both edges start at the SAME shared org node; each carries its own per-document name snapshot + ACL.
+
     def _edge(dst, src_name, dst_name, principal, doc_id):
         return {
             "type": "USES", "start_label": "Organization", "end_label": "System",

--- a/tests/unit/nodes/extractors/test_entity_extractor.py
+++ b/tests/unit/nodes/extractors/test_entity_extractor.py
@@ -131,6 +131,8 @@ class TestToWriteGraphPayload:
             },
             {"labels": ["PERSON", "Entity"], "identity_key": "id", "properties": {"id": "jane", "name": "Jane Doe"}},
         ]
+        # Endpoint names are snapshotted onto the edge (src_name/dst_name) so retrieval renders from the
+        # ACL-bearing edge, never the shared/merged entity node.
         assert graph_rels == [
             {
                 "type": "WORKS_AT",
@@ -140,7 +142,7 @@ class TestToWriteGraphPayload:
                 "end_identity_key": "id",
                 "start_identity": "jane",
                 "end_identity": "acme",
-                "properties": {"since": 2020},
+                "properties": {"since": 2020, "src_name": "Jane Doe", "dst_name": "Acme Capital"},
             }
         ]
         _assert_valid_for_neo4j(nodes, graph_rels)
@@ -275,6 +277,10 @@ class TestExecuteEndToEndWithStubLLM:
         assert attr_edge["start_identity"] == "jane@doc-1"
         assert attr_edge["end_identity"] == "jane@doc-1::salary::doc-1"
         assert attr_edge["properties"]["key"] == "salary"
+        # Endpoint-name snapshot rides on the ACL-bearing edge: owner name + the value itself, so retrieval
+        # renders "Jane Doe -[salary]-> $250,000" without dereferencing the shared node or the value node.
+        assert attr_edge["properties"]["src_name"] == "Jane Doe"
+        assert attr_edge["properties"]["dst_name"] == "$250,000"
 
     def test_execute_stamps_doc_discriminator_on_relationships(self):
         # Each relationship carries a scalar source_doc_id + identity_keys so the store keeps the SAME

--- a/tests/unit/nodes/extractors/test_knowledge_graph_writer.py
+++ b/tests/unit/nodes/extractors/test_knowledge_graph_writer.py
@@ -16,12 +16,19 @@ from pydantic import BaseModel, Field
 from dynamiq import Workflow
 from dynamiq.connections import Neo4j
 from dynamiq.flows import Flow
+from dynamiq.nodes.embedders.base import DocumentEmbedder
 from dynamiq.nodes.extractors import KnowledgeGraphWriter
-from dynamiq.nodes.extractors.entity_extractor import ATTRIBUTE_VALUE_LABEL, HAS_ATTRIBUTE_TYPE, KG_ENTITY_IDS_KEY
+from dynamiq.nodes.extractors.entity_extractor import (
+    ATTRIBUTE_VALUE_LABEL,
+    ENTITY_EMBEDDING_VECTOR_INDEX,
+    HAS_ATTRIBUTE_TYPE,
+    KG_ENTITY_IDS_KEY,
+)
 from dynamiq.nodes.extractors.knowledge_graph import _entity_ids_by_doc
 from dynamiq.nodes.node import InputTransformer, Node, NodeDependency
 from dynamiq.nodes.types import NodeGroup
 from dynamiq.runnables import RunnableStatus
+from dynamiq.storages.graph.neo4j import Neo4jGraphStore
 from dynamiq.types import Document
 
 
@@ -44,20 +51,62 @@ class FakeGraphStore:
             "keys": [],
         }
 
-    def run_cypher(self, *args, **kwargs):  # _existing_nodes path (none pre-seeded -> empty)
+    def run_cypher(self, *args, **kwargs):
         return ([], None, [])
 
     def format_records(self, records):
         return []
 
 
-def make_writer(existing: dict[str, list[tuple[str, str]]]) -> KnowledgeGraphWriter:
-    """Writer with a pre-populated per-call candidate cache, so no store is ever queried."""
+class _ResolveStore:
+    """Neo4j-typed stub for resolution: answers the two read queries resolution now issues.
+
+    - The existence check (``_existing_ids``, contains no ``queryNodes``) → returns the requested ids that
+      are in ``saved`` (the deterministic ids already "in the graph").
+    - The fuzzy blocking query (``_blocking_candidates``, contains ``queryNodes``) → returns the configured
+      near-dup ``(id, name)`` candidates for the queried label.
+    """
+
+    def __init__(self, existing_by_label=None, saved_ids=None):
+        self.existing = existing_by_label or {}
+        self.saved = set(saved_ids or [])
+        self.database = None
+        self.queries: list[str] = []
+
+    def run_cypher(self, query, parameters=None, database=None, **kwargs):
+        self.queries.append(query)
+        params = parameters or {}
+        if "queryNodes" in query:  # fuzzy blocking candidates for a label
+            rows = [{"id": i, "name": n} for i, n in self.existing.get(params.get("label"), [])]
+            return rows, None, []
+        # existence check: which of the requested ids already exist
+        return [{"id": i} for i in params.get("ids", []) if i in self.saved], None, []
+
+    @staticmethod
+    def format_records(records):
+        return list(records)
+
+
+def _neo4j_typed_store(existing_by_label=None, saved_ids=None) -> Neo4jGraphStore:
+    """A ``_ResolveStore`` masquerading as a ``Neo4jGraphStore`` so resolution's ``isinstance`` gate passes."""
+    store = Neo4jGraphStore.__new__(Neo4jGraphStore)
+    stub = _ResolveStore(existing_by_label, saved_ids)
+    store.database = None
+    store.run_cypher = stub.run_cypher
+    store.format_records = stub.format_records
+    store._stub = stub  # expose for query assertions
+    return store
+
+
+def make_writer(existing: dict[str, list[tuple[str, str]]] | None = None, fuzzy: bool = True, saved_ids=None):
+    """Writer over a Neo4j-typed stub store. ``existing`` are near-dup candidates the blocking query returns;
+    ``saved_ids`` are deterministic ids treated as already in the graph (to exercise the idempotent gate)."""
     writer = KnowledgeGraphWriter(
         connection=Neo4j(uri="bolt://localhost:7687", username="neo4j", password="password"),
         is_postponed_component_init=True,
+        fuzzy_matching=fuzzy,
     )
-    writer._existing_cache = existing
+    writer._graph_store = _neo4j_typed_store(existing, saved_ids)
     return writer
 
 
@@ -452,3 +501,177 @@ class TestAttachEntityIds:
         docs = [Document(id="c1", content="nothing linked")]
         out = KnowledgeGraphWriter._attach_entity_ids(docs, [])
         assert out[0].metadata[KG_ENTITY_IDS_KEY] == []
+
+
+class StubDocumentEmbedder(DocumentEmbedder):
+    """Embeds each document to a fixed-dim vector derived from its content length (no real model)."""
+
+    name: str = "stub-doc-embedder"
+    dim: int = 3
+    fail: bool = False
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("client", object())  # satisfy ConnectionNode's connection/client requirement
+        super().__init__(**kwargs)
+
+    def execute(self, input_data, config=None, **kwargs):
+        if self.fail:
+            raise RuntimeError("embed boom")
+        for doc in input_data.documents:
+            doc.embedding = [float(len(doc.content))] * self.dim
+        return {"documents": input_data.documents, "meta": {}}
+
+
+def _neo4j_conn() -> Neo4j:
+    return Neo4j(uri="bolt://localhost:7687", username="neo4j", password="password")
+
+
+def _recording_neo4j_store() -> tuple[Neo4jGraphStore, list[str]]:
+    """A Neo4jGraphStore (bypassing __init__/DB) that records every Cypher statement it is asked to run."""
+    store = Neo4jGraphStore.__new__(Neo4jGraphStore)
+    store.database = None
+    recorded: list[str] = []
+
+    def run_cypher(query, parameters=None, database=None, **kwargs):
+        recorded.append(query)
+        return [], None, []
+
+    store.run_cypher = run_cypher
+    return store, recorded
+
+
+def _entity(label: str, node_id: str, name: str) -> dict:
+    return {"labels": [label, "Entity"], "identity_key": "id", "properties": {"id": node_id, "name": name}}
+
+
+def _embedder_writer(**embedder_kwargs) -> KnowledgeGraphWriter:
+    return KnowledgeGraphWriter(
+        connection=_neo4j_conn(),
+        is_postponed_component_init=True,
+        entity_embedder=StubDocumentEmbedder(is_postponed_component_init=True, **embedder_kwargs),
+    )
+
+
+class TestEmbedEntityNames:
+    def test_embeds_names_and_attaches_to_entities_not_attribute_values(self):
+        writer = _embedder_writer(dim=3)
+        writer._graph_store, _ = _recording_neo4j_store()
+        nodes = [
+            _entity("PERSON", "u1", "Jane Doe"),  # len("Jane Doe") == 8
+            {"labels": [ATTRIBUTE_VALUE_LABEL], "identity_key": "id", "properties": {"id": "v1", "value": "CTO"}},
+        ]
+
+        vectors = writer._embed_entity_names(nodes, config=None)
+        assert vectors == {"Jane Doe": [8.0, 8.0, 8.0]}  # only the named entity, one embed call
+
+        out = writer._attach_embeddings(nodes, vectors)
+        assert out[0]["properties"]["embedding"] == [8.0, 8.0, 8.0]
+        assert "embedding" not in out[1]["properties"]  # AttributeValue holders are not seeded on
+
+    def test_empty_without_embedder(self):
+        writer = make_writer()
+        assert writer._embed_entity_names([_entity("PERSON", "u1", "Jane")], config=None) == {}
+
+    def test_empty_on_non_neo4j_store(self):
+        # Node embeddings are a Neo4j-only feature; on any other backend embedding is skipped so a raw
+        # vector never lands as unqueryable dead weight (e.g. Postgres JSONB).
+        writer = _embedder_writer()
+        writer._graph_store = FakeGraphStore()  # not a Neo4jGraphStore
+        assert writer._embed_entity_names([_entity("PERSON", "u1", "Jane")], config=None) == {}
+
+    def test_degrades_without_raising_on_embedder_failure(self):
+        writer = _embedder_writer(fail=True)
+        writer._graph_store, _ = _recording_neo4j_store()
+        assert writer._embed_entity_names([_entity("PERSON", "u1", "Jane")], config=None) == {}  # no raise
+
+    def test_attach_embeddings_noop_without_vectors(self):
+        writer = make_writer()
+        nodes = [_entity("PERSON", "u1", "Jane")]
+        assert "embedding" not in writer._attach_embeddings(nodes, {})[0]["properties"]
+
+    def test_ensure_vector_index_uses_embedding_dimension(self):
+        writer = KnowledgeGraphWriter(connection=_neo4j_conn(), is_postponed_component_init=True)
+        store, recorded = _recording_neo4j_store()
+        writer._graph_store = store
+
+        writer._ensure_entity_vector_index(4)
+
+        created = [q for q in recorded if "CREATE VECTOR INDEX" in q]
+        assert created, "expected a CREATE VECTOR INDEX statement"
+        assert ENTITY_EMBEDDING_VECTOR_INDEX in created[0]
+        assert "`vector.dimensions`: 4" in created[0]
+        assert "'cosine'" in created[0]
+        assert ENTITY_EMBEDDING_VECTOR_INDEX in writer._vector_indexes_ready
+
+
+class TestResolutionInternals:
+    def test_deterministic_id_is_stable_and_label_scoped(self):
+        w = make_writer()
+        base = w._deterministic_id("ORGANIZATION", "Acme Capital")
+        assert base == w._deterministic_id("ORGANIZATION", "acme   capital")  # case/whitespace-insensitive
+        assert base != w._deterministic_id("PRODUCT", "Acme Capital")  # label-scoped
+        assert is_uuid(base)
+
+    def test_deterministic_id_is_the_base_even_with_fuzzy_off(self):
+        # Deterministic id is ALWAYS assigned; fuzzy_matching only toggles the optional near-dup tier.
+        w = make_writer(fuzzy=False)
+        nodes = [entity("PERSON", "p@d1", "Jane Doe"), entity("PERSON", "p@d2", "Jane Doe")]
+        resolved, _ = w._resolve_against_graph(nodes, [])
+        assert resolved[0]["properties"]["id"] == w._deterministic_id("PERSON", "Jane Doe")
+        assert len({n["properties"]["id"] for n in resolved}) == 1  # identical names collapse
+        assert w._graph_store._stub.queries == []  # pure hash: no existence lookup, no fuzzy
+
+    def test_existing_det_id_skips_fuzzy_and_is_not_re_merged(self):
+        # Over-merge guard: an entity whose OWN deterministic node already exists is kept — a similar but
+        # different candidate ("Acme Capital LLC") must not hijack an established node ("Acme LLC").
+        w = make_writer()
+        det = w._deterministic_id("ORGANIZATION", "Acme LLC")
+        w._graph_store._stub.saved = {det}
+        w._graph_store._stub.existing = {"ORGANIZATION": [("other-uuid", "Acme Capital LLC")]}
+
+        resolved, _ = w._resolve_against_graph([entity("ORGANIZATION", "acme@d1", "Acme LLC")], [])
+
+        assert resolved[0]["properties"]["id"] == det  # kept, not merged into the near-dup
+        assert not any("queryNodes" in q for q in w._graph_store._stub.queries)  # fuzzy never ran
+
+    def test_fuzzy_off_issues_no_query_even_with_candidates(self):
+        w = make_writer(fuzzy=False, existing={"ORGANIZATION": [("x", "Acme Capital")]})
+        w._resolve_against_graph([entity("ORGANIZATION", "a@d1", "Acme Capital LLC")], [])
+        assert w._graph_store._stub.queries == []  # no existence check, no blocking
+
+
+class TestEmbedEdges:
+    def test_attaches_triplet_embedding_to_edge_properties(self):
+        writer = _embedder_writer(dim=3)
+        writer._graph_store, _ = _recording_neo4j_store()
+        rels = [edge("USES", "ORG", "SYS", "a", "b", {"src_name": "Acme", "dst_name": "Helios"})]
+
+        writer._maybe_embed_edges(rels, config=None)
+
+        # StubDocumentEmbedder embeds "{content}" -> [len(content)]*dim; "Acme USES Helios" has len 16.
+        assert rels[0]["properties"]["embedding"] == [16.0, 16.0, 16.0]
+
+    def test_noop_without_embedder(self):
+        writer = make_writer()  # no entity_embedder
+        rels = [edge("USES", "ORG", "SYS", "a", "b", {"src_name": "Acme", "dst_name": "Helios"})]
+        writer._maybe_embed_edges(rels, config=None)
+        assert "embedding" not in rels[0]["properties"]
+
+    def test_edge_triplet_text_uses_attribute_key_for_has_attribute(self):
+        rel = edge(
+            HAS_ATTRIBUTE_TYPE,
+            "PERSON",
+            ATTRIBUTE_VALUE_LABEL,
+            "p",
+            "v",
+            {"src_name": "Jane", "dst_name": "CTO", "key": "title"},
+        )
+        assert KnowledgeGraphWriter._edge_triplet_text(rel) == "Jane title CTO"
+
+    def test_edge_triplet_text_includes_description(self):
+        props = {"src_name": "Acme", "dst_name": "Helios", "description": "since 2020"}
+        rel = edge("USES", "ORG", "SYS", "a", "b", props)
+        assert KnowledgeGraphWriter._edge_triplet_text(rel) == "Acme USES Helios: since 2020"
+
+    def test_edge_triplet_text_none_without_endpoint_names(self):
+        assert KnowledgeGraphWriter._edge_triplet_text(edge("USES", "ORG", "SYS", "a", "b", {})) is None

--- a/tests/unit/nodes/retrievers/test_graph_retriever.py
+++ b/tests/unit/nodes/retrievers/test_graph_retriever.py
@@ -208,14 +208,20 @@ class TestEntryModes:
         assert "MATCH (a)-[r]-(b)" in query
         assert "startNode(r)" in query and "endNode(r)" in query
         assert "coalesce(r.allowed_principals, [])" in query  # ACL still enforced on the edge
+        # names render from the edge's own ACL-bearing snapshot, never the shared merged node
+        assert "r.src_name AS a_name" in query and "r.dst_name AS b_name" in query
+        assert "startNode(r).name" not in query and "endNode(r).name" not in query
 
     def test_scan_fallback_when_index_absent(self):
         node = make_retriever(filters=LOCKED_ACL)
         node._use_fulltext = False
         query, _ = node._build_query(GraphRetrieverInputSchema(query="What does Jane use?"), 10)
         assert "queryNodes" not in query
-        assert "toLower($q) CONTAINS toLower(a.name)" in query  # portable scan
+        assert "toLower($q) CONTAINS toLower(a.name)" in query  # portable scan (seed match still by node name)
         assert "MATCH (a)-[r]->(b)" in query  # directed
+        # but rendered names come from the edge snapshot, not the shared node
+        assert "r.src_name AS a_name" in query and "r.dst_name AS b_name" in query
+        assert "coalesce(a.name" not in query and "coalesce(b.name" not in query
 
     def test_explicit_entities_use_fulltext_fuzzily_like_extracted(self):
         # With the index present, explicit entities go through the SAME fuzzy full-text seek as extracted

--- a/tests/unit/nodes/retrievers/test_graph_retriever.py
+++ b/tests/unit/nodes/retrievers/test_graph_retriever.py
@@ -10,10 +10,13 @@ from typing import Any, ClassVar
 import pytest
 
 from dynamiq.connections import Neo4j
+from dynamiq.nodes.embedders.base import TextEmbedder
 from dynamiq.nodes.extractors import Ontology
+from dynamiq.nodes.extractors.entity_extractor import ENTITY_EMBEDDING_VECTOR_INDEX
 from dynamiq.nodes.node import Node, NodeGroup
 from dynamiq.nodes.retrievers import GraphRetriever
 from dynamiq.nodes.retrievers.graph import GraphRetrieverInputSchema, _compile_edge_filters
+from dynamiq.storages.graph.neo4j import Neo4jGraphStore
 
 
 class StubLLM(Node):
@@ -57,6 +60,25 @@ class FailingStubReranker(StubReranker):
 
     def execute(self, input_data, config=None, **kwargs):
         raise RuntimeError("rerank boom")
+
+
+class StubTextEmbedder(TextEmbedder):
+    """Embeds a query to a fixed-dim vector from its length (no real model); counts calls."""
+
+    name: str = "stub-text-embedder"
+    fail: bool = False
+    calls: int = 0
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("client", object())  # satisfy ConnectionNode's connection/client requirement
+        super().__init__(**kwargs)
+
+    def execute(self, input_data, config=None, **kwargs):
+        if self.fail:
+            raise RuntimeError("embed boom")
+        query = input_data.query if hasattr(input_data, "query") else input_data["query"]
+        self.calls += 1
+        return {"embedding": [float(len(query)), 1.0, 2.0], "query": query}
 
 
 _ONTOLOGY = Ontology(entity_types=["Org", "Person"], relationship_types=["WORKS_AT"])
@@ -418,3 +440,138 @@ class TestReranking:
         node = make_retriever(rows=[], document_reranker=StubReranker())
         data = node.to_dict()
         assert data["document_reranker"]["name"] == "stub-reranker"
+
+
+class TestVectorSeeding:
+    def test_vector_branch_binds_seeds_from_index(self):
+        # seed_vectors present -> a per-vector index lookup binds the seed entity `a`; expansion is anchored.
+        node = make_retriever(filters=LOCKED_ACL)
+        query, params = node._build_query(
+            GraphRetrieverInputSchema(query="who drives an automobile?"),
+            10,
+            seed_names=["car"],
+            seed_vectors=[[0.1, 0.2, 0.3]],
+        )
+        assert "UNWIND $qvecs AS qv" in query
+        assert f"db.index.vector.queryNodes('{ENTITY_EMBEDDING_VECTOR_INDEX}', $vk, qv) YIELD node AS a" in query
+        assert params["qvecs"] == [[0.1, 0.2, 0.3]]
+        assert params["vk"] == node.vector_top_k
+        assert "CONTAINS" not in query  # not the scan fallback
+        # anchored (undirected) one-hop, ACL still enforced on the edge
+        assert "MATCH (a)-[r]-(b)" in query
+        assert "coalesce(r.allowed_principals, [])" in query
+
+    def test_entity_ids_take_precedence_over_vectors(self):
+        node = make_retriever()
+        query, params = node._build_query(
+            GraphRetrieverInputSchema(query="x", entity_ids=["uuid-acme"]),
+            5,
+            seed_vectors=[[0.1, 0.2, 0.3]],
+        )
+        assert "a.id IN $entity_ids" in query
+        assert "vector.queryNodes" not in query
+
+    def test_falls_back_to_scan_without_seed_vectors(self):
+        # No seed_vectors -> unchanged behavior (CONTAINS scan when no full-text index).
+        node = make_retriever()
+        query, _ = node._build_query(GraphRetrieverInputSchema(query="who works at Acme?"), 10)
+        assert "vector.queryNodes" not in query
+        assert "toLower($q) CONTAINS toLower(a.name)" in query
+
+    def test_seed_vectors_embeds_each_name_when_vector_active(self):
+        embedder = StubTextEmbedder(is_postponed_component_init=True)
+        node = make_retriever(text_embedder=embedder)
+        node._use_vector = True
+
+        vectors = node._seed_vectors(GraphRetrieverInputSchema(query="q"), ["car", "bike"], None, config=None)
+
+        assert vectors == [[3.0, 1.0, 2.0], [4.0, 1.0, 2.0]]  # len("car")=3, len("bike")=4
+        assert embedder.calls == 2  # one embed per seed name
+
+    def test_seed_vectors_reuses_query_vector_when_no_names(self):
+        # No seed names (extraction found none, or seed_by_query) -> the precomputed whole-query vector is
+        # reused as the single seed, with NO extra embed call.
+        embedder = StubTextEmbedder(is_postponed_component_init=True)
+        node = make_retriever(text_embedder=embedder)
+        node._use_vector = True
+
+        vectors = node._seed_vectors(GraphRetrieverInputSchema(query="q"), [], [7.0, 7.0, 7.0], config=None)
+
+        assert vectors == [[7.0, 7.0, 7.0]]
+        assert embedder.calls == 0  # reused, not re-embedded
+
+    def test_seed_vectors_none_when_vector_inactive(self):
+        embedder = StubTextEmbedder(is_postponed_component_init=True)
+        node = make_retriever(text_embedder=embedder)
+        node._use_vector = False  # no vector index -> fall back, embedder untouched
+
+        assert node._seed_vectors(GraphRetrieverInputSchema(query="q"), ["car"], None, config=None) is None
+        assert embedder.calls == 0
+
+    def test_seed_vectors_none_for_entity_id_anchored(self):
+        node = make_retriever(text_embedder=StubTextEmbedder(is_postponed_component_init=True))
+        node._use_vector = True
+        q = GraphRetrieverInputSchema(query="q", entity_ids=["uuid-x"])
+        assert node._seed_vectors(q, [], [1.0], config=None) is None
+
+    def test_seed_vectors_degrades_on_embedder_failure(self):
+        node = make_retriever(text_embedder=StubTextEmbedder(is_postponed_component_init=True, fail=True))
+        node._use_vector = True
+        assert node._seed_vectors(GraphRetrieverInputSchema(query="q"), ["car"], None, config=None) is None
+
+    def test_probe_vector_false_without_embedder(self):
+        node = make_retriever()  # no text_embedder
+        assert node._probe_vector() is False
+
+    def test_probe_vector_true_when_index_present(self):
+        node = make_retriever(text_embedder=StubTextEmbedder(is_postponed_component_init=True))
+        store = Neo4jGraphStore.__new__(Neo4jGraphStore)
+        store.database = None
+        store.run_cypher = lambda *a, **k: ([{"c": 1}], None, [])
+        store.format_records = lambda records: list(records)
+        node._graph_store = store
+        assert node._probe_vector() is True
+
+    def test_to_dict_serializes_the_text_embedder(self):
+        node = make_retriever(rows=[], text_embedder=StubTextEmbedder(is_postponed_component_init=True))
+        data = node.to_dict()
+        assert data["text_embedder"]["name"] == "stub-text-embedder"
+
+
+class TestFactRerank:
+    def test_query_vector_ranks_facts_server_side(self):
+        # A query vector -> the neighbourhood is ordered by edge-embedding cosine, so top_k are MOST relevant.
+        node = make_retriever(filters=LOCKED_ACL)
+        query, params = node._build_query(
+            GraphRetrieverInputSchema(query="what does Acme use?"), 10, seed_names=["Acme"], query_vector=[0.1, 0.2]
+        )
+        assert "vector.similarity.cosine(r.embedding, $qvec)" in query
+        assert "ORDER BY CASE WHEN r.embedding IS NULL THEN -1.0" in query
+        assert params["qvec"] == [0.1, 0.2]
+        assert query.index("ORDER BY") < query.index("LIMIT $limit")  # rank the neighbourhood, THEN limit
+
+    def test_no_query_vector_no_ranking(self):
+        node = make_retriever()
+        query, params = node._build_query(GraphRetrieverInputSchema(query="who works at Acme?"), 10)
+        assert "vector.similarity.cosine" not in query
+        assert "qvec" not in params
+
+    def test_render_strips_edge_embedding_from_output(self):
+        rows = [
+            {
+                "a_name": "Acme",
+                "a_id": "1",
+                "rel": "USES",
+                "b_name": "Helios",
+                "b_id": "2",
+                "rprops": {"embedding": [0.1, 0.2, 0.3], "description": "for trading"},
+            }
+        ]
+        docs = GraphRetriever._render_single_hop(rows)
+        assert "embedding" not in docs[0].metadata  # edge vector never surfaces to the caller
+        assert docs[0].content == "Acme -[USES]-> Helios: for trading"
+
+    def test_seed_by_query_skips_extraction(self):
+        # seed_by_query -> no LLM extraction; seeding falls to the whole-query vector.
+        node = make_retriever(seed_by_query=True, llm=StubLLM(response_content='{"names": ["Acme"]}'))
+        assert node._seed_entity_names(GraphRetrieverInputSchema(query="who at Acme?"), config=None) == []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes entity identity, merge behavior, and ACL-sensitive rendering in the knowledge-graph pipeline; mis-resolution or embedding/index mismatches could duplicate entities or affect who sees which names/facts.
> 
> **Overview**
> **Knowledge graph write path** now assigns durable entity identity with **`uuid5(label:normalize_name(name))`** so identical names merge without a graph scan; optional **`fuzzy_matching`** (default on) still merges spelling variants using index-backed candidates (entity vector index when embeddings are enabled, else full-text) with **trigram** as the only merge decision. Random UUID resolution and per-label full scans are removed in favor of batched id existence checks and bounded candidate queries.
> 
> **Optional `entity_embedder` (Neo4j)** embeds entity **names** on nodes (with a lazy **`entity_embedding`** vector index) and relationship **triplets** on edges for retrieval-time semantic seeding and ranking. Shared helpers **`normalize_name`** and **`build_fact_text`** unify identity and fact text across writer and retriever.
> 
> **ACL fix:** **`EntityExtractor`** snapshots **`src_name` / `dst_name`** onto every relationship (including **`HAS_ATTRIBUTE`**); **`GraphRetriever`** renders facts from those edge properties instead of shared merged node names, so callers only see names scoped to edges they can access.
> 
> **`GraphRetriever`** gains optional **`text_embedder`**, **`vector_top_k`**, and **`seed_by_query`** for vector-based entry seeding; when a query vector is available, facts are **ordered in Cypher** by cosine similarity to edge embeddings before **`LIMIT`**, and embeddings are stripped from client output.
> 
> Tests add unit coverage for resolution/embeddings/vector Cypher and a Neo4j E2E regression for the name-leak scenario plus paraphrased vector seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5753cbfd3e5dfa9a12d73a9e89671edb888470f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->