### PR TITLE
feat: clean bare nodes

### DIFF
--- a/dynamiq/nodes/knowledge_graph/writer.py
+++ b/dynamiq/nodes/knowledge_graph/writer.py
@@ -374,6 +374,9 @@ class KnowledgeGraphWriter(Node):
                     "endpoint nodes."
                 )
 
+        # Bare nodes (referenced by no relationship) are never persisted -- see _drop_bare_nodes.
+        nodes = self._drop_bare_nodes(nodes, relationships)
+
         if nodes:
             # Embed BEFORE resolving so one embed call serves both: the fuzzy candidate lookup (Tier 2)
             # and node storage. Ensure the vector index up front so resolution can query it this write.
@@ -451,6 +454,29 @@ class KnowledgeGraphWriter(Node):
             f"{len(document_ids)} document(s)."
         )
         return totals
+
+    def _drop_bare_nodes(self, nodes: list[dict], relationships: list[dict]) -> list[dict]:
+        """Drop nodes referenced by NO relationship (bare mentions) instead of writing them.
+
+        All provenance and ACL live on edges, so a bare node could never be attributed to any document:
+        retrieval (edge-driven) cannot reach it, no chunk references it (``kg_entity_ids`` come from
+        relationship endpoints), and ``delete_documents`` could never remove it — the orphan sweep only
+        examines endpoints of removed edges. Skipping the write keeps the invariant that everything
+        persisted is reachable through at least one provenance-stamped edge, so deleting a document
+        provably removes all it contributed. Nothing is lost: entity ids are content-addressed
+        (``uuid5`` of label + normalized name), so a future document asserting a fact about the same
+        name re-creates the identical node.
+        """
+        if not nodes:
+            return nodes
+        referenced = {r["start_identity"] for r in relationships} | {r["end_identity"] for r in relationships}
+        kept = [node for node in nodes if node["properties"]["id"] in referenced]
+        if len(kept) != len(nodes):
+            logger.info(
+                f"Node {self.name} - {self.id}: skipping {len(nodes) - len(kept)} bare node(s) "
+                "referenced by no relationship."
+            )
+        return kept
 
     @staticmethod
     def _attach_entity_ids(documents: list, relationships: list[dict]) -> list:

--- a/tests/unit/nodes/extractors/test_knowledge_graph_writer.py
+++ b/tests/unit/nodes/extractors/test_knowledge_graph_writer.py
@@ -333,6 +333,40 @@ class TestExecute:
         assert result["nodes_created"] == 0 and result["relationships_created"] == 0
         assert writer._graph_store.written is None  # write_graph never called
 
+    def test_execute_skips_bare_nodes_with_no_relationship(self):
+        # A bare mention (an entity with no relationship and no attribute edge) is never persisted:
+        # provenance lives on edges, so a bare node could not be attributed to a document, reached by
+        # retrieval, or removed by delete_documents. Its content-addressed id makes recreation free.
+        writer = make_writer({})
+        store = FakeGraphStore()
+        writer._graph_store = store
+
+        nodes = [
+            entity("PERSON", "jane@d1", "Jane"),
+            entity("ORGANIZATION", "acme@d1", "Acme"),
+            entity("PERSON", "steve@d1", "Steve"),  # bare: no relationship references it
+        ]
+        rels = [edge("WORKS_AT", "PERSON", "ORGANIZATION", "jane@d1", "acme@d1", {"source_doc_id": "d1"})]
+
+        result = writer.execute(KnowledgeGraphWriter.input_schema(nodes=nodes, relationships=rels, documents=[]))
+
+        assert result["nodes_created"] == 2
+        assert {n["properties"]["name"] for n in store.written[0]} == {"Jane", "Acme"}  # Steve skipped
+
+    def test_execute_all_nodes_bare_writes_nothing(self):
+        writer = make_writer({})
+        store = FakeGraphStore()
+        writer._graph_store = store
+
+        result = writer.execute(
+            KnowledgeGraphWriter.input_schema(
+                nodes=[entity("PERSON", "steve@d1", "Steve")], relationships=[], documents=[]
+            )
+        )
+
+        assert result["nodes_created"] == 0
+        assert store.written is None  # write_graph never called
+
     def test_execute_rejects_relationship_endpoints_absent_from_nodes(self):
         # A relationship endpoint not present in `nodes` can never be resolved: it would write with an
         # ephemeral wiring id that MATCHes no graph node (no edge created) and mis-tag chunks with that id.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes ingestion semantics for entities extracted without edges; linked entities behave as before, but previously written bare nodes are no longer created on new ingests.
> 
> **Overview**
> **`KnowledgeGraphWriter`** now drops extracted entities that are not endpoints of any relationship before embedding, resolution, and `write_graph`.
> 
> The new **`_drop_bare_nodes`** keeps only nodes whose `properties.id` appears as a relationship start or end. Bare mentions are logged and skipped so the graph only stores nodes reachable via provenance-stamped edges (aligning with edge-driven retrieval, `kg_entity_ids`, and `delete_documents` orphan cleanup). If every node is bare, the write path is skipped like an empty payload.
> 
> Unit tests cover mixed payloads (only linked entities written) and all-bare inputs (`write_graph` not called).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c752738a9b77e4075948d68e504c892ffe33e991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->