### PR TITLE
feat: add contains filter for vector stores, user field in search node

### DIFF
--- a/dynamiq/nodes/knowledgebases/knowledgebase.py
+++ b/dynamiq/nodes/knowledgebases/knowledgebase.py
@@ -57,6 +57,7 @@ class DynamiqKnowledgebaseVectorSearch(ConnectionNode):
         ),
     )
     timeout: float = 30
+    user: str | None = None
     success_codes: list[int] = [200]
     input_schema: ClassVar[type[DynamiqKnowledgebaseVectorSearchInputSchema]] = (
         DynamiqKnowledgebaseVectorSearchInputSchema
@@ -74,6 +75,7 @@ class DynamiqKnowledgebaseVectorSearch(ConnectionNode):
             if input_data.similarity_threshold is not None
             else self.similarity_threshold
         )
+        user = self.user
 
         body: dict[str, Any] = {"query": input_data.query}
         if limit is not None:
@@ -82,6 +84,8 @@ class DynamiqKnowledgebaseVectorSearch(ConnectionNode):
             body["filters"] = filters
         if similarity_threshold is not None:
             body["similarity_threshold"] = similarity_threshold
+        if user is not None:
+            body["user"] = user
 
         return {
             "method": "POST",

--- a/dynamiq/storages/vector/pgvector/filters.py
+++ b/dynamiq/storages/vector/pgvector/filters.py
@@ -156,6 +156,13 @@ def _parse_comparison_condition(condition: dict[str, Any]) -> tuple[str, list[An
 
     value: Any = condition["value"]
 
+    if operator == "contains_any":
+        # `contains_any` operates on the raw JSONB array, so it must bypass the
+        # scalar `->>` casting applied to the other comparison operators. It also
+        # returns its own params list (the JSONB key + the value array), so unlike the
+        # other operators it is returned as-is instead of being wrapped in a list.
+        return _contains_any(field, value)
+
     if field.startswith("metadata."):
         field = _parse_metadata_fields_in_metadata(field, value)
 
@@ -417,6 +424,32 @@ def _in(field: str, value: Any) -> tuple[str, list]:
     return f"{field} = ANY(%s::text[])", value
 
 
+def _contains_any(field: str, value: Any) -> tuple[str, list]:
+    """
+    Creates a `contains_any` (union) comparison filter.
+
+    Args:
+        field (str): The field to compare (already qualified, e.g. ``metadata.tags``).
+        value (Any): The list of values to compare against.
+
+    Returns:
+        tuple[str, list]: A `contains_any` comparison SQL query and params to use in the query.
+
+    Raises:
+        VectorStoreFilterException: If the value is not a list or contains unsupported types.
+    """
+    _validate_list_value(field, value, "contains_any")
+
+    text_values = [str(v) for v in value]
+
+    if field.startswith("metadata."):
+        field_name = field.split(".", 1)[1]
+        return "metadata->%s ?| %s::text[]", [field_name, text_values]
+
+    # Fallback for a top-level JSONB column (the default schema has no such array column).
+    return f"{field} ?| %s::text[]", [text_values]
+
+
 LOGICAL_OPERATORS = ["AND", "OR"]
 
 COMPARISON_OPERATORS = {
@@ -428,4 +461,5 @@ COMPARISON_OPERATORS = {
     "<=": _less_than_equal,
     "in": _in,
     "not in": _not_in,
+    "contains_any": _contains_any,
 }

--- a/dynamiq/storages/vector/pgvector/filters.py
+++ b/dynamiq/storages/vector/pgvector/filters.py
@@ -442,12 +442,17 @@ def _contains_any(field: str, value: Any) -> tuple[str, list]:
 
     text_values = [str(v) for v in value]
 
-    if field.startswith("metadata."):
-        field_name = field.split(".", 1)[1]
-        return "metadata->%s ?| %s::text[]", [field_name, text_values]
+    if not field.startswith("metadata."):
+        msg = f"'contains_any' is only supported on metadata list fields, got '{field}'"
+        raise VectorStoreFilterException(msg)
 
-    # Fallback for a top-level JSONB column (the default schema has no such array column).
-    return f"{field} ?| %s::text[]", [text_values]
+    field_name = field.split(".", 1)[1]
+    query = (
+        "EXISTS (SELECT 1 FROM jsonb_array_elements_text("
+        "CASE WHEN jsonb_typeof(metadata->%s) = 'array' THEN metadata->%s ELSE '[]'::jsonb END"
+        ") AS elem WHERE elem = ANY(%s::text[]))"
+    )
+    return query, [field_name, field_name, text_values]
 
 
 LOGICAL_OPERATORS = ["AND", "OR"]

--- a/dynamiq/storages/vector/pinecone/filters.py
+++ b/dynamiq/storages/vector/pinecone/filters.py
@@ -309,6 +309,40 @@ def _in(field: str, value: Any) -> dict[str, Any]:
     return {field: {"$in": value}}
 
 
+def _contains_any(field: str, value: Any) -> dict[str, Any]:
+    """
+    Creates a 'contains any' (union) comparison filter.
+
+    Matches vectors whose list-valued metadata ``field`` shares at least one element
+    with ``value``. Pinecone's ``$in`` operator matches when a list metadata field
+    contains any of the given values.
+
+    Args:
+        field (str): The field to compare.
+        value (Any): The list of values to compare against.
+
+    Returns:
+        dict[str, Any]: A 'contains any' comparison filter.
+
+    Raises:
+        VectorStoreFilterException: If the value is not a list or contains unsupported types.
+    """
+    if not isinstance(value, list):
+        msg = f"{field}'s value must be a list when using 'contains_any' comparator in Pinecone"
+        raise VectorStoreFilterException(msg)
+
+    supported_types = (int, float, str)
+    for v in value:
+        if not isinstance(v, supported_types):
+            msg = (
+                f"Unsupported type for 'contains_any' comparison: {type(v)}. "
+                f"Types supported by Pinecone are: {supported_types}"
+            )
+            raise VectorStoreFilterException(msg)
+
+    return {field: {"$in": value}}
+
+
 COMPARISON_OPERATORS = {
     "==": _equal,
     "!=": _not_equal,
@@ -318,6 +352,7 @@ COMPARISON_OPERATORS = {
     "<=": _less_than_equal,
     "in": _in,
     "not in": _not_in,
+    "contains_any": _contains_any,
 }
 
 LOGICAL_OPERATORS = {"AND": "$and", "OR": "$or"}

--- a/dynamiq/storages/vector/weaviate/filters.py
+++ b/dynamiq/storages/vector/weaviate/filters.py
@@ -62,7 +62,17 @@ def _invert_condition(filters: dict[str, Any]) -> dict[str, Any]:
     inverted_condition = filters.copy()
     if "operator" not in filters:
         return inverted_condition
-    inverted_condition["operator"] = OPERATOR_INVERSE[filters["operator"]]
+    operator = filters["operator"]
+    if operator not in OPERATOR_INVERSE:
+        # 'contains_any' / 'contains_all' have no single-operator negation in Weaviate
+        # ("contains none" is not a native operator), so a NOT wrapping them cannot be
+        # inverted. Fail with a clear message instead of a KeyError.
+        msg = (
+            f"Operator '{operator}' cannot be used inside a 'NOT' filter for Weaviate. "
+            f"Invertible operators are: {sorted(OPERATOR_INVERSE)}"
+        )
+        raise VectorStoreFilterException(msg)
+    inverted_condition["operator"] = OPERATOR_INVERSE[operator]
     if "conditions" in filters:
         inverted_condition["conditions"] = []
         for condition in filters["conditions"]:

--- a/dynamiq/storages/vector/weaviate/filters.py
+++ b/dynamiq/storages/vector/weaviate/filters.py
@@ -321,6 +321,54 @@ def _not_in(field: str, value: Any) -> FilterReturn:
     return Filter.all_of(operands)
 
 
+def _contains_any(field: str, value: Any) -> FilterReturn:
+    """
+    Create a 'contains any' (union) filter.
+
+    Matches documents whose ``field`` contains at least one of the given values.
+    See https://docs.weaviate.io/weaviate/search/filters#containsany-filter
+
+    Args:
+        field (str): The field to filter on.
+        value (Any): The list of values to compare against.
+
+    Returns:
+        FilterReturn: The 'contains any' filter.
+
+    Raises:
+        VectorStoreFilterException: If the value is not a list.
+    """
+    if not isinstance(value, list):
+        msg = f"{field}'s value must be a list when using 'contains_any' or 'contains_all' comparators"
+        raise VectorStoreFilterException(msg)
+
+    return Filter.by_property(field).contains_any(value)
+
+
+def _contains_all(field: str, value: Any) -> FilterReturn:
+    """
+    Create a 'contains all' (intersection) filter.
+
+    Matches documents whose ``field`` contains every one of the given values.
+    See https://docs.weaviate.io/weaviate/search/filters#containsall-filter
+
+    Args:
+        field (str): The field to filter on.
+        value (Any): The list of values to compare against.
+
+    Returns:
+        FilterReturn: The 'contains all' filter.
+
+    Raises:
+        VectorStoreFilterException: If the value is not a list.
+    """
+    if not isinstance(value, list):
+        msg = f"{field}'s value must be a list when using 'contains_any' or 'contains_all' comparators"
+        raise VectorStoreFilterException(msg)
+
+    return Filter.by_property(field).contains_all(value)
+
+
 COMPARISON_OPERATORS = {
     "==": _equal,
     "!=": _not_equal,
@@ -330,6 +378,8 @@ COMPARISON_OPERATORS = {
     "<=": _less_than_equal,
     "in": _in,
     "not in": _not_in,
+    "contains_any": _contains_any,
+    "contains_all": _contains_all,
 }
 
 

--- a/tests/unit/storages/vector/pgvector/test_pgvector_filters.py
+++ b/tests/unit/storages/vector/pgvector/test_pgvector_filters.py
@@ -1,0 +1,40 @@
+import pytest
+
+from dynamiq.storages.vector.exceptions import VectorStoreFilterException
+from dynamiq.storages.vector.pgvector.filters import _contains_any, _convert_filters_to_query
+
+EXPECTED_QUERY = (
+    "EXISTS (SELECT 1 FROM jsonb_array_elements_text("
+    "CASE WHEN jsonb_typeof(metadata->%s) = 'array' THEN metadata->%s ELSE '[]'::jsonb END"
+    ") AS elem WHERE elem = ANY(%s::text[]))"
+)
+
+
+def test_contains_any_builds_jsonb_membership_query():
+    query, params = _contains_any("metadata.tags", ["ai", "ml"])
+    assert query == EXPECTED_QUERY
+    assert params == ["tags", "tags", ["ai", "ml"]]
+
+
+def test_contains_any_coerces_values_to_text_for_numeric_arrays():
+    _, params = _contains_any("metadata.codes", [1, 2])
+    assert params == ["codes", "codes", ["1", "2"]]
+
+
+def test_contains_any_requires_list():
+    with pytest.raises(VectorStoreFilterException, match="must be a list"):
+        _contains_any("metadata.tags", "ai")
+
+
+def test_contains_any_rejects_non_metadata_field():
+    # Only metadata list keys are supported; anything else fails loudly (and keeps the SQL
+    # a static, injection-free string).
+    with pytest.raises(VectorStoreFilterException, match="only supported on metadata list fields"):
+        _contains_any("content", ["ai"])
+
+
+def test_convert_filters_to_query_with_contains_any():
+    filters = {"field": "tags", "operator": "contains_any", "value": ["ai", "ml"]}
+    where_clause, params = _convert_filters_to_query(filters)
+    assert "jsonb_array_elements_text" in where_clause.as_string(None)
+    assert params == ("tags", "tags", ["ai", "ml"])

--- a/tests/unit/storages/vector/pinecone/test_pinecone_filters.py
+++ b/tests/unit/storages/vector/pinecone/test_pinecone_filters.py
@@ -1,0 +1,34 @@
+import pytest
+
+from dynamiq.storages.vector.exceptions import VectorStoreFilterException
+from dynamiq.storages.vector.pinecone.filters import _contains_any, _normalize_filters
+
+
+def test_contains_any_builds_filter():
+    assert _contains_any("tags", ["ai", "ml"]) == {"tags": {"$in": ["ai", "ml"]}}
+
+
+def test_contains_any_requires_list():
+    with pytest.raises(VectorStoreFilterException, match="must be a list"):
+        _contains_any("tags", "ai")
+
+
+def test_contains_any_rejects_unsupported_types():
+    with pytest.raises(VectorStoreFilterException, match="Unsupported type"):
+        _contains_any("tags", [{"a": 1}])
+
+
+def test_normalize_filters_with_contains_any():
+    filters = {"field": "metadata.tags", "operator": "contains_any", "value": ["ai", "ml"]}
+    assert _normalize_filters(filters) == {"tags": {"$in": ["ai", "ml"]}}
+
+
+def test_normalize_filters_contains_any_inside_logical():
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "year", "operator": ">=", "value": 2020},
+            {"field": "tags", "operator": "contains_any", "value": ["ai", "ml"]},
+        ],
+    }
+    assert _normalize_filters(filters) == {"$and": [{"year": {"$gte": 2020}}, {"tags": {"$in": ["ai", "ml"]}}]}

--- a/tests/unit/storages/vector/weaviate/test_weaviate_filters.py
+++ b/tests/unit/storages/vector/weaviate/test_weaviate_filters.py
@@ -40,3 +40,17 @@ def test_convert_filters_contains_any_inside_logical():
         ],
     }
     assert convert_filters(filters) is not None
+
+
+@pytest.mark.parametrize("operator", ["contains_any", "contains_all"])
+def test_not_wrapping_contains_raises_clear_error(operator):
+    # `contains_*` have no invertible counterpart in Weaviate; a NOT around them must
+    # raise a clear VectorStoreFilterException, not a KeyError.
+    filters = {
+        "operator": "NOT",
+        "conditions": [
+            {"field": "tags", "operator": operator, "value": ["ai", "ml"]},
+        ],
+    }
+    with pytest.raises(VectorStoreFilterException, match="cannot be used inside a 'NOT' filter"):
+        convert_filters(filters)

--- a/tests/unit/storages/vector/weaviate/test_weaviate_filters.py
+++ b/tests/unit/storages/vector/weaviate/test_weaviate_filters.py
@@ -1,0 +1,42 @@
+import pytest
+from weaviate.collections.classes.filters import _FilterValue
+
+from dynamiq.storages.vector.exceptions import VectorStoreFilterException
+from dynamiq.storages.vector.weaviate.filters import _contains_all, _contains_any, convert_filters
+
+
+def test_contains_any_builds_filter():
+    result = _contains_any("tags", ["ai", "ml"])
+    assert isinstance(result, _FilterValue)
+    assert result.value == ["ai", "ml"]
+    assert result.operator.value == "ContainsAny"
+
+
+def test_contains_all_builds_filter():
+    result = _contains_all("tags", ["ai", "ml"])
+    assert isinstance(result, _FilterValue)
+    assert result.value == ["ai", "ml"]
+    assert result.operator.value == "ContainsAll"
+
+
+@pytest.mark.parametrize("builder", [_contains_any, _contains_all])
+def test_contains_operators_require_list(builder):
+    with pytest.raises(VectorStoreFilterException, match="must be a list"):
+        builder("tags", "ai")
+
+
+@pytest.mark.parametrize("operator", ["contains_any", "contains_all"])
+def test_convert_filters_with_contains_operators(operator):
+    filters = {"field": "metadata.tags", "operator": operator, "value": ["ai", "ml"]}
+    assert convert_filters(filters) is not None
+
+
+def test_convert_filters_contains_any_inside_logical():
+    filters = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "year", "operator": ">=", "value": 2020},
+            {"field": "tags", "operator": "contains_all", "value": ["ai", "ml"]},
+        ],
+    }
+    assert convert_filters(filters) is not None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes query translation for three vector backends and knowledgebase API payloads; incorrect filter SQL or semantics could skew retrieval, though behavior is covered by new unit tests and PGVector uses parameterized queries.
> 
> **Overview**
> Adds **list-style metadata filtering** across PGVector, Pinecone, and Weaviate, plus an optional **`user`** field on the Dynamiq knowledgebase vector-search node.
> 
> **Vector filters:** New `contains_any` (match if a list metadata field overlaps any given value) is wired in all three backends—PGVector via parameterized JSONB `jsonb_array_elements_text`, Pinecone via `$in` on list metadata, Weaviate via native `contains_any`. Weaviate also gets **`contains_all`** (intersection). PGVector restricts `contains_any` to `metadata.*` list keys and handles it before scalar `->>` casting. Weaviate **NOT** inversion now raises a clear `VectorStoreFilterException` when wrapping `contains_any` / `contains_all` instead of a `KeyError`.
> 
> **Knowledgebase node:** `DynamiqKnowledgebaseVectorSearch` accepts optional `user` and includes it in the vector-search POST body when set (for API-side ACL/context).
> 
> Unit tests cover the new operators and Weaviate NOT behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62025b5e256336590d3c8e2e323b4d28e54b6cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->