### PR TITLE
feat: unify get_document_by_id method

### DIFF
--- a/dynamiq/nodes/retrievers/base.py
+++ b/dynamiq/nodes/retrievers/base.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 
 from dynamiq.nodes.node import NodeGroup, VectorStoreNode
 from dynamiq.nodes.types import ActionType
+from dynamiq.types import Document
 
 
 class RetrieverInputSchema(BaseModel):
@@ -41,3 +42,14 @@ class Retriever(VectorStoreNode, ABC):
     @property
     def to_dict_exclude_params(self):
         return super().to_dict_exclude_params | {"document_retriever": True}
+
+    def get_documents_by_id(self, ids: list[str]) -> list[Document]:
+        """Fetch documents by their exact ids, forwarding to the underlying vector store.
+
+        Shared by every retriever node; backends whose store can't fetch by id raise NotImplementedError.
+        """
+        if not ids:
+            return []
+        if self.vector_store is None:
+            self.init_components()
+        return self.vector_store.get_documents_by_id(list(ids))

--- a/dynamiq/nodes/retrievers/graph.py
+++ b/dynamiq/nodes/retrievers/graph.py
@@ -659,10 +659,10 @@ class GraphRetriever(ConnectionNode):
 
         Each fact came from an ACL-visible edge whose ACL equals its source document's, so the caller is
         already entitled to those documents; the distinct ``source_doc_ids`` (every per-document edge behind
-        a deduped fact) are pulled via the ``document_retriever``'s ``get_documents_by_ids`` with no extra
+        a deduped fact) are pulled via the ``document_retriever``'s ``get_documents_by_id`` with no extra
         ACL check. Returns ``[]`` when no retriever is set, no fact carries provenance, or the fetch fails.
         """
-        if not self.document_retriever or not hasattr(self.document_retriever, "get_documents_by_ids"):
+        if not self.document_retriever or not hasattr(self.document_retriever, "get_documents_by_id"):
             return []
         ids: list[str] = []
         for d in documents:
@@ -672,7 +672,7 @@ class GraphRetriever(ConnectionNode):
         if not ids:
             return []
         try:
-            return self.document_retriever.get_documents_by_ids(ids)
+            return self.document_retriever.get_documents_by_id(ids)
         except Exception as e:
             logger.warning(f"Tool {self.name} - {self.id}: source-document fetch failed: {e}")
             return []

--- a/dynamiq/nodes/retrievers/pgvector.py
+++ b/dynamiq/nodes/retrievers/pgvector.py
@@ -8,7 +8,6 @@ from dynamiq.nodes.retrievers.base import Retriever, RetrieverInputSchema
 from dynamiq.runnables import RunnableConfig
 from dynamiq.storages.vector import PGVectorStore
 from dynamiq.storages.vector.pgvector.pgvector import PGVectorStoreParams, PGVectorStoreRetrieverParams
-from dynamiq.types import Document
 from dynamiq.types.cancellation import check_cancellation
 
 
@@ -131,12 +130,3 @@ class PGVectorDocumentRetriever(Retriever, PGVectorStoreRetrieverParams):
         return {
             "documents": output["documents"],
         }
-
-    def get_documents_by_ids(self, ids: list[str]) -> list[Document]:
-        """Fetch documents by exact id — e.g. to pull a graph fact's source chunk (``source_doc_id``) for
-        grounding. A pgvector-only capability (no similarity search); other retrievers don't define it."""
-        if not ids:
-            return []
-        if self.vector_store is None:
-            self.init_components()
-        return self.vector_store.get_documents_by_ids(list(ids))

--- a/dynamiq/storages/vector/base.py
+++ b/dynamiq/storages/vector/base.py
@@ -1,10 +1,13 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
 from dynamiq.storages.vector.utils import create_file_id_filter, create_file_ids_filter
 from dynamiq.utils.logger import logger
+
+if TYPE_CHECKING:
+    from dynamiq.types import Document
 
 
 class BaseVectorStoreParams(BaseModel):
@@ -34,6 +37,14 @@ class BaseVectorStore(ABC):
     This abstract class provides a consistent interface for all vector store implementations,
     including common methods for document deletion by file ID(s).
     """
+
+    def get_documents_by_id(self, ids: list[str]) -> list["Document"]:
+        """Fetch documents by their exact ids (not a similarity search).
+
+        Backends that can address points by id override this; the rest inherit this default so callers
+        can rely on a single contract.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support fetch-by-id.")
 
     @abstractmethod
     def delete_documents_by_filters(self, filters: dict[str, Any]) -> None:

--- a/dynamiq/storages/vector/pgvector/pgvector.py
+++ b/dynamiq/storages/vector/pgvector/pgvector.py
@@ -948,7 +948,7 @@ class PGVectorStore(BaseVectorStore, DryRunMixin):
                 documents = self._convert_query_result_to_documents(records)
                 return documents
 
-    def get_documents_by_ids(
+    def get_documents_by_id(
         self,
         ids: list[str],
         content_key: str | None = None,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is a breaking rename for any external code still calling `get_documents_by_ids`; behavior is otherwise a small refactor with clearer defaults for unsupported stores.
> 
> **Overview**
> **Unifies exact-id document lookup** under a single name: `get_documents_by_id` (replacing `get_documents_by_ids` on PGVector and the PGVector-only retriever helper).
> 
> **`Retriever`** now implements `get_documents_by_id` for all retriever nodes by delegating to the bound vector store (empty ids → `[]`, lazy `init_components` when needed). **`PGVectorDocumentRetriever`** drops its duplicate method and inherits this behavior.
> 
> **`BaseVectorStore`** adds a default `get_documents_by_id` that raises `NotImplementedError` so callers have one contract; backends that support id lookup override it (PGVector keeps its SQL `WHERE id = ANY(...)` implementation under the new name).
> 
> **`GraphRetriever`** source-document grounding is updated to call and probe `get_documents_by_id` on `document_retriever`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0d4ee1cf04595df052b85e27351785ace1ec67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->