### PR TITLE
fix: drop unused node ids from GraphRetriever output

### DIFF
--- a/dynamiq/nodes/retrievers/graph.py
+++ b/dynamiq/nodes/retrievers/graph.py
@@ -166,8 +166,8 @@ class GraphRetriever(ConnectionNode):
     controlled alternative to ``CypherExecutor`` for read access. An LLM first extracts the entities the
     question is about (constrained to the ontology's types), the retriever finds those entry-point entities
     by name, expands ONE hop through **visible** edges, and renders the resulting facts as ``Document``
-    objects an agent can consume directly. Deeper exploration is by iteration: each fact carries its
-    neighbor's ``source_id``/``target_id``, which an agent feeds back as the next call's ``entity_ids``.
+    objects an agent can consume directly. Deeper exploration is by iteration: an agent feeds a fact's
+    neighbor name back as the next call's ``entities`` seed.
 
     Entry-point selection is backend-agnostic: on Neo4j with the entity-name full-text index present
     (created by ``KnowledgeGraphWriter``) it uses an index seek and expands only the seed's neighborhood;
@@ -556,27 +556,20 @@ class GraphRetriever(ConnectionNode):
         """
         params: dict[str, Any] = {"limit": limit}
         lead, entry_where, anchored = self._entry(input_data, params, seed_names, seed_vectors)
-        # Anchored expansion is undirected (catch edges into and out of the seed); direction is recovered
-        # in RETURN via startNode/endNode. The scan keeps the directed pattern with a=source, b=target.
+        # Anchored expansion is undirected (catch edges into and out of the seed); each edge's direction is
+        # carried by its own r.src_name/r.dst_name snapshot. The scan keeps the directed pattern with
+        # a=source, b=target.
         arrow = "-[{rel}]-" if anchored else "-[{rel}]->"
 
         rel_clauses, filter_params = self._edge_predicates("r", input_data.filters)
         params.update(filter_params)
         where = " AND ".join([t for t in [entry_where, *rel_clauses] if t])
         # Names come from the edge's own ACL-bearing snapshot (r.src_name/r.dst_name), never the shared
-        # merged node, so a differently-scoped name can't leak. Node ids still come from the nodes (for
-        # next-hop iteration).
-        if anchored:
-            ret = (
-                "RETURN r.src_name AS a_name, startNode(r).id AS a_id, "
-                "type(r) AS rel, properties(r) AS rprops, "
-                "r.dst_name AS b_name, endNode(r).id AS b_id"
-            )
-        else:
-            ret = (
-                "RETURN r.src_name AS a_name, a.id AS a_id, type(r) AS rel, "
-                "properties(r) AS rprops, r.dst_name AS b_name, b.id AS b_id"
-            )
+        # merged node, so a differently-scoped name can't leak.
+        ret = (
+            "RETURN r.src_name AS a_name, type(r) AS rel, "
+            "properties(r) AS rprops, r.dst_name AS b_name"
+        )
         lines = [*lead, f"MATCH (a){arrow.format(rel='r')}(b)"]
         if where:
             lines.append(f"WHERE {where}")
@@ -759,12 +752,6 @@ class GraphRetriever(ConnectionNode):
             # Normalize provenance to a list so later duplicate facts can accumulate every source doc.
             if source_doc_id:
                 metadata["source_doc_ids"] = [source_doc_id]
-            # Endpoint entity ids (when available) let a caller iterate: feed a fact's neighbor id back as
-            # the next hop's seed instead of doing an exploding variable-length expansion.
-            if row.get("a_id") is not None:
-                metadata["source_id"] = row["a_id"]
-            if row.get("b_id") is not None:
-                metadata["target_id"] = row["b_id"]
             document = Document(content=fact, metadata=metadata, score=1.0 / (1.0 + rank))
             seen[fact] = document
             documents.append(document)

--- a/tests/unit/nodes/retrievers/test_graph_retriever.py
+++ b/tests/unit/nodes/retrievers/test_graph_retriever.py
@@ -227,13 +227,12 @@ class TestEntryModes:
         assert "db.index.fulltext.queryNodes('entity_name', $q) YIELD node AS a" in query
         assert "CONTAINS" not in query  # no scan
         assert params["q"] == "What~ OR does~ OR Jane~ OR use~"  # fuzzy Lucene OR-query
-        # anchored expansion is undirected; real direction recovered via startNode/endNode
+        # anchored expansion is undirected; per-edge direction comes from the r.src_name/r.dst_name snapshot
         assert "MATCH (a)-[r]-(b)" in query
-        assert "startNode(r)" in query and "endNode(r)" in query
         assert "coalesce(r.allowed_principals, [])" in query  # ACL still enforced on the edge
         # names render from the edge's own ACL-bearing snapshot, never the shared merged node
         assert "r.src_name AS a_name" in query and "r.dst_name AS b_name" in query
-        assert "startNode(r).name" not in query and "endNode(r).name" not in query
+        assert "startNode(r)" not in query and "endNode(r)" not in query  # shared node ids never surface
 
     def test_scan_fallback_when_index_absent(self):
         node = make_retriever(filters=LOCKED_ACL)
@@ -285,8 +284,8 @@ class TestExecuteRendering:
         assert out["content"] == "- Jane Doe -[WORKS_AT]-> Acme\n- Jane Doe -[salary]-> $250,000"
         assert out["documents"][0].score > out["documents"][1].score  # rank-derived ordering
 
-    def test_single_hop_exposes_endpoint_entity_ids_for_iteration(self):
-        # Endpoint ids let a caller feed a fact's neighbor back as the next hop's seed (no *1..N).
+    def test_single_hop_does_not_expose_endpoint_node_ids(self):
+        # Node ids are a public-namespace hash of the canonical name -> never surfaced to the caller.
         rows = [
             {
                 "a_name": "Jane Doe",
@@ -299,8 +298,8 @@ class TestExecuteRendering:
         ]
         node = make_retriever(rows=rows)
         out = node.execute(GraphRetrieverInputSchema(query="Jane Doe"))
-        assert out["documents"][0].metadata["source_id"] == "id-jane"
-        assert out["documents"][0].metadata["target_id"] == "id-acme"
+        assert "source_id" not in out["documents"][0].metadata
+        assert "target_id" not in out["documents"][0].metadata
 
     def test_empty_result_message(self):
         node = make_retriever(rows=[])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Callers that relied on `source_id`/`target_id` for iterative retrieval must switch to names or explicit `entity_ids`; behavior change on a public retriever API.
> 
> **Overview**
> **GraphRetriever** no longer returns internal graph node ids on retrieved facts. The one-hop Cypher query’s `RETURN` drops `a_id`/`b_id` (including `startNode`/`endNode` id lookups), and `_render_single_hop` no longer adds `source_id`/`target_id` on document metadata.
> 
> Docs and tests now describe **multi-hop exploration by neighbor name** via the `entities` input, not by feeding endpoint ids from prior results. Input `entity_ids` for **seeding** traversal is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400a455e498ff688d5eb7200eda98d06b10d8b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->