### PR TITLE
feat: add MiniMax M3 to model registry

### DIFF
--- a/dynamiq/nodes/llms/model_registry.json
+++ b/dynamiq/nodes/llms/model_registry.json
@@ -107,6 +107,22 @@
         "input_cost_per_token": 0.0000003,
         "output_cost_per_token": 0.0000012
     },
+    "MiniMaxAI/MiniMax-M3": {
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "litellm_provider": "minimax",
+        "supports_vision": true,
+        "supports_pdf_input": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "input_cost_per_token": 0.0000006,
+        "output_cost_per_token": 0.0000024,
+        "cache_read_input_token_cost": 0.00000012
+    },
     "moonshotai/kimi-k2.6": {
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,


### PR DESCRIPTION
Reason: 有自有 model 目录 model_registry.json 已列 MiniMax-M2.5/M2.7(litellm_provider minimax)但缺 M3

## Summary
- Add MiniMaxAI/MiniMax-M3 metadata to the custom LLM model registry.
- Include the MiniMax provider, 1M-token context, token pricing, and cache-read pricing for LiteLLM compatibility.

## Checks
- python3 -m json.tool dynamiq/nodes/llms/model_registry.json
- git add -A -N && git diff HEAD | grep -E <secret_regex>