### PR TITLE
feat: add Cloudflare Sandboxes support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,10 @@ FIRECRAWL_API_KEY=your_firecrawl_api_key
 #E2B
 E2B_API_KEY=your_e2b_api_key
 
+#Cloudflare Sandboxes (deployed sandbox bridge Worker URL + its SANDBOX_API_KEY secret)
+CLOUDFLARE_SANDBOX_API_URL=https://your-sandbox-bridge.workers.dev
+CLOUDFLARE_SANDBOX_API_KEY=your_cloudflare_sandbox_api_key
+
 #Perplexity
 PERPLEXITYAI_API_KEY=your_perplexity_api_key
 

--- a/dynamiq/connections/cloudflare_sandbox.py
+++ b/dynamiq/connections/cloudflare_sandbox.py
@@ -1,0 +1,383 @@
+"""HTTP client for Cloudflare Sandboxes reached through the official Bridge Worker.
+
+Cloudflare Sandboxes have no public REST API and no Python SDK: sandboxes are only
+reachable through a Worker deployed in the user's Cloudflare account. The official
+path for external clients is the Bridge Worker (``@cloudflare/sandbox/bridge``),
+which exposes a versioned HTTP API under ``/v1`` authenticated with
+``Authorization: Bearer <SANDBOX_API_KEY>``.
+
+This module implements that wire contract with plain ``requests`` (no extra
+dependencies):
+
+- ``POST /v1/sandbox`` -> ``{"id": "<base32 id>"}`` (container is allocated lazily
+  on the first operation).
+- ``POST /v1/sandbox/:id/exec`` with ``{"argv": [...], "timeout_ms"?, "cwd"?}``,
+  streamed back as SSE: ``event: stdout|stderr`` carry base64 chunks,
+  ``event: exit`` carries ``{"exit_code": N}``, ``event: error`` carries
+  ``{"error", "code"}``. An optional ``Session-Id`` header scopes the command to a
+  previously created execution session.
+- ``GET|PUT /v1/sandbox/:id/file/<path>`` for raw file bytes. All paths are
+  constrained to ``/workspace`` by the bridge.
+- ``GET /v1/sandbox/:id/running``, ``DELETE /v1/sandbox/:id``, session and tunnel
+  management routes.
+"""
+
+import base64
+import json
+import re
+from typing import Any
+from urllib.parse import quote
+
+import requests
+from pydantic import BaseModel
+
+from dynamiq.utils.logger import logger
+
+WORKSPACE_ROOT = "/workspace"
+SANDBOX_ID_PATTERN = re.compile(r"[a-z2-7]{1,128}")
+SANDBOX_MARKER_PATH = f"{WORKSPACE_ROOT}/.dynamiq/created"
+
+
+class CloudflareSandboxError(Exception):
+    """Error returned by the Cloudflare sandbox bridge."""
+
+    def __init__(self, message: str, code: str | None = None, status_code: int | None = None):
+        self.code = code
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class CloudflareRateLimitError(CloudflareSandboxError):
+    """Raised when the bridge reports capacity or rate limiting.
+
+    Maps HTTP 429 responses and 503 responses with the ``capacity_exceeded`` code
+    (Cloudflare Containers instance limit reached), both of which are retryable.
+    """
+
+
+class CloudflareExecResult(BaseModel):
+    """Result of a command executed through the bridge."""
+
+    exit_code: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+
+
+def resolve_workspace_path(path: str) -> str:
+    """POSIX-normalize a path and ensure it stays inside /workspace.
+
+    Mirrors the bridge-side validation so invalid paths fail fast locally with a
+    clear error instead of an HTTP 403.
+
+    Args:
+        path: Absolute or /workspace-relative path.
+
+    Returns:
+        The normalized absolute path.
+
+    Raises:
+        ValueError: If the path escapes /workspace.
+    """
+    abs_path = path if path.startswith("/") else f"{WORKSPACE_ROOT}/{path}"
+    parts: list[str] = []
+    for segment in abs_path.split("/"):
+        if segment in ("", "."):
+            continue
+        if segment == "..":
+            if parts:
+                parts.pop()
+        else:
+            parts.append(segment)
+    resolved = "/" + "/".join(parts)
+    if resolved == WORKSPACE_ROOT or resolved.startswith(f"{WORKSPACE_ROOT}/"):
+        return resolved
+    raise ValueError(
+        f"Cloudflare sandbox file paths must stay inside {WORKSPACE_ROOT} " f"(got {path!r}, resolved to {resolved!r})"
+    )
+
+
+class CloudflareSandboxClient:
+    """Minimal HTTP client for a deployed Cloudflare sandbox bridge Worker.
+
+    Args:
+        url: Base URL of the deployed bridge Worker (e.g. ``https://my-bridge.workers.dev``).
+        api_key: The Worker's ``SANDBOX_API_KEY`` secret. Optional only when the
+            Worker was deployed without one (auth disabled).
+        api_prefix: Route prefix configured in the bridge (default ``/v1``).
+        connect_timeout: TCP connect timeout in seconds.
+        read_timeout: Default read timeout in seconds for non-exec requests. The
+            first operation on a sandbox may block while the container boots
+            (up to ~2 minutes inside the Worker), so this needs generous headroom.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        api_key: str | None = None,
+        api_prefix: str = "/v1",
+        connect_timeout: float = 30.0,
+        read_timeout: float = 300.0,
+    ):
+        if not url:
+            raise ValueError(
+                "Cloudflare sandbox bridge URL is required. Deploy the bridge Worker "
+                "(https://developers.cloudflare.com/sandbox/bridge/) and pass its URL."
+            )
+        self.base_url = url.rstrip("/")
+        self.api_prefix = f"/{api_prefix.strip('/')}" if api_prefix else ""
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
+        self._session = requests.Session()
+        if api_key:
+            self._session.headers["Authorization"] = f"Bearer {api_key}"
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}{self.api_prefix}{path}"
+
+    @staticmethod
+    def _validate_sandbox_id(sandbox_id: str) -> str:
+        if not SANDBOX_ID_PATTERN.fullmatch(sandbox_id or ""):
+            raise ValueError(f"Invalid Cloudflare sandbox id {sandbox_id!r}: expected ^[a-z2-7]{{1,128}}$")
+        return sandbox_id
+
+    @staticmethod
+    def _raise_for_error(response: requests.Response) -> None:
+        if 300 <= response.status_code < 400:
+            raise CloudflareSandboxError(
+                f"Cloudflare sandbox bridge returned a redirect (HTTP {response.status_code}). "
+                "Use the final https:// Worker URL as the connection url.",
+                status_code=response.status_code,
+            )
+        if response.status_code < 400:
+            return
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+        message = payload.get("error") or f"Cloudflare sandbox bridge returned HTTP {response.status_code}"
+        code = payload.get("code")
+        if response.status_code == 429 or code == "capacity_exceeded":
+            raise CloudflareRateLimitError(message, code=code, status_code=response.status_code)
+        raise CloudflareSandboxError(message, code=code, status_code=response.status_code)
+
+    def _request(self, method: str, path: str, *, read_timeout: float | None = None, **kwargs) -> requests.Response:
+        timeout = (self.connect_timeout, read_timeout or self.read_timeout)
+        response = self._session.request(method, self._url(path), timeout=timeout, allow_redirects=False, **kwargs)
+        self._raise_for_error(response)
+        return response
+
+    def health(self) -> bool:
+        """Check bridge health (unauthenticated ``GET /health`` at the Worker root)."""
+        try:
+            response = self._session.get(f"{self.base_url}/health", timeout=(self.connect_timeout, self.read_timeout))
+            return response.status_code == 200 and response.json().get("ok") is True
+        except (requests.RequestException, ValueError) as e:
+            logger.debug(f"Cloudflare sandbox bridge health check failed: {e}")
+            return False
+
+    def create_sandbox(self) -> str:
+        """Create a new sandbox and return its id (container is allocated lazily)."""
+        response = self._request("POST", "/sandbox")
+        sandbox_id = response.json()["id"]
+        logger.debug(f"Cloudflare sandbox created: {sandbox_id}")
+        return sandbox_id
+
+    def destroy_sandbox(self, sandbox_id: str) -> None:
+        """Destroy the sandbox container and release its warm-pool assignment."""
+        self._request("DELETE", f"/sandbox/{self._validate_sandbox_id(sandbox_id)}")
+        logger.debug(f"Cloudflare sandbox destroyed: {sandbox_id}")
+
+    def is_running(self, sandbox_id: str) -> bool:
+        """Check sandbox liveness. Note: this starts the container if it is asleep."""
+        response = self._request("GET", f"/sandbox/{self._validate_sandbox_id(sandbox_id)}/running")
+        return bool(response.json().get("running"))
+
+    def exec(
+        self,
+        sandbox_id: str,
+        command: str | list[str],
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+        session_id: str | None = None,
+    ) -> CloudflareExecResult:
+        """Execute a command in the sandbox and collect its streamed output.
+
+        Args:
+            sandbox_id: Target sandbox id.
+            command: Shell command string (run via ``bash -c``) or argv list.
+            cwd: Working directory; must resolve inside /workspace.
+            env: Environment variables for this command. The bridge exec route has
+                no env field, so they are prepended via ``env KEY=VALUE ...``.
+            timeout: Command timeout in seconds (mapped to ``timeout_ms``).
+            session_id: Optional execution session id (``Session-Id`` header) so
+                shell state (cwd, exported vars) persists across commands.
+
+        Returns:
+            CloudflareExecResult with exit_code, stdout, and stderr.
+        """
+        argv = ["bash", "-c", command] if isinstance(command, str) else list(command)
+        if env:
+            argv = ["env", *[f"{key}={value}" for key, value in env.items()], *argv]
+
+        body: dict[str, Any] = {"argv": argv}
+        if timeout:
+            body["timeout_ms"] = int(timeout * 1000)
+        if cwd:
+            body["cwd"] = resolve_workspace_path(cwd)
+
+        headers = {"Session-Id": session_id} if session_id else None
+        read_timeout = max((timeout or 0) + 120, self.read_timeout)
+        response = self._request(
+            "POST",
+            f"/sandbox/{self._validate_sandbox_id(sandbox_id)}/exec",
+            json=body,
+            headers=headers,
+            stream=True,
+            read_timeout=read_timeout,
+        )
+        return self._parse_exec_sse(response)
+
+    @staticmethod
+    def _parse_exec_sse(response: requests.Response) -> CloudflareExecResult:
+        """Parse the exec SSE stream into a CloudflareExecResult."""
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
+        exit_code: int | None = None
+        event: str | None = None
+        data_lines: list[str] = []
+
+        def handle_event() -> None:
+            nonlocal exit_code
+            data = "\n".join(data_lines)
+            if event in ("stdout", "stderr"):
+                try:
+                    decoded = base64.b64decode(data)
+                except (ValueError, TypeError):
+                    decoded = data.encode("utf-8", errors="replace")
+                (stdout_chunks if event == "stdout" else stderr_chunks).append(decoded)
+            elif event == "exit":
+                try:
+                    exit_code = json.loads(data).get("exit_code")
+                except (ValueError, AttributeError):
+                    exit_code = None
+            elif event == "error":
+                try:
+                    payload = json.loads(data)
+                except ValueError:
+                    payload = {"error": data}
+                raise CloudflareSandboxError(
+                    payload.get("error") or "Cloudflare sandbox exec failed", code=payload.get("code")
+                )
+
+        # The bridge emits UTF-8; requests would otherwise fall back to ISO-8859-1
+        # for text/event-stream responses without an explicit charset.
+        response.encoding = "utf-8"
+        try:
+            with response:
+                for line in response.iter_lines(decode_unicode=True):
+                    if line is None:
+                        continue
+                    if line == "":
+                        if event is not None:
+                            handle_event()
+                        event, data_lines = None, []
+                        continue
+                    if line.startswith("event:"):
+                        event = line[len("event:") :].strip()
+                    elif line.startswith("data:"):
+                        data_lines.append(line[len("data:") :].removeprefix(" "))
+                if event is not None:
+                    handle_event()
+        except requests.RequestException as e:
+            raise CloudflareSandboxError(f"Cloudflare sandbox exec stream failed: {e}") from e
+
+        # Decode once so multibyte characters split across SSE chunks survive intact.
+        return CloudflareExecResult(
+            exit_code=exit_code,
+            stdout=b"".join(stdout_chunks).decode("utf-8", errors="replace"),
+            stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
+        )
+
+    def _file_url_path(self, sandbox_id: str, path: str) -> str:
+        # The bridge routes decode the URL with decodeURI, which leaves URI-reserved
+        # characters (: @ & = + $ , ;) and % encoded/untouched asymmetrically - keep
+        # them raw so the container sees the literal filename, exactly like a TS
+        # client using fetch(). Filenames containing %, ? or # are unrepresentable
+        # through the bridge file routes (true for all clients).
+        resolved = resolve_workspace_path(path)
+        return f"/sandbox/{self._validate_sandbox_id(sandbox_id)}/file{quote(resolved, safe='/:@&=+$,;')}"
+
+    def read_file(self, sandbox_id: str, path: str) -> bytes:
+        """Read a file from the sandbox as raw bytes (path must be inside /workspace)."""
+        response = self._request("GET", self._file_url_path(sandbox_id, path))
+        return response.content
+
+    def write_file(self, sandbox_id: str, path: str, content: bytes) -> None:
+        """Write raw bytes to a file in the sandbox (max 32 MiB; parents auto-created)."""
+        self._request("PUT", self._file_url_path(sandbox_id, path), data=content)
+
+    def create_session(
+        self,
+        sandbox_id: str,
+        session_id: str | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        """Create an execution session with isolated shell state; returns its id."""
+        body: dict[str, Any] = {}
+        if session_id:
+            body["id"] = session_id
+        if cwd:
+            body["cwd"] = cwd
+        if env:
+            body["env"] = env
+        response = self._request("POST", f"/sandbox/{self._validate_sandbox_id(sandbox_id)}/session", json=body)
+        return response.json()["id"]
+
+    def delete_session(self, sandbox_id: str, session_id: str) -> None:
+        """Delete an execution session."""
+        self._request("DELETE", f"/sandbox/{self._validate_sandbox_id(sandbox_id)}/session/{quote(session_id)}")
+
+    def create_tunnel(self, sandbox_id: str, port: int, name: str | None = None) -> dict[str, Any]:
+        """Expose a sandbox port via a Cloudflare tunnel; returns tunnel info incl. ``url``."""
+        kwargs: dict[str, Any] = {"json": {"name": name}} if name else {}
+        response = self._request(
+            "POST", f"/sandbox/{self._validate_sandbox_id(sandbox_id)}/tunnel/{int(port)}", **kwargs
+        )
+        return response.json()
+
+    def delete_tunnel(self, sandbox_id: str, port: int) -> None:
+        """Tear down the tunnel for a sandbox port."""
+        self._request("DELETE", f"/sandbox/{self._validate_sandbox_id(sandbox_id)}/tunnel/{int(port)}")
+
+
+class CloudflareSandboxInstance:
+    """Lightweight handle binding a client to one sandbox id (and optional session).
+
+    Used as the live sandbox object by CloudflareInterpreterTool, mirroring the
+    role SDK sandbox instances play for the E2B and Daytona tools.
+    """
+
+    def __init__(self, client: CloudflareSandboxClient, sandbox_id: str, session_id: str | None = None):
+        self.client = client
+        self.sandbox_id = sandbox_id
+        self.session_id = session_id
+
+    def exec(
+        self,
+        command: str | list[str],
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> CloudflareExecResult:
+        return self.client.exec(self.sandbox_id, command, cwd=cwd, env=env, timeout=timeout, session_id=self.session_id)
+
+    def read_file(self, path: str) -> bytes:
+        return self.client.read_file(self.sandbox_id, path)
+
+    def write_file(self, path: str, content: bytes) -> None:
+        self.client.write_file(self.sandbox_id, path, content)
+
+    def destroy(self) -> None:
+        self.client.destroy_sandbox(self.sandbox_id)

--- a/dynamiq/connections/connections.py
+++ b/dynamiq/connections/connections.py
@@ -899,6 +899,32 @@ class Daytona(BaseApiKeyConnection):
         return self._client
 
 
+class Cloudflare(BaseApiKeyConnection):
+    """Connection to Cloudflare Sandboxes via a deployed sandbox bridge Worker.
+
+    Cloudflare Sandboxes are only reachable through a Worker in the user's
+    Cloudflare account; the official external HTTP surface is the bridge Worker
+    (https://developers.cloudflare.com/sandbox/bridge/). ``url`` is the deployed
+    bridge Worker URL and ``api_key`` is its ``SANDBOX_API_KEY`` secret.
+    """
+
+    api_key: str = Field(default_factory=partial(get_env_var, "CLOUDFLARE_SANDBOX_API_KEY"))
+    url: str = Field(default_factory=partial(get_env_var, "CLOUDFLARE_SANDBOX_API_URL"))
+
+    _client: Any = PrivateAttr(default=None)
+
+    def connect(self):
+        pass
+
+    def get_client(self):
+        """Get or create a cached Cloudflare sandbox bridge HTTP client."""
+        if self._client is None:
+            from dynamiq.connections.cloudflare_sandbox import CloudflareSandboxClient
+
+            self._client = CloudflareSandboxClient(url=self.url, api_key=self.api_key)
+        return self._client
+
+
 class HuggingFace(BaseApiKeyConnection):
     api_key: str = Field(default_factory=partial(get_env_var, "HUGGINGFACE_API_KEY"))
 

--- a/dynamiq/nodes/tools/__init__.py
+++ b/dynamiq/nodes/tools/__init__.py
@@ -1,4 +1,5 @@
 from .agent_tool import SubAgentTool
+from .cloudflare_sandbox import CloudflareInterpreterTool
 from .cua_desktop import CuaDesktopTool
 from .cypher_executor import CypherExecutor
 from .daytona_sandbox import DaytonaInterpreterTool

--- a/dynamiq/nodes/tools/cloudflare_sandbox.py
+++ b/dynamiq/nodes/tools/cloudflare_sandbox.py
@@ -1,0 +1,234 @@
+import io
+import shlex
+from typing import Any, ClassVar
+from uuid import uuid4
+
+from pydantic import field_validator
+
+from dynamiq.connections import Cloudflare as CloudflareConnection
+from dynamiq.connections.cloudflare_sandbox import (
+    SANDBOX_MARKER_PATH,
+    CloudflareExecResult,
+    CloudflareRateLimitError,
+    CloudflareSandboxInstance,
+    resolve_workspace_path,
+)
+from dynamiq.nodes.agents.exceptions import ToolExecutionException
+from dynamiq.nodes.tools.code_interpreter import BaseCodeInterpreterTool
+from dynamiq.utils.logger import logger
+
+DESCRIPTION_CLOUDFLARE_INTERPRETER = """Executes Python code and shell commands in a secure cloud sandbox environment.
+Provides isolated execution with package installation,
+file upload/download, and a persistent filesystem for complex data analysis and system operations.
+
+-Key Capabilities:-
+- Execute Python code (each execution runs in a fresh python3 process)
+- Run shell commands and system operations with file system access
+- Upload and process files (CSV, JSON, images) with persistent storage
+- Files persist across executions for the lifetime of the sandbox
+
+-Usage Strategy:-
+Always use print() statements to display results - code without output will fail.
+Specify required packages in the 'packages' parameter.
+ Variables do NOT persist between Python executions - save intermediate results to files under /workspace.
+
+-File Management Strategy:-
+- Uploaded files are automatically saved to the /workspace/input directory
+- If file name contains path (e.g., "data/file.csv"), it will be saved as /workspace/input/data/file.csv
+- If file name is just a filename (e.g., "file.csv"), it will be saved as /workspace/input/file.csv
+- To return files back to the user, save them in the /workspace/output directory
+- Files saved in /workspace/output will be automatically collected and returned
+- Use absolute paths like /workspace/output/filename.ext when saving files
+- Access uploaded files from /workspace/input/filename.ext in your code
+- All file paths must stay inside /workspace
+
+-Parameter Guide:-
+- packages: Comma-separated list of Python packages to install
+- python: Python code to execute (must include print statements)
+- shell_command: Shell commands to run in the sandbox
+- files: Binary files to upload for processing (saved to /workspace/input)
+
+-Examples:-
+- Data analysis: {"python": "import pandas as pd\\ndf = pd.read_csv('/workspace/input/data.csv')\\nprint(df.head())"}
+- File processing: {"packages": "requests",
+"python": "import requests\\nresponse = requests.get('https://api.example.com')\\nprint(response.json())"}
+- System operations: {"shell_command": "ls -la /workspace/input && ls -la /workspace/output"}
+- File generation: {"python": "import pandas as pd\\ndf = pd.DataFrame({'A': [1,2,3], 'B': [4,5,6]})\\n\
+df.to_csv('/workspace/output/result.csv')\\nprint('File saved to /workspace/output/result.csv')"}"""
+
+
+class CloudflareInterpreterTool(BaseCodeInterpreterTool):
+    """Cloudflare Sandboxes implementation of the sandbox interpreter tool.
+
+    Talks plain HTTP to a deployed Cloudflare sandbox bridge Worker (see
+    ``dynamiq.connections.cloudflare_sandbox``). Python code is written to a
+    temporary file inside the sandbox and executed with ``python3``, so each
+    execution runs in a fresh process; the /workspace filesystem persists for
+    the sandbox lifetime.
+    """
+
+    name: str = "cloudflare-code-interpreter-tool"
+    description: str = DESCRIPTION_CLOUDFLARE_INTERPRETER
+    base_path: str = "/workspace"
+    connection: CloudflareConnection
+    _sandbox: CloudflareSandboxInstance | None = None
+    _rate_limit_exception: ClassVar[type[Exception]] = CloudflareRateLimitError
+
+    @field_validator("base_path")
+    @classmethod
+    def validate_base_path(cls, value: str) -> str:
+        """The bridge constrains all file operations to /workspace; fail fast otherwise."""
+        return resolve_workspace_path(value)
+
+    def _create_sandbox(self) -> CloudflareSandboxInstance:
+        """Create a sandbox and boot its container.
+
+        POST /sandbox only mints an id - the container is allocated lazily on the
+        first operation, so capacity errors surface there. Running the marker
+        warm-up here keeps that first operation inside the creation retry loop
+        (CloudflareRateLimitError is retried with backoff by the base class) and
+        leaves a sentinel that reconnection can later verify.
+        """
+        client = self.connection.get_client()
+        sandbox = CloudflareSandboxInstance(client, client.create_sandbox())
+        result = sandbox.exec(
+            f"mkdir -p {shlex.quote(SANDBOX_MARKER_PATH.rsplit('/', 1)[0])} "
+            f"&& touch {shlex.quote(SANDBOX_MARKER_PATH)}",
+            timeout=self.timeout,
+        )
+        if result.exit_code != 0:
+            raise ValueError(f"Failed to initialize Cloudflare sandbox: {result.stderr or result.stdout}")
+        return sandbox
+
+    def _get_sandbox_id(self, sandbox: CloudflareSandboxInstance) -> str:
+        return sandbox.sandbox_id
+
+    def _get_sandbox_host(self, sandbox: CloudflareSandboxInstance) -> str | None:
+        return None
+
+    def _raise_on_failure(self, result: CloudflareExecResult, action: str) -> str:
+        if result.exit_code is None:
+            raise ToolExecutionException(
+                f"Error during {action}: command stream ended without an exit status "
+                f"(sandbox may have restarted). Partial output: {result.stdout or result.stderr or 'none'}",
+                recoverable=True,
+            )
+        if result.exit_code != 0:
+            raise ToolExecutionException(
+                f"Error during {action}: {result.stderr or result.stdout or f'exit code {result.exit_code}'}",
+                recoverable=True,
+            )
+        output_parts = []
+        if result.stdout:
+            output_parts.append(result.stdout)
+        if result.stderr:
+            output_parts.append(f"[stderr] {result.stderr}")
+        return "\n".join(output_parts)
+
+    def _execute_python_code(
+        self, code: str, sandbox: Any, params: dict | None = None, timeout: int | None = None
+    ) -> str:
+        if not sandbox:
+            raise ValueError("Sandbox instance is required for code execution.")
+
+        if params:
+            vars_code = "\n# Tool params variables\n"
+            for key, value in params.items():
+                resolved = self._resolve_param_value(value, sandbox)
+                vars_code += f"{key} = {repr(resolved)}\n"
+            code = vars_code + "\n" + code
+
+        script_path = f"{self.base_path}/.dynamiq/script_{uuid4().hex}.py"
+        try:
+            logger.info(f"Executing Python code: {code}")
+            sandbox.write_file(script_path, code.encode("utf-8"))
+            result = sandbox.exec(f"python3 {shlex.quote(script_path)}", timeout=timeout or self.timeout)
+            return self._raise_on_failure(result, "Python code execution")
+        except ToolExecutionException:
+            raise
+        except Exception as e:
+            raise ToolExecutionException(f"Error during Python code execution: {e}", recoverable=True)
+        finally:
+            # Ephemeral sandboxes are destroyed right after execute(), so cleanup
+            # would only add a round-trip (and could boot a fresh container).
+            if self.persistent_sandbox:
+                try:
+                    sandbox.exec(f"rm -f {shlex.quote(script_path)}", timeout=30)
+                except Exception as e:
+                    logger.debug(f"Tool {self.name} - {self.id}: Failed to clean up {script_path}: {e}")
+
+    def _execute_shell_command(
+        self,
+        command: str,
+        sandbox: Any,
+        env: dict | None = None,
+        cwd: str | None = None,
+        timeout: int | None = None,
+    ) -> str:
+        if not sandbox:
+            raise ValueError("Sandbox instance is required for command execution.")
+
+        try:
+            result = sandbox.exec(command, cwd=cwd, env=env or None, timeout=timeout or self.timeout)
+        except ToolExecutionException:
+            raise
+        except Exception as e:
+            raise ToolExecutionException(f"Error during shell command execution: {e}", recoverable=True)
+
+        return self._raise_on_failure(result, "shell command execution")
+
+    def _install_packages(self, sandbox: Any, packages: str) -> None:
+        if packages:
+            logger.debug(f"Tool {self.name} - {self.id}: Installing packages: {packages}")
+            try:
+                result = sandbox.exec(f"pip install -qq {' '.join(packages.split(','))}", timeout=self.timeout)
+            except Exception as e:
+                raise ToolExecutionException(f"Error during package installation: {e}", recoverable=True)
+
+            if result.exit_code != 0:
+                raise ToolExecutionException(
+                    f"Error during package installation: {result.stderr or result.stdout}", recoverable=True
+                )
+
+    def _upload_file_to_sandbox(self, file: io.BytesIO, target_path: str, sandbox: Any) -> str:
+        sandbox.write_file(target_path, file.read())
+        logger.debug(f"Tool {self.name} - {self.id}: Uploaded file to: {target_path}")
+        return target_path
+
+    def _download_file_bytes(self, file_path: str, sandbox: Any) -> bytes:
+        return sandbox.read_file(file_path)
+
+    def _run_shell_command(self, command: str, sandbox: Any) -> tuple[int, str]:
+        result = sandbox.exec(command)
+        return result.exit_code if result.exit_code is not None else 1, result.stdout or ""
+
+    def _reconnect_sandbox(self, sandbox_id: str) -> CloudflareSandboxInstance:
+        """Reconnect to an existing sandbox, verifying its state survived.
+
+        Sandbox ids are Durable-Object addressed, so any well-formed id "exists"
+        and would silently get a fresh empty container. The creation marker
+        distinguishes a live sandbox from an expired one, letting the base class
+        fall back to recreating the sandbox (and reinstalling packages).
+        """
+        client = self.connection.get_client()
+        sandbox = CloudflareSandboxInstance(client, sandbox_id)
+        result = sandbox.exec(f"test -f {shlex.quote(SANDBOX_MARKER_PATH)}", timeout=self.timeout)
+        if result.exit_code != 0:
+            raise ValueError(f"Cloudflare sandbox {sandbox_id} has expired or was destroyed (state lost)")
+        return sandbox
+
+    def _destroy_sandbox(self, sandbox: Any) -> None:
+        try:
+            sandbox.destroy()
+        except Exception as e:
+            logger.warning(f"Tool {self.name} - {self.id}: Failed to destroy sandbox: {e}")
+
+    def close(self) -> None:
+        """Close the persistent sandbox if it exists."""
+        if self._sandbox and self.persistent_sandbox:
+            logger.debug(f"Tool {self.name} - {self.id}: Closing Sandbox")
+            try:
+                self._sandbox.destroy()
+            except Exception as e:
+                logger.warning(f"Tool {self.name} - {self.id}: Failed to destroy sandbox: {e}")
+            self._sandbox = None

--- a/dynamiq/sandboxes/__init__.py
+++ b/dynamiq/sandboxes/__init__.py
@@ -1,4 +1,5 @@
 from .base import Sandbox, SandboxConfig, SandboxTool, ShellCommandResult
+from .cloudflare import CloudflareSandbox
 from .daytona import DaytonaSandbox
 from .e2b import E2BSandbox
 from .e2b_desktop import E2BDesktopSandbox
@@ -10,6 +11,7 @@ __all__ = [
     "SandboxConnectionError",
     "SandboxTool",
     "ShellCommandResult",
+    "CloudflareSandbox",
     "DaytonaSandbox",
     "E2BSandbox",
     "E2BDesktopSandbox",

--- a/dynamiq/sandboxes/cloudflare.py
+++ b/dynamiq/sandboxes/cloudflare.py
@@ -1,0 +1,349 @@
+import shlex
+import threading
+from typing import Any
+
+from pydantic import ConfigDict, Field, PrivateAttr, field_validator
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from dynamiq.connections import Cloudflare
+from dynamiq.connections.cloudflare_sandbox import (
+    SANDBOX_MARKER_PATH,
+    CloudflareRateLimitError,
+    CloudflareSandboxInstance,
+    resolve_workspace_path,
+)
+from dynamiq.nodes import Node
+from dynamiq.nodes.tools.code_interpreter import SandboxCreationErrorHandling
+from dynamiq.sandboxes.base import Sandbox, SandboxInfo, ShellCommandResult
+from dynamiq.sandboxes.exceptions import SandboxConnectionError
+from dynamiq.utils.logger import logger
+
+
+class CloudflareSandbox(Sandbox):
+    """Cloudflare Sandboxes implementation.
+
+    Runs commands and stores files in a Cloudflare sandbox reached through a
+    deployed sandbox bridge Worker (plain HTTP, no SDK). The container image and
+    instance type are fixed by the deployed Worker's wrangler configuration, so
+    unlike E2B/Daytona there are no template/image fields here. All file paths
+    are constrained to /workspace by the bridge.
+
+    Supports reconnecting to existing sandboxes by providing sandbox_id.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    connection: Cloudflare
+    base_path: str = Field(default="/workspace", description="Base path in the sandbox filesystem.")
+    timeout: int = Field(
+        default=3600,
+        description="Timeout budget in seconds for sandbox boot during creation and reconnection.",
+    )
+
+    envs: dict[str, str] | None = Field(
+        default=None,
+        description="Environment variables applied to every command executed in the sandbox.",
+    )
+    sandbox_id: str | None = Field(
+        default=None,
+        description="Existing sandbox ID to reconnect to. If None, a new sandbox is created.",
+    )
+    creation_error_handling: SandboxCreationErrorHandling = Field(
+        default_factory=SandboxCreationErrorHandling,
+        description="Retry and backoff config for sandbox creation and reconnection.",
+    )
+    _sandbox: CloudflareSandboxInstance | None = PrivateAttr(default=None)
+    _sandbox_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+
+    @field_validator("base_path")
+    @classmethod
+    def validate_base_path(cls, value: str) -> str:
+        """The bridge constrains all file operations to /workspace; fail fast otherwise."""
+        return resolve_workspace_path(value)
+
+    @property
+    def to_dict_exclude_params(self) -> dict[str, bool]:
+        """Exclude sensitive fields from serialization."""
+        return super().to_dict_exclude_params | {"envs": True}
+
+    def to_dict(self, **kwargs) -> dict[str, Any]:
+        """Convert the CloudflareSandbox instance to a dictionary."""
+        for_tracing = kwargs.get("for_tracing", False)
+        data = super().to_dict(**kwargs)
+        if not for_tracing and self.envs is not None:
+            data["envs"] = self.envs
+        return data
+
+    @property
+    def current_sandbox_id(self) -> str | None:
+        """Get the current sandbox ID (for saving/reconnecting later)."""
+        return self.sandbox_id
+
+    def _ensure_sandbox(self) -> CloudflareSandboxInstance:
+        """Lazily create or reconnect to a Cloudflare sandbox, with retries on capacity errors.
+
+        Uses double-checked locking so concurrent threads never create duplicate sandboxes.
+        """
+        if self._sandbox is not None:
+            return self._sandbox
+
+        with self._sandbox_lock:
+            if self._sandbox is not None:
+                return self._sandbox
+
+            client = self.connection.get_client()
+
+            if self.sandbox_id:
+                try:
+                    self._reconnect_with_retry()
+                    self._sandbox = CloudflareSandboxInstance(client, self.sandbox_id)
+                    logger.debug(f"Cloudflare sandbox reconnected: {self.sandbox_id}")
+                    return self._sandbox
+                except Exception as e:
+                    raise SandboxConnectionError(self.sandbox_id, cause=e, provider="Cloudflare") from e
+
+            self.sandbox_id = self._create_with_retry()
+            self._sandbox = CloudflareSandboxInstance(client, self.sandbox_id)
+            logger.debug(f"Cloudflare sandbox created: {self.sandbox_id}")
+            return self._sandbox
+
+    def _reconnect_with_retry(self) -> None:
+        """Verify an existing sandbox is alive and kept its state, with backoff on capacity errors.
+
+        Sandbox ids are Durable-Object addressed, so any well-formed id "exists" and
+        would silently get a fresh empty container; the creation marker distinguishes
+        a live sandbox from an expired one.
+        """
+        cfg = self.creation_error_handling
+        client = self.connection.get_client()
+
+        @retry(
+            retry=retry_if_exception_type(CloudflareRateLimitError),
+            stop=stop_after_attempt(cfg.max_retries),
+            wait=wait_exponential_jitter(
+                initial=cfg.initial_wait_seconds,
+                max=cfg.max_wait_seconds,
+                exp_base=cfg.exponential_base,
+                jitter=cfg.jitter,
+            ),
+            reraise=True,
+        )
+        def connect():
+            logger.debug(f"Reconnecting to Cloudflare sandbox: {self.sandbox_id}")
+            result = client.exec(self.sandbox_id, f"test -f {shlex.quote(SANDBOX_MARKER_PATH)}", timeout=self.timeout)
+            if result.exit_code != 0:
+                raise ValueError(f"Cloudflare sandbox {self.sandbox_id} has expired or was destroyed (state lost)")
+
+        connect()
+
+    def _create_with_retry(self) -> str:
+        """Create a new sandbox and boot its container, with backoff on capacity errors.
+
+        POST /sandbox only mints an id - the container is allocated lazily on the
+        first operation, so capacity errors surface there. Running the warm-up
+        command inside the retry loop makes CloudflareRateLimitError retryable and
+        leaves the creation marker plus the base directory in place.
+        """
+        cfg = self.creation_error_handling
+        client = self.connection.get_client()
+
+        @retry(
+            retry=retry_if_exception_type(CloudflareRateLimitError),
+            stop=stop_after_attempt(cfg.max_retries),
+            wait=wait_exponential_jitter(
+                initial=cfg.initial_wait_seconds,
+                max=cfg.max_wait_seconds,
+                exp_base=cfg.exponential_base,
+                jitter=cfg.jitter,
+            ),
+            reraise=True,
+        )
+        def create():
+            try:
+                sandbox_id = client.create_sandbox()
+                marker_dir = SANDBOX_MARKER_PATH.rsplit("/", 1)[0]
+                result = client.exec(
+                    sandbox_id,
+                    f"mkdir -p {shlex.quote(self.base_path)} {shlex.quote(marker_dir)} "
+                    f"&& touch {shlex.quote(SANDBOX_MARKER_PATH)}",
+                    timeout=self.timeout,
+                )
+                if result.exit_code != 0:
+                    raise ValueError(f"Failed to initialize Cloudflare sandbox: {result.stderr or result.stdout}")
+                return sandbox_id
+            except CloudflareRateLimitError:
+                logger.warning("Cloudflare sandbox creation rate-limited. Retrying with exponential backoff.")
+                raise
+
+        return create()
+
+    def run_command_shell(
+        self,
+        command: str,
+        timeout: int = 60,
+        run_in_background_enabled: bool = False,
+    ) -> ShellCommandResult:
+        """Execute a shell command in the Cloudflare sandbox."""
+        sandbox = self._ensure_sandbox()
+        logger.debug(f"CloudflareSandbox running command: {command[:100]}...")
+
+        try:
+            if run_in_background_enabled:
+                sandbox.exec(f"nohup {command} > /dev/null 2>&1 &", cwd=self.base_path, env=self.envs)
+                return ShellCommandResult(background=True)
+
+            result = sandbox.exec(command, cwd=self.base_path, env=self.envs, timeout=timeout)
+            if result.exit_code is None:
+                return ShellCommandResult(
+                    stdout=result.stdout,
+                    stderr=result.stderr or None,
+                    error="Command stream ended without an exit status (sandbox may have restarted)",
+                )
+            return ShellCommandResult(
+                stdout=result.stdout,
+                stderr=result.stderr or None,
+                exit_code=result.exit_code,
+            )
+        except Exception as e:
+            logger.error(f"Command execution failed: {e}")
+            return ShellCommandResult(error=str(e))
+
+    def upload_file(
+        self,
+        file_name: str,
+        content: bytes,
+        destination_path: str | None = None,
+        ensure_parent_dirs: bool = True,
+    ) -> str:
+        """Upload a file to the Cloudflare sandbox.
+
+        Parent directories are created automatically by the sandbox file API,
+        so ``ensure_parent_dirs`` needs no extra round-trip here.
+        """
+        sandbox = self._ensure_sandbox()
+
+        if destination_path is None:
+            destination_path = f"{self.base_path}/{file_name}"
+
+        try:
+            sandbox.write_file(destination_path, content)
+            logger.debug(f"CloudflareSandbox uploaded file: {destination_path}")
+            return destination_path
+        except Exception as e:
+            logger.error(f"Failed to upload file {file_name}: {e}")
+            raise
+
+    def list_files(self, target_dir: str | None = None) -> list[str]:
+        """List files in the Cloudflare sandbox directory."""
+        sandbox = self._ensure_sandbox()
+        if target_dir is None:
+            target_dir = self.base_path
+
+        try:
+            result = sandbox.exec(
+                f"find {shlex.quote(target_dir)} -maxdepth 4 -type f 2>/dev/null "
+                f"| head -{int(self.max_output_files)}"
+            )
+            if result.exit_code != 0:
+                logger.warning(f"CloudflareSandbox list_files failed for {target_dir}: {result.stderr}")
+                return []
+            return [line for line in (result.stdout or "").splitlines() if line.strip()]
+        except Exception as e:
+            logger.warning(f"CloudflareSandbox list_files failed for {target_dir}: {e}")
+            return []
+
+    def exists(self, file_path: str) -> bool:
+        """Return True when file exists in sandbox filesystem."""
+        try:
+            sandbox = self._ensure_sandbox()
+            resolved_path = self._resolve_path(file_path)
+            result = sandbox.exec(f"test -f {shlex.quote(resolved_path)}")
+            return result.exit_code == 0
+        except Exception as e:
+            logger.debug(f"CloudflareSandbox exists({file_path}) failed (treating as missing): {e}")
+            return False
+
+    def retrieve(self, file_path: str) -> bytes:
+        """Read file bytes from sandbox filesystem."""
+        sandbox = self._ensure_sandbox()
+        resolved_path = self._resolve_path(file_path)
+        return sandbox.read_file(resolved_path)
+
+    def get_tools(self, llm: Any = None) -> list[Node]:
+        """Return tools this sandbox provides for agent use."""
+        from dynamiq.nodes.tools.file_tools import FileReadTool, FileWriteTool
+        from dynamiq.nodes.tools.todo_tools import TodoWriteTool
+        from dynamiq.sandboxes.tools.sandbox_info import SandboxInfoTool
+        from dynamiq.sandboxes.tools.shell import SandboxShellTool
+
+        tools = [
+            SandboxShellTool(sandbox=self),
+            FileWriteTool(file_store=self, absolute_file_paths_allowed=True),
+            TodoWriteTool(file_store=self),
+            SandboxInfoTool(sandbox=self),
+        ]
+        if llm is not None:
+            tools.append(FileReadTool(file_store=self, llm=llm, absolute_file_paths_allowed=True))
+
+        return tools
+
+    def get_sandbox_info(self, port: int | None = None) -> SandboxInfo:
+        """Return sandbox metadata including optional public tunnel URL for a port."""
+        public_host: str | None = None
+        public_url: str | None = None
+        public_url_error: str | None = None
+        if port is not None:
+            try:
+                self._ensure_sandbox()
+                client = self.connection.get_client()
+                tunnel = client.create_tunnel(self.sandbox_id, port)
+                public_url = tunnel.get("url")
+                public_host = tunnel.get("hostname")
+                if public_host is None and public_url:
+                    public_host = public_url.split("://", 1)[-1]
+            except Exception as e:
+                logger.debug("create_tunnel failed: %s", e)
+                public_url_error = str(e)
+        return SandboxInfo(
+            base_path=self.base_path,
+            sandbox_id=self.sandbox_id,
+            public_host=public_host,
+            public_url=public_url,
+            public_url_error=public_url_error,
+        )
+
+    def close(self, kill: bool = False) -> None:
+        """Close the Cloudflare sandbox connection.
+
+        Args:
+            kill: If False (default), just disconnects but keeps the sandbox alive
+                  for reconnection (the container sleeps on idle). If True,
+                  destroys the sandbox.
+        """
+        if self._sandbox:
+            try:
+                if kill:
+                    self._sandbox.destroy()
+                    logger.debug(f"Cloudflare sandbox destroyed: {self.sandbox_id}")
+                    self.sandbox_id = None
+                else:
+                    logger.debug(f"Cloudflare sandbox disconnected (kept alive): {self.sandbox_id}")
+            except Exception as e:
+                logger.warning(f"CloudflareSandbox close() failed: {e}")
+            finally:
+                self._sandbox = None
+
+    def __enter__(self):
+        """Context manager entry."""
+        self._ensure_sandbox()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()
+
+    def __del__(self):
+        """Destructor - attempt to close sandbox on garbage collection."""
+        try:
+            self.close()
+        except Exception:
+            ...

--- a/examples/components/agents/agents/agent_cloudflare_sandbox.py
+++ b/examples/components/agents/agents/agent_cloudflare_sandbox.py
@@ -1,0 +1,153 @@
+"""Example demonstrating the use of CloudflareSandbox with an Agent.
+
+This example shows how to configure an agent with a Cloudflare sandbox for:
+- Remote file storage in an isolated Cloudflare container (/workspace)
+- File read/write/list operations via sandbox tools
+- Shell command execution via SandboxShellTool
+
+Prerequisites:
+- A deployed Cloudflare sandbox bridge Worker
+  (https://developers.cloudflare.com/sandbox/bridge/):
+    npm create cloudflare -- sandbox-bridge --template=cloudflare/sandbox-sdk/bridge/worker
+    npx wrangler secret put SANDBOX_API_KEY
+    npx wrangler deploy
+- CLOUDFLARE_SANDBOX_API_URL set to the deployed Worker URL
+- CLOUDFLARE_SANDBOX_API_KEY set to the Worker's SANDBOX_API_KEY secret
+
+For low-latency sandbox startup, set WARM_POOL_TARGET > 0 in the Worker's vars so
+new sandboxes are assigned pre-booted containers instead of cold-starting (~1-3s).
+Each sandbox runs in its own VM; warm-pool containers are assigned exclusively to
+one sandbox id and never reused across sandboxes.
+"""
+
+import os
+
+from dynamiq import Workflow
+from dynamiq.callbacks import TracingCallbackHandler
+from dynamiq.connections import Cloudflare as CloudflareConnection
+from dynamiq.flows import Flow
+from dynamiq.nodes.agents import Agent
+from dynamiq.nodes.types import InferenceMode
+from dynamiq.runnables import RunnableConfig
+from dynamiq.sandboxes import SandboxConfig
+from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+from dynamiq.utils.logger import logger
+from examples.llm_setup import setup_llm
+
+AGENT_ROLE = """
+You are a helpful assistant that can execute shell commands in a remote sandbox environment.
+ Use write tool to write to the sandbox
+"""
+
+EXAMPLE_QUERY = """
+1. Create a file called 'hello.py' with a Python script that prints "Hello from Cloudflare!"
+2. Edit it with edit action, by changing it to 'Hello from Cloudflare!!!'
+3. Run the script: python3 hello.py
+4. Show the output
+"""
+
+
+def setup_agent(api_url: str = None, api_key: str = None) -> tuple[Agent, CloudflareSandbox]:
+    """
+    Set up and return an agent configured with a Cloudflare sandbox.
+
+    Args:
+        api_url: Deployed bridge Worker URL. Defaults to CLOUDFLARE_SANDBOX_API_URL.
+        api_key: Bridge SANDBOX_API_KEY secret. Defaults to CLOUDFLARE_SANDBOX_API_KEY.
+
+    Returns:
+        tuple: (Agent, CloudflareSandbox) - Configured agent and sandbox backend.
+    """
+    url = api_url or os.getenv("CLOUDFLARE_SANDBOX_API_URL")
+    key = api_key or os.getenv("CLOUDFLARE_SANDBOX_API_KEY")
+    if not url or not key:
+        raise ValueError(
+            "Cloudflare sandbox bridge URL and API key are required. Set the "
+            "CLOUDFLARE_SANDBOX_API_URL and CLOUDFLARE_SANDBOX_API_KEY environment variables."
+        )
+
+    llm = setup_llm(model_provider="gpt", model_name="gpt-4o", temperature=0.2)
+
+    cloudflare_connection = CloudflareConnection(url=url, api_key=key)
+
+    # Create Cloudflare sandbox backend (all files live under /workspace)
+    cloudflare_sandbox = CloudflareSandbox(
+        connection=cloudflare_connection,
+        base_path="/workspace",
+    )
+
+    sandbox_config = SandboxConfig(
+        enabled=True,
+        backend=cloudflare_sandbox,
+    )
+
+    agent = Agent(
+        name="CloudflareSandboxAgent",
+        id="cloudflare-sandbox-agent",
+        llm=llm,
+        sandbox=sandbox_config,
+        role=AGENT_ROLE,
+        inference_mode=InferenceMode.XML,
+        max_loops=10,
+    )
+
+    return agent, cloudflare_sandbox
+
+
+def run_workflow(
+    agent: Agent = None,
+    sandbox: CloudflareSandbox = None,
+    input_prompt: str = EXAMPLE_QUERY,
+) -> str:
+    """
+    Run the agent workflow with a Cloudflare sandbox.
+
+    Args:
+        agent: The agent to use. If None, will create a new one.
+        sandbox: The Cloudflare sandbox backend. If None, will be created with agent.
+        input_prompt: The input prompt for the agent.
+
+    Returns:
+        str: The agent's output content.
+    """
+    if agent is None:
+        agent, sandbox = setup_agent()
+
+    tracing = TracingCallbackHandler()
+    wf = Workflow(flow=Flow(nodes=[agent]))
+
+    try:
+        result = wf.run(
+            input_data={"input": input_prompt},
+            config=RunnableConfig(callbacks=[tracing]),
+        )
+
+        output = result.output[agent.id]["output"]["content"]
+        print(f"\n=== Agent Output ===\n{output}")
+
+        return output
+
+    except Exception as e:
+        logger.exception(f"An error occurred: {e}")
+        return f"Error: {e}"
+
+    finally:
+        if sandbox:
+            try:
+                sandbox.close(kill=True)
+                print("\nCloudflare sandbox closed successfully.")
+            except Exception as e:
+                logger.warning(f"Failed to close Cloudflare sandbox: {e}")
+
+
+if __name__ == "__main__":
+    print("=== Cloudflare Sandbox Agent Example ===\n")
+
+    if not os.getenv("CLOUDFLARE_SANDBOX_API_URL") or not os.getenv("CLOUDFLARE_SANDBOX_API_KEY"):
+        print("Warning: CLOUDFLARE_SANDBOX_API_URL / CLOUDFLARE_SANDBOX_API_KEY not set.")
+        print("Deploy the bridge Worker and set them before running this example:")
+        print("  export CLOUDFLARE_SANDBOX_API_URL='https://your-sandbox-bridge.workers.dev'")
+        print("  export CLOUDFLARE_SANDBOX_API_KEY='your-sandbox-api-key'\n")
+        exit(1)
+
+    result = run_workflow()

--- a/examples/components/core/dag/agent_cloudflare_sandbox.yaml
+++ b/examples/components/core/dag/agent_cloudflare_sandbox.yaml
@@ -1,0 +1,37 @@
+connections:
+  openai-conn:
+    type: dynamiq.connections.OpenAI
+  cloudflare-conn:
+    type: dynamiq.connections.Cloudflare
+    url: ${oc.env:CLOUDFLARE_SANDBOX_API_URL}
+    api_key: ${oc.env:CLOUDFLARE_SANDBOX_API_KEY}
+
+nodes:
+  sandbox-agent:
+    type: dynamiq.nodes.agents.Agent
+    llm:
+      id: sandbox-agent-llm
+      type: dynamiq.nodes.llms.OpenAI
+      connection: openai-conn
+      model: gpt-4o
+    role: "a helpful assistant that can execute shell commands in a sandbox environment."
+    sandbox:
+      enabled: true
+      backend:
+        type: dynamiq.sandboxes.CloudflareSandbox
+        connection: cloudflare-conn
+    max_loops: 15
+    inference_mode: XML
+    summarization_config:
+      enabled: true
+
+flows:
+  sandbox-agent-flow:
+    name: Sandbox Agent Flow
+    nodes:
+      - sandbox-agent
+
+workflows:
+  sandbox-agent-workflow:
+    flow: sandbox-agent-flow
+    version: 1

--- a/tests/integration/nodes/agents/test_agent_sandbox.py
+++ b/tests/integration/nodes/agents/test_agent_sandbox.py
@@ -249,6 +249,70 @@ def test_agent_e2b_sandbox_yaml_roundtrip_no_duplicate_tools(tmp_path):
     assert isinstance(roundtrip_agent.sandbox.backend, E2BSandbox)
 
 
+def test_agent_cloudflare_sandbox_yaml_roundtrip_no_duplicate_tools(tmp_path):
+    """Roundtrip for the Cloudflare backend: dump → load → dump → load with init_components.
+
+    Mirrors the E2B roundtrip above; ensures the CloudflareSandbox backend class and its
+    connection survive serialization and sandbox tools are not duplicated.
+    """
+    from dynamiq.connections import Cloudflare
+    from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+
+    cloudflare_conn = Cloudflare(id="cloudflare-conn", api_key="test-key", url="https://bridge.test.workers.dev")
+    openai_conn = OpenAIConnection(id="openai-conn", api_key="test-key")
+
+    backend = CloudflareSandbox(connection=cloudflare_conn)
+    sandbox_config = SandboxConfig(enabled=True, backend=backend)
+
+    agent = Agent(
+        id="cloudflare-sandbox-agent",
+        name="Cloudflare Sandbox Agent",
+        llm=OpenAI(
+            id="cloudflare-sandbox-agent-llm",
+            connection=openai_conn,
+            model="gpt-4o",
+        ),
+        role="a helpful assistant that can execute shell commands in a sandbox.",
+        sandbox=sandbox_config,
+        max_loops=15,
+    )
+
+    workflow = Workflow(
+        id="cloudflare-sandbox-workflow",
+        flow=Flow(id="cloudflare-sandbox-flow", name="Cloudflare Sandbox Agent Flow", nodes=[agent]),
+        version="1",
+    )
+
+    yaml_path = tmp_path / "agent_cloudflare_sandbox.yaml"
+    workflow.to_yaml_file(yaml_path)
+
+    loaded = Workflow.from_yaml_file(str(yaml_path), init_components=True)
+    loaded_agent = loaded.flow.nodes[0]
+    assert isinstance(loaded_agent, Agent)
+    assert loaded_agent.sandbox is not None
+    assert loaded_agent.sandbox.enabled
+    assert isinstance(loaded_agent.sandbox.backend, CloudflareSandbox)
+    assert loaded_agent.sandbox.backend.base_path == "/workspace"
+    assert loaded_agent.sandbox.backend.connection.url == "https://bridge.test.workers.dev"
+
+    shell_tools_first = [t for t in loaded_agent.tools if isinstance(t, SandboxShellTool)]
+    assert len(shell_tools_first) == 1, "First load should have exactly one SandboxShellTool"
+
+    roundtrip_path = tmp_path / "agent_cloudflare_sandbox_roundtrip.yaml"
+    loaded.to_yaml_file(roundtrip_path)
+    roundtrip = Workflow.from_yaml_file(str(roundtrip_path), init_components=True)
+
+    roundtrip_agent = roundtrip.flow.nodes[0]
+    assert isinstance(roundtrip_agent, Agent)
+
+    shell_tools_roundtrip = [t for t in roundtrip_agent.tools if isinstance(t, SandboxShellTool)]
+    assert len(shell_tools_roundtrip) == 1, "After roundtrip, SandboxShellTool must not be duplicated"
+
+    assert roundtrip_agent.sandbox is not None
+    assert roundtrip_agent.sandbox.enabled
+    assert isinstance(roundtrip_agent.sandbox.backend, CloudflareSandbox)
+
+
 def test_agent_with_sandbox_returns_files(mocker):
     """Agent with sandbox collects files explicitly listed in <output_files>."""
     from litellm import ModelResponse

--- a/tests/unit/connections/test_cloudflare_sandbox_client.py
+++ b/tests/unit/connections/test_cloudflare_sandbox_client.py
@@ -1,0 +1,360 @@
+"""Unit tests for the Cloudflare sandbox bridge HTTP client (no network).
+
+Uses the ``requests_mock`` fixture provided by the requests-mock pytest plugin.
+"""
+
+import base64
+import json
+
+import pytest
+import requests
+
+from dynamiq.connections.cloudflare_sandbox import (
+    CloudflareRateLimitError,
+    CloudflareSandboxClient,
+    CloudflareSandboxError,
+    CloudflareSandboxInstance,
+    resolve_workspace_path,
+)
+
+BASE_URL = "https://bridge.example.workers.dev"
+SANDBOX_ID = "abcdefgh234567"
+
+
+@pytest.fixture
+def client():
+    return CloudflareSandboxClient(url=BASE_URL, api_key="test-key")
+
+
+def sse_body(events: list[tuple[str, str]]) -> str:
+    """Build an SSE body the way the bridge does (event + data lines)."""
+    return "".join(f"event: {event}\ndata: {data}\n\n" for event, data in events)
+
+
+def b64(text: str) -> str:
+    return base64.b64encode(text.encode()).decode()
+
+
+class TestResolveWorkspacePath:
+    def test_absolute_path_inside_workspace(self):
+        assert resolve_workspace_path("/workspace/output/x.txt") == "/workspace/output/x.txt"
+
+    def test_relative_path_is_anchored_to_workspace(self):
+        assert resolve_workspace_path("output/x.txt") == "/workspace/output/x.txt"
+
+    def test_workspace_root_allowed(self):
+        assert resolve_workspace_path("/workspace") == "/workspace"
+
+    def test_dot_segments_normalized(self):
+        assert resolve_workspace_path("/workspace/a/../b/./c.txt") == "/workspace/b/c.txt"
+
+    @pytest.mark.parametrize("path", ["/etc/passwd", "/workspace/../etc/passwd", "/home/user/x.txt"])
+    def test_paths_escaping_workspace_rejected(self, path):
+        with pytest.raises(ValueError, match="must stay inside /workspace"):
+            resolve_workspace_path(path)
+
+
+class TestClientRequests:
+    def test_create_sandbox(self, client, requests_mock):
+        requests_mock.post(f"{BASE_URL}/v1/sandbox", json={"id": SANDBOX_ID})
+
+        assert client.create_sandbox() == SANDBOX_ID
+        assert requests_mock.last_request.headers["Authorization"] == "Bearer test-key"
+
+    def test_destroy_sandbox(self, client, requests_mock):
+        requests_mock.delete(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}", status_code=204)
+
+        client.destroy_sandbox(SANDBOX_ID)
+        assert requests_mock.called
+
+    @pytest.mark.parametrize("bad_id", ["NOT/VALID", "abcd\n", "", "abc1"])
+    def test_invalid_sandbox_id_rejected_locally(self, client, bad_id):
+        with pytest.raises(ValueError, match="Invalid Cloudflare sandbox id"):
+            client.destroy_sandbox(bad_id)
+
+    def test_is_running(self, client, requests_mock):
+        requests_mock.get(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/running", json={"running": True})
+
+        assert client.is_running(SANDBOX_ID) is True
+
+    def test_read_file(self, client, requests_mock):
+        requests_mock.get(
+            f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/file/workspace/output/data.bin", content=b"\x00\x01binary"
+        )
+
+        assert client.read_file(SANDBOX_ID, "/workspace/output/data.bin") == b"\x00\x01binary"
+
+    def test_write_file(self, client, requests_mock):
+        requests_mock.put(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/file/workspace/input/a.txt", json={"ok": True})
+
+        client.write_file(SANDBOX_ID, "/workspace/input/a.txt", b"hello")
+        assert requests_mock.last_request.body == b"hello"
+
+    def test_file_path_outside_workspace_rejected(self, client):
+        with pytest.raises(ValueError, match="must stay inside /workspace"):
+            client.read_file(SANDBOX_ID, "/etc/passwd")
+
+    def test_file_url_keeps_uri_reserved_characters_raw(self, client, requests_mock):
+        """decodeURI on the bridge never decodes : @ & = + $ , ; - they must be sent raw."""
+        requests_mock.get(
+            f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/file/workspace/output/report:v2,final+1.csv", content=b"x"
+        )
+
+        client.read_file(SANDBOX_ID, "/workspace/output/report:v2,final+1.csv")
+
+        assert (
+            requests_mock.last_request.path == f"/v1/sandbox/{SANDBOX_ID}/file/workspace/output/report:v2,final+1.csv"
+        )
+
+    def test_file_url_percent_encodes_unsafe_characters(self, client, requests_mock):
+        """Characters like spaces and # must be percent-encoded so the URL stays intact."""
+        requests_mock.get(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/file/workspace/output/report%20%231.csv", content=b"x")
+
+        client.read_file(SANDBOX_ID, "/workspace/output/report #1.csv")
+
+        assert requests_mock.last_request.url.endswith("/file/workspace/output/report%20%231.csv")
+
+    def test_health(self, client, requests_mock):
+        requests_mock.get(f"{BASE_URL}/health", json={"ok": True})
+
+        assert client.health() is True
+
+    def test_health_false_on_http_error(self, client, requests_mock):
+        requests_mock.get(f"{BASE_URL}/health", status_code=500, text="boom")
+
+        assert client.health() is False
+
+    def test_health_false_on_not_ok_body(self, client, requests_mock):
+        requests_mock.get(f"{BASE_URL}/health", json={"ok": False, "errors": ["missing binding"]})
+
+        assert client.health() is False
+
+    def test_health_false_on_connection_error(self, client, requests_mock):
+        requests_mock.get(f"{BASE_URL}/health", exc=requests.exceptions.ConnectTimeout)
+
+        assert client.health() is False
+
+    def test_create_session(self, client, requests_mock):
+        requests_mock.post(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/session", json={"id": "sess1"})
+
+        assert client.create_session(SANDBOX_ID, cwd="/workspace", env={"A": "b"}) == "sess1"
+        assert requests_mock.last_request.json() == {"cwd": "/workspace", "env": {"A": "b"}}
+
+    def test_create_tunnel(self, client, requests_mock):
+        tunnel = {"id": "t1", "port": 8000, "url": "https://x.trycloudflare.com", "hostname": "x.trycloudflare.com"}
+        requests_mock.post(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/tunnel/8000", json=tunnel)
+
+        assert client.create_tunnel(SANDBOX_ID, 8000) == tunnel
+
+
+class TestExec:
+    def exec_url(self):
+        return f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/exec"
+
+    def test_exec_parses_sse_stream(self, client, requests_mock):
+        body = sse_body(
+            [
+                ("stdout", b64("hello ")),
+                ("stdout", b64("world\n")),
+                ("stderr", b64("warning\n")),
+                ("exit", json.dumps({"exit_code": 0})),
+            ]
+        )
+        requests_mock.post(self.exec_url(), text=body, headers={"Content-Type": "text/event-stream"})
+
+        result = client.exec(SANDBOX_ID, "echo hello world")
+
+        assert result.exit_code == 0
+        assert result.stdout == "hello world\n"
+        assert result.stderr == "warning\n"
+
+    def test_exec_builds_bash_argv_for_string_command(self, client, requests_mock):
+        requests_mock.post(self.exec_url(), text=sse_body([("exit", json.dumps({"exit_code": 0}))]))
+
+        client.exec(SANDBOX_ID, "echo hi", cwd="/workspace/output", timeout=30)
+
+        request_body = requests_mock.last_request.json()
+        assert request_body["argv"] == ["bash", "-c", "echo hi"]
+        assert request_body["timeout_ms"] == 30000
+        assert request_body["cwd"] == "/workspace/output"
+
+    def test_exec_read_timeout_headroom(self, client, requests_mock):
+        """The socket read timeout must exceed the command timeout so long commands are not cut off."""
+        requests_mock.post(self.exec_url(), text=sse_body([("exit", json.dumps({"exit_code": 0}))]))
+
+        client.exec(SANDBOX_ID, "sleep 500", timeout=600)
+
+        assert requests_mock.last_request.timeout == (30.0, 720)
+
+    def test_exec_env_is_prepended_via_env_command(self, client, requests_mock):
+        requests_mock.post(self.exec_url(), text=sse_body([("exit", json.dumps({"exit_code": 0}))]))
+
+        client.exec(SANDBOX_ID, "printenv FOO", env={"FOO": "bar baz"})
+
+        assert requests_mock.last_request.json()["argv"] == ["env", "FOO=bar baz", "bash", "-c", "printenv FOO"]
+
+    def test_exec_list_command_passed_as_argv(self, client, requests_mock):
+        requests_mock.post(self.exec_url(), text=sse_body([("exit", json.dumps({"exit_code": 0}))]))
+
+        client.exec(SANDBOX_ID, ["python3", "-V"])
+
+        assert requests_mock.last_request.json()["argv"] == ["python3", "-V"]
+
+    def test_exec_session_id_header(self, client, requests_mock):
+        requests_mock.post(self.exec_url(), text=sse_body([("exit", json.dumps({"exit_code": 0}))]))
+
+        client.exec(SANDBOX_ID, "true", session_id="sess1")
+
+        assert requests_mock.last_request.headers["Session-Id"] == "sess1"
+
+    def test_exec_nonzero_exit_code(self, client, requests_mock):
+        body = sse_body([("stderr", b64("boom")), ("exit", json.dumps({"exit_code": 2}))])
+        requests_mock.post(self.exec_url(), text=body)
+
+        result = client.exec(SANDBOX_ID, "exit 2")
+
+        assert result.exit_code == 2
+        assert result.stderr == "boom"
+
+    def test_exec_error_event_raises(self, client, requests_mock):
+        body = sse_body([("error", json.dumps({"error": "exec failed: kaput", "code": "exec_transport_error"}))])
+        requests_mock.post(self.exec_url(), text=body)
+
+        with pytest.raises(CloudflareSandboxError, match="kaput"):
+            client.exec(SANDBOX_ID, "true")
+
+    def test_exec_error_event_mid_stream_raises(self, client, requests_mock):
+        """A transport error arriving after some stdout must still raise."""
+        body = sse_body(
+            [
+                ("stdout", b64("partial output")),
+                ("error", json.dumps({"error": "container evicted", "code": "exec_transport_error"})),
+            ]
+        )
+        requests_mock.post(self.exec_url(), text=body)
+
+        with pytest.raises(CloudflareSandboxError, match="container evicted"):
+            client.exec(SANDBOX_ID, "true")
+
+    def test_exec_stream_without_trailing_blank_line(self, client, requests_mock):
+        """The final event must be flushed even when the stream ends without a blank line."""
+        body = sse_body([("stdout", b64("done\n")), ("exit", json.dumps({"exit_code": 0}))]).rstrip("\n")
+        requests_mock.post(self.exec_url(), text=body)
+
+        result = client.exec(SANDBOX_ID, "echo done")
+
+        assert result.exit_code == 0
+        assert result.stdout == "done\n"
+
+    def test_exec_multibyte_character_split_across_chunks(self, client, requests_mock):
+        """UTF-8 characters split across SSE chunk boundaries must survive intact."""
+        encoded = "héllo".encode()
+        first, second = encoded[:2], encoded[2:]  # split mid 'é' (0xC3 | 0xA9)
+        body = sse_body(
+            [
+                ("stdout", base64.b64encode(first).decode()),
+                ("stdout", base64.b64encode(second).decode()),
+                ("exit", json.dumps({"exit_code": 0})),
+            ]
+        )
+        requests_mock.post(self.exec_url(), text=body)
+
+        result = client.exec(SANDBOX_ID, "echo héllo")
+
+        assert result.stdout == "héllo"
+
+    def test_exec_invalid_base64_falls_back_to_raw_data(self, client, requests_mock):
+        body = sse_body([("stdout", "!!not-base64!!"), ("exit", json.dumps({"exit_code": 0}))])
+        requests_mock.post(self.exec_url(), text=body)
+
+        result = client.exec(SANDBOX_ID, "true")
+
+        assert result.stdout == "!!not-base64!!"
+
+    def test_exec_missing_exit_event_yields_none_exit_code(self, client, requests_mock):
+        """A stream that dies before the exit event must not report success."""
+        body = sse_body([("stdout", b64("partial"))])
+        requests_mock.post(self.exec_url(), text=body)
+
+        result = client.exec(SANDBOX_ID, "true")
+
+        assert result.exit_code is None
+        assert result.stdout == "partial"
+
+    def test_exec_stream_disconnect_wrapped(self):
+        """Connection drops mid-stream surface as CloudflareSandboxError, not raw requests errors."""
+
+        class BrokenStreamResponse:
+            encoding = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def iter_lines(self, decode_unicode=True):
+                yield "event: stdout"
+                yield f"data: {b64('partial')}"
+                yield ""
+                raise requests.exceptions.ChunkedEncodingError("connection broken mid-stream")
+
+        with pytest.raises(CloudflareSandboxError, match="stream failed"):
+            CloudflareSandboxClient._parse_exec_sse(BrokenStreamResponse())
+
+
+class TestErrorMapping:
+    def test_http_401_raises_sandbox_error(self, client, requests_mock):
+        requests_mock.post(
+            f"{BASE_URL}/v1/sandbox", status_code=401, json={"error": "Unauthorized", "code": "unauthorized"}
+        )
+
+        with pytest.raises(CloudflareSandboxError, match="Unauthorized") as exc_info:
+            client.create_sandbox()
+        assert not isinstance(exc_info.value, CloudflareRateLimitError)
+        assert exc_info.value.status_code == 401
+
+    def test_http_429_raises_rate_limit_error(self, client, requests_mock):
+        requests_mock.post(f"{BASE_URL}/v1/sandbox", status_code=429, json={"error": "slow down"})
+
+        with pytest.raises(CloudflareRateLimitError):
+            client.create_sandbox()
+
+    def test_capacity_exceeded_503_raises_rate_limit_error(self, client, requests_mock):
+        requests_mock.post(
+            f"{BASE_URL}/v1/sandbox",
+            status_code=503,
+            json={"error": "instance limit reached", "code": "capacity_exceeded"},
+        )
+
+        with pytest.raises(CloudflareRateLimitError, match="instance limit reached"):
+            client.create_sandbox()
+
+    def test_non_json_error_body(self, client, requests_mock):
+        requests_mock.post(f"{BASE_URL}/v1/sandbox", status_code=502, text="Bad Gateway")
+
+        with pytest.raises(CloudflareSandboxError, match="HTTP 502"):
+            client.create_sandbox()
+
+    def test_missing_url_raises(self):
+        with pytest.raises(ValueError, match="bridge URL is required"):
+            CloudflareSandboxClient(url="", api_key="k")
+
+
+class TestSandboxInstance:
+    def test_instance_delegates_to_client(self, client, requests_mock):
+        requests_mock.post(
+            f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/exec",
+            text=sse_body([("stdout", b64("ok")), ("exit", json.dumps({"exit_code": 0}))]),
+        )
+        requests_mock.put(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/file/workspace/f.txt", json={"ok": True})
+        requests_mock.get(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}/file/workspace/f.txt", content=b"data")
+        requests_mock.delete(f"{BASE_URL}/v1/sandbox/{SANDBOX_ID}", status_code=204)
+
+        instance = CloudflareSandboxInstance(client, SANDBOX_ID)
+
+        assert instance.exec("echo ok").stdout == "ok"
+        instance.write_file("/workspace/f.txt", b"data")
+        assert instance.read_file("/workspace/f.txt") == b"data"
+        instance.destroy()
+        assert requests_mock.call_count == 4

--- a/tests/unit/nodes/schema_generation/test_schemas.py
+++ b/tests/unit/nodes/schema_generation/test_schemas.py
@@ -3,7 +3,7 @@ import pytest
 from dynamiq.nodes.agents import Agent
 from dynamiq.nodes.llms import Anthropic, Gemini, OpenAI, WatsonX
 from dynamiq.nodes.node import ConnectionNode
-from dynamiq.nodes.tools import E2BInterpreterTool, ScaleSerpTool, TavilyTool
+from dynamiq.nodes.tools import CloudflareInterpreterTool, E2BInterpreterTool, ScaleSerpTool, TavilyTool
 from dynamiq.nodes.utils import Input, Output
 from dynamiq.serializers.loaders.yaml import WorkflowYAMLLoader
 from dynamiq.utils.workflow_generation import (
@@ -27,6 +27,7 @@ from dynamiq.utils.workflow_generation import (
         (Anthropic, {"models": ["model1", "model2"]}),
         (WatsonX, {"models": ["model1", "model2"]}),
         (E2BInterpreterTool, {}),
+        (CloudflareInterpreterTool, {}),
         (ScaleSerpTool, {}),
         (TavilyTool, {}),
         (KnowledgebaseRetriever, {}),

--- a/tests/unit/nodes/tools/test_cloudflare_sandbox.py
+++ b/tests/unit/nodes/tools/test_cloudflare_sandbox.py
@@ -1,0 +1,367 @@
+"""Unit tests for CloudflareInterpreterTool with a mocked bridge client."""
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynamiq.connections import Cloudflare as CloudflareConnection
+from dynamiq.connections.cloudflare_sandbox import CloudflareExecResult
+
+SANDBOX_ID = "testsandboxid234"
+
+
+def exec_result(exit_code=0, stdout="", stderr=""):
+    return CloudflareExecResult(exit_code=exit_code, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def mock_cloudflare_client():
+    """Create a fully mocked Cloudflare bridge client."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = SANDBOX_ID
+    mock_client.is_running.return_value = True
+    mock_client.exec.return_value = exec_result()
+
+    with patch.object(CloudflareConnection, "get_client", return_value=mock_client):
+        yield mock_client
+
+
+@pytest.fixture
+def cloudflare_tool(mock_cloudflare_client):
+    """Create a CloudflareInterpreterTool with mocked client."""
+    from dynamiq.nodes.tools.cloudflare_sandbox import CloudflareInterpreterTool
+
+    return CloudflareInterpreterTool(
+        connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+        persistent_sandbox=True,
+        is_optimized_for_agents=False,
+    )
+
+
+def make_exec_side_effect(mock_client, python_result=None, shell_result=None, pip_result=None):
+    """Route client.exec calls by command prefix, defaulting to success."""
+
+    def side_effect(sandbox_id, command, **kwargs):
+        cmd = command if isinstance(command, str) else " ".join(command)
+        if cmd.startswith("python3") and python_result is not None:
+            return python_result
+        if "pip install" in cmd and pip_result is not None:
+            return pip_result
+        if cmd.startswith(("mkdir", "rm -f", "test -")):
+            return exec_result()
+        if shell_result is not None:
+            return shell_result
+        return exec_result()
+
+    mock_client.exec.side_effect = side_effect
+
+
+def test_python_execution(cloudflare_tool, mock_cloudflare_client):
+    """Python code is uploaded as a script and executed with python3."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, python_result=exec_result(stdout="42"))
+
+    result = cloudflare_tool.execute(CodeInterpreterInputSchema(python="print(42)"))
+
+    assert result["content"]["code_execution"] == "42"
+    mock_cloudflare_client.write_file.assert_called()
+    script_path = mock_cloudflare_client.write_file.call_args[0][1]
+    assert script_path.startswith("/workspace/.dynamiq/script_")
+    assert mock_cloudflare_client.write_file.call_args[0][2] == b"print(42)"
+
+
+def test_python_execution_with_params(cloudflare_tool, mock_cloudflare_client):
+    """Params are injected as Python globals before the user code."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, python_result=exec_result(stdout="7"))
+
+    cloudflare_tool.execute(CodeInterpreterInputSchema(python="print(x)", params={"x": 7}))
+
+    uploaded_code = mock_cloudflare_client.write_file.call_args[0][2].decode()
+    assert "x = 7" in uploaded_code
+    assert "print(x)" in uploaded_code
+
+
+def test_shell_command_execution(cloudflare_tool, mock_cloudflare_client):
+    """Shell command execution returns stdout."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, shell_result=exec_result(stdout="hello world"))
+
+    result = cloudflare_tool.execute(CodeInterpreterInputSchema(shell_command="echo hello world"))
+
+    assert result["content"]["shell_command_execution"] == "hello world"
+
+
+def test_shell_command_plumbs_env_cwd_timeout(cloudflare_tool, mock_cloudflare_client):
+    """env, cwd, and timeout from the input schema must reach the client exec call."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, shell_result=exec_result(stdout="1"))
+
+    cloudflare_tool.execute(
+        CodeInterpreterInputSchema(shell_command="printenv X", env={"X": "1"}, cwd="/workspace", timeout=30)
+    )
+
+    shell_calls = [c for c in mock_cloudflare_client.exec.call_args_list if c.args[1] == "printenv X"]
+    assert len(shell_calls) == 1
+    assert shell_calls[0].kwargs["env"] == {"X": "1"}
+    assert shell_calls[0].kwargs["cwd"] == "/workspace"
+    assert shell_calls[0].kwargs["timeout"] == 30
+
+
+def test_shell_command_default_cwd_is_output_dir(cloudflare_tool, mock_cloudflare_client):
+    """Without an explicit cwd, shell commands run in the output directory."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, shell_result=exec_result(stdout="ok"))
+
+    cloudflare_tool.execute(CodeInterpreterInputSchema(shell_command="ls"))
+
+    shell_calls = [c for c in mock_cloudflare_client.exec.call_args_list if c.args[1] == "ls"]
+    assert shell_calls[0].kwargs["cwd"] == "/workspace/output"
+
+
+def test_execute_creates_input_output_dirs(cloudflare_tool, mock_cloudflare_client):
+    """execute() must create the input/output dirs (default shell cwd depends on it)."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, shell_result=exec_result(stdout="ok"))
+
+    cloudflare_tool.execute(CodeInterpreterInputSchema(shell_command="ls"))
+
+    mkdir_calls = [str(c) for c in mock_cloudflare_client.exec.call_args_list]
+    assert any("mkdir -p /workspace/input /workspace/output" in c for c in mkdir_calls)
+
+
+def test_package_installation(cloudflare_tool, mock_cloudflare_client):
+    """Packages are installed via pip before code runs."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, python_result=exec_result(stdout="done"), pip_result=exec_result())
+
+    result = cloudflare_tool.execute(CodeInterpreterInputSchema(packages="pandas,numpy", python="print('done')"))
+
+    assert result["content"]["packages_installation"] == "Installed packages: pandas,numpy"
+    pip_commands = [c.args[1] for c in mock_cloudflare_client.exec.call_args_list if "pip install" in str(c.args[1])]
+    assert pip_commands == ["pip install -qq pandas numpy"]
+
+
+def test_package_installation_failure_raises(cloudflare_tool, mock_cloudflare_client):
+    """A failed pip install must raise instead of silently running code without deps."""
+    from dynamiq.nodes.agents.exceptions import ToolExecutionException
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(
+        mock_cloudflare_client,
+        pip_result=exec_result(exit_code=1, stderr="No matching distribution found for nonexistent-pkg"),
+    )
+
+    with pytest.raises(ToolExecutionException, match="No matching distribution"):
+        cloudflare_tool.execute(CodeInterpreterInputSchema(packages="nonexistent-pkg", python="print(1)"))
+
+
+def test_file_upload(cloudflare_tool, mock_cloudflare_client):
+    """Uploaded files are written under /workspace/input."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, python_result=exec_result(stdout="ok"))
+
+    test_file = io.BytesIO(b"test content")
+    test_file.name = "test.txt"
+
+    result = cloudflare_tool.execute(CodeInterpreterInputSchema(python="print('ok')", files=[test_file]))
+
+    assert "files_uploaded" in result["content"]
+    uploaded_paths = [call[0][1] for call in mock_cloudflare_client.write_file.call_args_list]
+    assert "/workspace/input/test.txt" in uploaded_paths
+
+
+def test_file_download(cloudflare_tool, mock_cloudflare_client):
+    """Downloaded files are returned as base64 content."""
+    import base64
+
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    mock_cloudflare_client.read_file.return_value = b"file content here"
+
+    result = cloudflare_tool.execute(CodeInterpreterInputSchema(download_files=["/workspace/output/result.txt"]))
+
+    expected_b64 = base64.b64encode(b"file content here").decode("utf-8")
+    assert result["content"]["files"]["/workspace/output/result.txt"] == expected_b64
+    mock_cloudflare_client.read_file.assert_called_once_with(SANDBOX_ID, "/workspace/output/result.txt")
+
+
+def test_python_error_handling(cloudflare_tool, mock_cloudflare_client):
+    """Nonzero python exit codes raise ToolExecutionException with stderr."""
+    from dynamiq.nodes.agents.exceptions import ToolExecutionException
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(
+        mock_cloudflare_client,
+        python_result=exec_result(exit_code=1, stderr="NameError: name 'x' is not defined"),
+    )
+
+    with pytest.raises(ToolExecutionException, match="NameError"):
+        cloudflare_tool.execute(CodeInterpreterInputSchema(python="print(x)"))
+
+
+def test_shell_command_error(cloudflare_tool, mock_cloudflare_client):
+    """Failed shell commands raise ToolExecutionException."""
+    from dynamiq.nodes.agents.exceptions import ToolExecutionException
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, shell_result=exec_result(exit_code=127, stderr="command not found"))
+
+    with pytest.raises(ToolExecutionException, match="command not found"):
+        cloudflare_tool.execute(CodeInterpreterInputSchema(shell_command="nonexistent_command"))
+
+
+def test_stderr_appended_on_success(cloudflare_tool, mock_cloudflare_client):
+    """Stderr with exit code 0 is appended to output, not raised."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, python_result=exec_result(stdout="42", stderr="FutureWarning: soon"))
+
+    result = cloudflare_tool.execute(CodeInterpreterInputSchema(python="print(42)"))
+
+    assert result["content"]["code_execution"] == "42\n[stderr] FutureWarning: soon"
+
+
+def test_close_destroys_sandbox(cloudflare_tool, mock_cloudflare_client):
+    """close() destroys the persistent sandbox."""
+    cloudflare_tool.close()
+
+    mock_cloudflare_client.destroy_sandbox.assert_called_once_with(SANDBOX_ID)
+    assert cloudflare_tool._sandbox is None
+
+
+def test_persistent_sandbox_false(mock_cloudflare_client):
+    """Sandbox is destroyed after execution when persistent_sandbox=False."""
+    from dynamiq.nodes.tools.cloudflare_sandbox import CloudflareInterpreterTool
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, python_result=exec_result(stdout="hello"))
+
+    tool = CloudflareInterpreterTool(
+        connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+        persistent_sandbox=False,
+        is_optimized_for_agents=False,
+    )
+
+    tool.execute(CodeInterpreterInputSchema(python="print('hello')"))
+
+    mock_cloudflare_client.destroy_sandbox.assert_called_once_with(SANDBOX_ID)
+
+
+def test_optimized_for_agents_output(cloudflare_tool, mock_cloudflare_client):
+    """Formatted markdown output when is_optimized_for_agents=True."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterInputSchema
+
+    make_exec_side_effect(mock_cloudflare_client, python_result=exec_result(stdout="42"))
+    cloudflare_tool.is_optimized_for_agents = True
+
+    result = cloudflare_tool.execute(CodeInterpreterInputSchema(python="print(42)"))
+
+    assert isinstance(result["content"], str)
+    assert "## Output" in result["content"]
+    assert "42" in result["content"]
+    assert "files" in result
+
+
+def test_creation_writes_marker(cloudflare_tool, mock_cloudflare_client):
+    """Sandbox creation boots the container and writes the reconnect marker."""
+    marker_calls = [
+        c for c in mock_cloudflare_client.exec.call_args_list if "touch /workspace/.dynamiq/created" in str(c.args[1])
+    ]
+    assert len(marker_calls) == 1
+
+
+def test_reconnect_sandbox(cloudflare_tool, mock_cloudflare_client):
+    """Reconnection verifies the creation marker and returns a handle to the same id."""
+    mock_cloudflare_client.exec.side_effect = None
+    mock_cloudflare_client.exec.return_value = exec_result(exit_code=0)
+
+    sandbox = cloudflare_tool._reconnect_sandbox("existingid234567")
+
+    marker_call = mock_cloudflare_client.exec.call_args
+    assert marker_call.args[0] == "existingid234567"
+    assert marker_call.args[1] == "test -f /workspace/.dynamiq/created"
+    assert sandbox.sandbox_id == "existingid234567"
+
+
+def test_reconnect_sandbox_expired(cloudflare_tool, mock_cloudflare_client):
+    """Reconnection to an expired sandbox (marker gone) raises so the base class recreates."""
+    mock_cloudflare_client.exec.side_effect = None
+    mock_cloudflare_client.exec.return_value = exec_result(exit_code=1)
+
+    with pytest.raises(ValueError, match="expired or was destroyed"):
+        cloudflare_tool._reconnect_sandbox("existingid234567")
+
+
+def test_to_checkpoint_state_saves_sandbox_id(cloudflare_tool, mock_cloudflare_client):
+    """Checkpoint save must capture the live sandbox id."""
+    assert cloudflare_tool.to_checkpoint_state().sandbox_id == SANDBOX_ID
+
+
+def test_from_checkpoint_state_reconnects(cloudflare_tool, mock_cloudflare_client):
+    """Checkpoint restore reconnects to the saved sandbox_id via the marker check."""
+    from dynamiq.nodes.tools.code_interpreter import CodeInterpreterCheckpointState
+
+    mock_cloudflare_client.exec.side_effect = None
+    mock_cloudflare_client.exec.return_value = exec_result(exit_code=0)
+
+    state = CodeInterpreterCheckpointState(sandbox_id="checkpointid2345", installed_packages=[])
+    cloudflare_tool.from_checkpoint_state(state)
+
+    marker_call = mock_cloudflare_client.exec.call_args
+    assert marker_call.args[0] == "checkpointid2345"
+    assert marker_call.args[1] == "test -f /workspace/.dynamiq/created"
+    assert cloudflare_tool._sandbox.sandbox_id == "checkpointid2345"
+
+
+def test_base_path_outside_workspace_rejected(mock_cloudflare_client):
+    """base_path outside /workspace fails fast at construction."""
+    from dynamiq.nodes.tools.cloudflare_sandbox import CloudflareInterpreterTool
+
+    with pytest.raises(ValueError, match="must stay inside /workspace"):
+        CloudflareInterpreterTool(
+            connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+            base_path="/home/user",
+        )
+
+
+def test_description_uses_workspace_paths(cloudflare_tool):
+    """Tool description must reference /workspace and not claim variable persistence."""
+    assert "/workspace" in cloudflare_tool.description
+    assert "{home_dir}" not in cloudflare_tool.description
+    assert "/home/user" not in cloudflare_tool.description
+    assert "Variables do NOT persist" in cloudflare_tool.description
+
+
+def test_tool_serialization_roundtrip(mock_cloudflare_client, tmp_path):
+    """Workflow with the tool node round-trips through YAML dump/load."""
+    from dynamiq import Workflow
+    from dynamiq.flows import Flow
+    from dynamiq.nodes.tools.cloudflare_sandbox import CloudflareInterpreterTool
+
+    tool = CloudflareInterpreterTool(
+        id="cf-tool",
+        connection=CloudflareConnection(id="cf-conn", api_key="test-key", url="https://bridge.test.workers.dev"),
+    )
+    workflow = Workflow(id="wf", flow=Flow(id="flow", nodes=[tool]))
+
+    yaml_path = tmp_path / "cloudflare_tool.yaml"
+    workflow.to_yaml_file(yaml_path)
+
+    loaded = Workflow.from_yaml_file(str(yaml_path), init_components=True)
+
+    loaded_tool = loaded.flow.nodes[0]
+    assert isinstance(loaded_tool, CloudflareInterpreterTool)
+    assert loaded_tool.type == "dynamiq.nodes.tools.CloudflareInterpreterTool"
+    assert loaded_tool.connection.type == "dynamiq.connections.Cloudflare"
+    assert loaded_tool.connection.url == "https://bridge.test.workers.dev"
+    assert loaded_tool.base_path == "/workspace"

--- a/tests/unit/sandboxes/test_cloudflare_sandbox_provider.py
+++ b/tests/unit/sandboxes/test_cloudflare_sandbox_provider.py
@@ -1,0 +1,346 @@
+"""Unit tests for CloudflareSandbox provider with a mocked bridge client."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynamiq.connections import Cloudflare as CloudflareConnection
+from dynamiq.connections.cloudflare_sandbox import CloudflareExecResult
+
+SANDBOX_ID = "testsandbox23456"
+
+
+def exec_result(exit_code=0, stdout="", stderr=""):
+    return CloudflareExecResult(exit_code=exit_code, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def mock_cloudflare_client():
+    """Create a fully mocked Cloudflare bridge client for the sandbox provider."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = SANDBOX_ID
+    mock_client.is_running.return_value = True
+    mock_client.exec.return_value = exec_result()
+
+    with patch.object(CloudflareConnection, "get_client", return_value=mock_client):
+        yield mock_client
+
+
+@pytest.fixture
+def cloudflare_sandbox(mock_cloudflare_client):
+    """Create a CloudflareSandbox instance with mocked client."""
+    from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+
+    return CloudflareSandbox(
+        connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+    )
+
+
+def test_run_command_shell(cloudflare_sandbox, mock_cloudflare_client):
+    """Shell command execution maps to ShellCommandResult."""
+
+    def side_effect(sandbox_id, command, **kwargs):
+        if isinstance(command, str) and command.startswith("mkdir"):
+            return exec_result()
+        return exec_result(stdout="hello world")
+
+    mock_cloudflare_client.exec.side_effect = side_effect
+
+    result = cloudflare_sandbox.run_command_shell("echo hello world", timeout=30)
+
+    assert result.is_success
+    assert result.stdout == "hello world"
+    assert result.exit_code == 0
+    shell_call = mock_cloudflare_client.exec.call_args_list[-1]
+    assert shell_call.args[1] == "echo hello world"
+    assert shell_call.kwargs["cwd"] == "/workspace"
+    assert shell_call.kwargs["timeout"] == 30
+
+
+def test_run_command_shell_stream_without_exit_status_is_error(cloudflare_sandbox, mock_cloudflare_client):
+    """A stream that died before the exit event must not be reported as success."""
+
+    def side_effect(sandbox_id, command, **kwargs):
+        if isinstance(command, str) and (command.startswith("mkdir") or command.startswith("test")):
+            return exec_result()
+        return exec_result(exit_code=None, stdout="partial")
+
+    mock_cloudflare_client.exec.side_effect = side_effect
+
+    result = cloudflare_sandbox.run_command_shell("long_command")
+
+    assert not result.is_success
+    assert "without an exit status" in result.error
+
+
+def test_run_command_shell_background(cloudflare_sandbox, mock_cloudflare_client):
+    """Background shell commands return immediately."""
+    result = cloudflare_sandbox.run_command_shell("sleep 100", run_in_background_enabled=True)
+
+    assert result.background is True
+    background_calls = [call for call in mock_cloudflare_client.exec.call_args_list if "nohup" in str(call.args[1])]
+    assert len(background_calls) == 1
+    assert background_calls[0].args[1] == "nohup sleep 100 > /dev/null 2>&1 &"
+    assert background_calls[0].kwargs["cwd"] == "/workspace"
+
+
+def test_run_command_shell_error(cloudflare_sandbox, mock_cloudflare_client):
+    """Transport errors surface as ShellCommandResult.error."""
+
+    def side_effect(sandbox_id, command, **kwargs):
+        if isinstance(command, str) and command.startswith("mkdir"):
+            return exec_result()
+        raise Exception("connection lost")
+
+    mock_cloudflare_client.exec.side_effect = side_effect
+
+    result = cloudflare_sandbox.run_command_shell("echo test")
+
+    assert not result.is_success
+    assert "connection lost" in result.error
+
+
+def test_run_command_shell_passes_envs(mock_cloudflare_client):
+    """Configured envs are passed to every command."""
+    from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+
+    sandbox = CloudflareSandbox(
+        connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+        envs={"FOO": "bar"},
+    )
+
+    sandbox.run_command_shell("printenv FOO")
+
+    shell_call = mock_cloudflare_client.exec.call_args_list[-1]
+    assert shell_call.kwargs.get("env") == {"FOO": "bar"}
+
+
+def test_upload_file(cloudflare_sandbox, mock_cloudflare_client):
+    """File upload writes to base_path by default."""
+    path = cloudflare_sandbox.upload_file("test.txt", b"content here")
+
+    assert path == "/workspace/test.txt"
+    mock_cloudflare_client.write_file.assert_called_once_with(SANDBOX_ID, "/workspace/test.txt", b"content here")
+
+
+def test_upload_file_with_destination(cloudflare_sandbox, mock_cloudflare_client):
+    """File upload honors an explicit destination path."""
+    path = cloudflare_sandbox.upload_file("test.txt", b"content", destination_path="/workspace/custom/test.txt")
+
+    assert path == "/workspace/custom/test.txt"
+    mock_cloudflare_client.write_file.assert_called_once_with(SANDBOX_ID, "/workspace/custom/test.txt", b"content")
+
+
+def test_list_files(cloudflare_sandbox, mock_cloudflare_client):
+    """Listing files parses find output."""
+
+    def side_effect(sandbox_id, command, **kwargs):
+        if isinstance(command, str) and command.startswith("find"):
+            return exec_result(stdout="/workspace/output/file1.txt\n/workspace/output/file2.csv\n")
+        return exec_result()
+
+    mock_cloudflare_client.exec.side_effect = side_effect
+
+    files = cloudflare_sandbox.list_files("/workspace/output")
+
+    assert files == ["/workspace/output/file1.txt", "/workspace/output/file2.csv"]
+    find_call = [c for c in mock_cloudflare_client.exec.call_args_list if str(c.args[1]).startswith("find")][0]
+    assert "find /workspace/output -maxdepth 4 -type f" in find_call.args[1]
+    assert "head -50" in find_call.args[1]
+
+
+def test_exists_true(cloudflare_sandbox, mock_cloudflare_client):
+    """exists() resolves the path against base_path and probes it with test -f."""
+    assert cloudflare_sandbox.exists("test.txt") is True
+
+    exists_call = mock_cloudflare_client.exec.call_args_list[-1]
+    assert exists_call.args[1] == "test -f /workspace/test.txt"
+
+
+def test_exists_false(cloudflare_sandbox, mock_cloudflare_client):
+    """exists() returns False when test -f fails."""
+
+    def side_effect(sandbox_id, command, **kwargs):
+        if isinstance(command, str) and command.startswith("test -f /workspace/missing.txt"):
+            return exec_result(exit_code=1)
+        return exec_result()
+
+    mock_cloudflare_client.exec.side_effect = side_effect
+
+    assert cloudflare_sandbox.exists("missing.txt") is False
+
+
+def test_retrieve(cloudflare_sandbox, mock_cloudflare_client):
+    """retrieve() reads file bytes resolved against base_path."""
+    mock_cloudflare_client.read_file.return_value = b"file bytes"
+
+    content = cloudflare_sandbox.retrieve("test.txt")
+
+    assert content == b"file bytes"
+    mock_cloudflare_client.read_file.assert_called_once_with(SANDBOX_ID, "/workspace/test.txt")
+
+
+def test_get_sandbox_info_with_port(cloudflare_sandbox, mock_cloudflare_client):
+    """Sandbox info with a port creates a tunnel and returns its URL."""
+    mock_cloudflare_client.create_tunnel.return_value = {
+        "id": "t1",
+        "port": 3000,
+        "url": "https://random.trycloudflare.com",
+        "hostname": "random.trycloudflare.com",
+    }
+
+    info = cloudflare_sandbox.get_sandbox_info(port=3000)
+
+    assert info.public_url == "https://random.trycloudflare.com"
+    assert info.public_host == "random.trycloudflare.com"
+    assert info.sandbox_id == SANDBOX_ID
+    mock_cloudflare_client.create_tunnel.assert_called_once_with(SANDBOX_ID, 3000)
+
+
+def test_get_sandbox_info_without_port(cloudflare_sandbox, mock_cloudflare_client):
+    """Sandbox info without port returns basic info and creates no tunnel."""
+    info = cloudflare_sandbox.get_sandbox_info()
+
+    assert info.base_path == "/workspace"
+    assert info.public_url is None
+    mock_cloudflare_client.create_tunnel.assert_not_called()
+
+
+def test_get_sandbox_info_tunnel_error(cloudflare_sandbox, mock_cloudflare_client):
+    """Tunnel failures surface as public_url_error, not exceptions."""
+    mock_cloudflare_client.create_tunnel.side_effect = Exception("tunnel refused")
+
+    info = cloudflare_sandbox.get_sandbox_info(port=3000)
+
+    assert info.public_url is None
+    assert "tunnel refused" in info.public_url_error
+
+
+def test_close_kill(cloudflare_sandbox, mock_cloudflare_client):
+    """close(kill=True) destroys the sandbox."""
+    cloudflare_sandbox._ensure_sandbox()
+
+    cloudflare_sandbox.close(kill=True)
+
+    mock_cloudflare_client.destroy_sandbox.assert_called_once_with(SANDBOX_ID)
+    assert cloudflare_sandbox.sandbox_id is None
+
+
+def test_close_no_kill(cloudflare_sandbox, mock_cloudflare_client):
+    """close() without kill keeps the sandbox alive for reconnection."""
+    cloudflare_sandbox._ensure_sandbox()
+
+    cloudflare_sandbox.close(kill=False)
+
+    mock_cloudflare_client.destroy_sandbox.assert_not_called()
+    assert cloudflare_sandbox.sandbox_id == SANDBOX_ID
+
+
+def test_create_boots_container_and_writes_marker(cloudflare_sandbox, mock_cloudflare_client):
+    """Creation must boot the container (warm-up inside the retry loop) and write the marker."""
+    cloudflare_sandbox._ensure_sandbox()
+
+    warmup_call = mock_cloudflare_client.exec.call_args_list[0]
+    assert warmup_call.args[0] == SANDBOX_ID
+    assert "mkdir -p /workspace /workspace/.dynamiq" in warmup_call.args[1]
+    assert "touch /workspace/.dynamiq/created" in warmup_call.args[1]
+
+
+def test_create_retries_on_capacity_error(mock_cloudflare_client):
+    """capacity_exceeded during the warm-up exec (lazy allocation) must be retried."""
+    from dynamiq.connections.cloudflare_sandbox import CloudflareRateLimitError
+    from dynamiq.nodes.tools.code_interpreter import SandboxCreationErrorHandling
+    from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+
+    attempts = []
+
+    def exec_side_effect(sandbox_id, command, **kwargs):
+        attempts.append(command)
+        if len(attempts) == 1:
+            raise CloudflareRateLimitError("instance limit reached", code="capacity_exceeded", status_code=503)
+        return exec_result()
+
+    mock_cloudflare_client.exec.side_effect = exec_side_effect
+
+    sandbox = CloudflareSandbox(
+        connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+        creation_error_handling=SandboxCreationErrorHandling(
+            max_retries=3, initial_wait_seconds=0.01, max_wait_seconds=0.02
+        ),
+    )
+
+    sandbox._ensure_sandbox()
+
+    assert len(attempts) == 2
+    assert sandbox.sandbox_id == SANDBOX_ID
+
+
+def test_reconnect_to_existing_sandbox(mock_cloudflare_client):
+    """Reconnecting by id verifies the creation marker instead of creating a new sandbox."""
+    from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+
+    sandbox = CloudflareSandbox(
+        connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+        sandbox_id="existingid234567",
+    )
+
+    sandbox._ensure_sandbox()
+
+    marker_call = mock_cloudflare_client.exec.call_args_list[0]
+    assert marker_call.args[0] == "existingid234567"
+    assert marker_call.args[1] == "test -f /workspace/.dynamiq/created"
+    mock_cloudflare_client.create_sandbox.assert_not_called()
+
+
+def test_reconnect_failure_raises_connection_error(mock_cloudflare_client):
+    """Expired sandbox ids (marker gone) raise SandboxConnectionError with the Cloudflare provider."""
+    from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+    from dynamiq.sandboxes.exceptions import SandboxConnectionError
+
+    mock_cloudflare_client.exec.return_value = exec_result(exit_code=1)
+
+    sandbox = CloudflareSandbox(
+        connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+        sandbox_id="existingid234567",
+    )
+
+    with pytest.raises(SandboxConnectionError, match="Cloudflare"):
+        sandbox._ensure_sandbox()
+
+
+def test_base_path_outside_workspace_rejected(mock_cloudflare_client):
+    """base_path outside /workspace fails fast at construction."""
+    from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+
+    with pytest.raises(ValueError, match="must stay inside /workspace"):
+        CloudflareSandbox(
+            connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+            base_path="/home/user",
+        )
+
+
+def test_get_tools(cloudflare_sandbox):
+    """get_tools returns the expected tool set."""
+    tools = cloudflare_sandbox.get_tools()
+
+    tool_names = [t.name for t in tools]
+    assert "sandbox-shell" in tool_names
+    assert "sandbox-info" in tool_names
+
+
+def test_to_dict_excludes_envs_for_tracing(mock_cloudflare_client):
+    """envs are serialized normally but excluded from tracing dumps."""
+    from dynamiq.sandboxes.cloudflare import CloudflareSandbox
+
+    sandbox = CloudflareSandbox(
+        connection=CloudflareConnection(api_key="test-key", url="https://bridge.test.workers.dev"),
+        envs={"SECRET": "value"},
+    )
+
+    data = sandbox.to_dict()
+    assert data["envs"] == {"SECRET": "value"}
+    assert data["type"] == "dynamiq.sandboxes.CloudflareSandbox"
+
+    tracing_data = sandbox.to_dict(for_tracing=True)
+    assert "envs" not in tracing_data
+    assert tracing_data["connection"] == {"id": sandbox.connection.id, "type": "dynamiq.connections.Cloudflare"}


### PR DESCRIPTION
## Summary

Adds **Cloudflare Sandboxes** as a third code-execution sandbox provider alongside E2B and Daytona, implemented in the same fashion on both integration surfaces:

- `dynamiq.connections.Cloudflare` — connection holding the deployed sandbox **bridge Worker URL** + its `SANDBOX_API_KEY` secret (`CLOUDFLARE_SANDBOX_API_URL` / `CLOUDFLARE_SANDBOX_API_KEY` env vars)
- `dynamiq.nodes.tools.CloudflareInterpreterTool` — code-interpreter tool node (`BaseCodeInterpreterTool` subclass)
- `dynamiq.sandboxes.CloudflareSandbox` — agent sandbox backend for `Agent(sandbox=SandboxConfig(...))`, providing shell/file/todo/sandbox-info tools

## Why a bridge Worker

Cloudflare Sandboxes (GA 2026-04, built on Containers + Durable Objects) have **no public REST API and no Python SDK** — sandboxes are only reachable through a Worker in the user's Cloudflare account. The official path for external clients is Cloudflare's [bridge Worker](https://developers.cloudflare.com/sandbox/bridge/) (`@cloudflare/sandbox/bridge`, one-click deploy), which exposes a versioned HTTP API under `/v1` with Bearer auth. `dynamiq/connections/cloudflare_sandbox.py` implements that wire contract (verified against `cloudflare/sandbox-sdk` v0.12.4 source) with plain `requests` — **zero new dependencies**:

- exec via `argv` + SSE streaming (base64 stdout/stderr chunks, exit/error events, UTF-8-safe decoding across chunk boundaries)
- raw file GET/PUT constrained to `/workspace` (mirrors the bridge's `resolveWorkspacePath`, keeps URI-reserved characters raw to match the router's `decodeURI` behavior)
- sessions, tunnels (public URLs for `get_sandbox_info(port)`), health
- error mapping: HTTP 429 / 503 `capacity_exceeded` → retryable `CloudflareRateLimitError`

## Cloudflare-specific behaviors handled

- **Lazy container allocation**: `POST /v1/sandbox` only mints an id; the container boots on first operation. Creation therefore runs a warm-up command *inside* the tenacity retry loop so capacity errors are retried with backoff (`creation_error_handling`), matching E2B/Daytona create semantics.
- **Reconnection safety**: sandbox ids are Durable-Object addressed, so any well-formed id "exists" and would silently get a fresh empty container. Creation writes a marker (`/workspace/.dynamiq/created`); reconnect/checkpoint-restore verifies it and fails loudly when state was lost, letting the base class fall back to recreating the sandbox.
- **Fresh-process Python semantics**: the bridge has no stateful interpreter contexts, so Python runs as `python3` on an uploaded script; the tool description explicitly states variables do not persist between executions (files under `/workspace` do).
- **Isolation / startup**: each sandbox runs in its own VM (per Cloudflare's security model docs); bridge warm-pool containers are assigned 1:1 and never reused across sandbox ids. For low-latency startup, set `WARM_POOL_TARGET > 0` on the deployed Worker (documented in the example).

## Serialization

No serializer/registry changes needed — type strings resolve dynamically:
`dynamiq.connections.Cloudflare`, `dynamiq.nodes.tools.CloudflareInterpreterTool`, `dynamiq.sandboxes.CloudflareSandbox`.
Round-trips covered by tests for both the tool node and the agent backend (dump → load → dump → load with `init_components=True`, including the no-duplicate-sandbox-tools check). Tracing dumps exclude `api_key` and `envs`.

## Tests

- `tests/unit/connections/test_cloudflare_sandbox_client.py` — 45 tests: SSE parsing (unterminated streams, mid-stream errors, multibyte splits, invalid base64, missing exit event, disconnects), error mapping, workspace containment, URL encoding, health, read-timeout headroom
- `tests/unit/nodes/tools/test_cloudflare_sandbox.py` — 24 tests: python/shell/pip flows incl. failure paths and kwargs plumbing, uploads/downloads, checkpoint save/restore, marker-based reconnect, ephemeral destroy, YAML round-trip
- `tests/unit/sandboxes/test_cloudflare_sandbox_provider.py` — 23 tests: shell/file ops, capacity-error retry, marker reconnect, tunnels, close semantics, tracing serialization
- Additions to `tests/integration/nodes/agents/test_agent_sandbox.py` (agent-backend YAML round-trip) and `tests/unit/nodes/schema_generation/test_schemas.py`
- Full suite: 1994 passed, 1 skipped (pre-existing); pre-commit hooks green

Examples: `examples/components/agents/agents/agent_cloudflare_sandbox.py`, `examples/components/core/dag/agent_cloudflare_sandbox.yaml`.

## Platform follow-ups (separate repos)

- ui/mono registries need the three new type strings (`dynamiq.connections.Cloudflare`, `dynamiq.sandboxes.CloudflareSandbox`, `dynamiq.nodes.tools.CloudflareInterpreterTool`) added to their enums/typed registries for builder support.
- The connection intentionally uses the vendor name `Cloudflare` (consistent with `E2B`/`Daytona`); a future generic Cloudflare-account connection would get its own name (e.g. `CloudflareAI`), same as the existing `GoogleCloud`/`GoogleOAuth2` split.