### PR TITLE
fix: upd agent state prompt

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -228,6 +228,15 @@ class Agent(HistoryManagerMixin, BaseAgent):
     format_schema: list = Field(default_factory=list)
     summarization_config: SummarizationConfig = Field(default_factory=SummarizationConfig)
     state: AgentState = Field(default_factory=AgentState, exclude=True)
+    track_state: bool = Field(
+        default=True,
+        description=(
+            "Append a [State: ...] block (loop progress and current todos) to the last user message "
+            "on every LLM call. The block is sent to the model only - it is never written to prompt "
+            "history, memory or checkpoints. Set False to keep the state out of the prompt; todos "
+            "then reach the model only via the todo-write tool result."
+        ),
+    )
     response_format: dict[str, Any] | None = Field(
         default=None,
         description=(
@@ -1662,6 +1671,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
         Original messages are not modified. Handles both Message and VisionMessage types.
         """
+        if not self.track_state:
+            return messages
+
         state_info = self.state.to_prompt_string()
         if not state_info or not messages:
             return messages
@@ -2126,6 +2138,12 @@ class Agent(HistoryManagerMixin, BaseAgent):
             loop_num: Current loop iteration number.
         """
         self.state.update_loop(loop_num)
+
+        # Todos are only read to render the [State: ...] block; skip the per-loop
+        # backend read (a network round-trip for remote sandboxes) when it is off.
+        if not self.track_state:
+            return
+
         todo_backend = None
         if self.sandbox_backend:
             todo_backend = self.sandbox_backend
@@ -2216,6 +2234,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             context_compaction_enabled=self.summarization_config.enabled,
             todo_management_enabled=(self.file_store.enabled and self.file_store.todo_enabled)
             or bool(self.sandbox_backend),
+            track_state=self.track_state,
             sandbox_base_path=self.sandbox_backend.base_path if self.sandbox_backend else None,
             has_sub_agent_tools=any(isinstance(t, SubAgentTool) for t in tools),
             role=self.role,

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -2139,8 +2139,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
         """
         self.state.update_loop(loop_num)
 
-        # Todos are only read to render the [State: ...] block; skip the per-loop
-        # backend read (a network round-trip for remote sandboxes) when it is off.
         if not self.track_state:
             return
 

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -2058,6 +2058,7 @@ class Agent(AgentIterativeCheckpointMixin, Node):
                         context_compaction_enabled=self.summarization_config.enabled,
                         todo_management_enabled=(self.file_store.enabled and self.file_store.todo_enabled)
                         or bool(self.sandbox_backend),
+                        track_state=self.track_state,
                         sandbox_base_path=self.sandbox_backend.base_path if self.sandbox_backend else None,
                         has_sub_agent_tools=any(isinstance(t, SubAgentTool) for t in self.tools),
                         role=self.role,

--- a/dynamiq/nodes/agents/prompts/manager.py
+++ b/dynamiq/nodes/agents/prompts/manager.py
@@ -31,6 +31,7 @@ from dynamiq.nodes.agents.prompts.secondary_instructions import (
     SANDBOX_INSTRUCTIONS_TEMPLATE,
     SUB_AGENT_INSTRUCTIONS,
     TODO_TOOLS_INSTRUCTIONS,
+    TODO_TOOLS_INSTRUCTIONS_TRACKED,
 )
 from dynamiq.nodes.agents.prompts.templates import AGENT_PROMPT_TEMPLATE
 from dynamiq.nodes.types import InferenceMode
@@ -46,6 +47,7 @@ class ReactPromptConfig(BaseModel):
     delegation_allowed: bool = False
     context_compaction_enabled: bool = False
     todo_management_enabled: bool = False
+    track_state: bool = False
     sandbox_base_path: str | None = None
     has_sub_agent_tools: bool = False
     role: str | None = None
@@ -316,7 +318,7 @@ class AgentPromptManager:
         if config.context_compaction_enabled:
             ops_parts.append(CONTEXT_MANAGER_INSTRUCTIONS)
         if config.todo_management_enabled:
-            ops_parts.append(TODO_TOOLS_INSTRUCTIONS)
+            ops_parts.append(TODO_TOOLS_INSTRUCTIONS_TRACKED if config.track_state else TODO_TOOLS_INSTRUCTIONS)
         if config.has_sub_agent_tools:
             ops_parts.append(SUB_AGENT_INSTRUCTIONS)
 

--- a/dynamiq/nodes/agents/prompts/secondary_instructions.py
+++ b/dynamiq/nodes/agents/prompts/secondary_instructions.py
@@ -20,13 +20,21 @@ CONTEXT_MANAGER_INSTRUCTIONS = """## Context Management
 - Use the context-manager tool proactively when conversation is getting long
 - Save critical info (IDs, filenames) in "notes" field BEFORE calling - previous messages will be summarized"""
 
-TODO_TOOLS_INSTRUCTIONS = """## Todo Management
+_TODO_TOOLS_INSTRUCTIONS_TEMPLATE = """## Todo Management
 - Use the todo-write tool for complex 3+ step tasks; skip for simple requests
-- Current todos shown in [State: ...] at the end of user last messages under "Todos:"
+- {todo_visibility}
 - When creating initial list: first task "in_progress", rest "pending"
 - After initial creation, ONLY update status via merge=true - do not restructure the plan
 - Mark completed IMMEDIATELY after finishing each step - don't batch
 - Only mark completed when FULLY done; if blocked, keep in_progress"""
+
+TODO_TOOLS_INSTRUCTIONS_TRACKED = _TODO_TOOLS_INSTRUCTIONS_TEMPLATE.format(
+    todo_visibility='Current todos shown in [State: ...] at the end of user last messages under "Todos:"'
+)
+
+TODO_TOOLS_INSTRUCTIONS = _TODO_TOOLS_INSTRUCTIONS_TEMPLATE.format(
+    todo_visibility="The todo-write result lists the full current todo list - re-read it there"
+)
 
 
 SANDBOX_INSTRUCTIONS_TEMPLATE = """## Sandbox Environment

--- a/examples/components/core/dag/agent_file_storage.yaml
+++ b/examples/components/core/dag/agent_file_storage.yaml
@@ -33,8 +33,10 @@ nodes:
       backend:
         type: dynamiq.storages.file.InMemoryFileStore
       agent_file_write_enabled: true
+      todo_enabled: true
     max_loops: 15
     inference_mode: XML
+    track_state: false
     summarization_config:
       enabled: true
 

--- a/tests/integration/nodes/agents/test_agent_methods.py
+++ b/tests/integration/nodes/agents/test_agent_methods.py
@@ -664,6 +664,68 @@ def test_todo_tools_added_when_enabled(openai_node, mock_llm_executor):
     prompt = agent.generate_prompt()
     assert "Todo Management" in prompt, "TODO instructions should be in system prompt"
     assert "todo-write" in prompt, "todo-write tool should be mentioned in prompt"
+    assert "[State: ...]" in prompt, "tracking is on by default, so todos are advertised there"
+
+
+def test_todo_instructions_avoid_state_block_when_tracking_disabled(openai_node, mock_llm_executor):
+    """With track_state=False the instructions must not point at a block that is never injected."""
+
+    file_store_config = FileStoreConfig(enabled=True, backend=InMemoryFileStore(), todo_enabled=True)
+    agent = Agent(
+        name="Todo Agent",
+        llm=openai_node,
+        tools=[],
+        file_store=file_store_config,
+        inference_mode=InferenceMode.DEFAULT,
+        track_state=False,
+    )
+
+    prompt = agent.generate_prompt()
+    assert "Todo Management" in prompt
+    assert "[State: ...]" not in prompt, "must not reference a state block that is never injected"
+    assert "The todo-write result lists the full current todo list" in prompt
+
+
+@pytest.mark.parametrize("track_state", [False, True])
+def test_inject_state_into_messages_respects_track_state(openai_node, track_state):
+    """The [State: ...] suffix is only appended when track_state is enabled."""
+
+    agent = Agent(name="Agent", llm=openai_node, tools=[], track_state=track_state)
+    agent.state.max_loops = 15
+    agent.state.update_loop(3)
+
+    messages = [Message(role=MessageRole.USER, content="do the thing")]
+    result = agent._inject_state_into_messages(messages)
+
+    if track_state:
+        assert result is not messages, "must not mutate the original message list"
+        assert "[State: Progress: Loop 3/15]" in result[-1].content
+        assert messages[-1].content == "do the thing", "original message must be untouched"
+    else:
+        assert result is messages
+        assert result[-1].content == "do the thing"
+
+
+def test_refresh_agent_state_skips_todo_read_when_not_tracking(openai_node):
+    """Loop number is always tracked, but todos are only loaded when track_state is on."""
+    from dynamiq.nodes.tools.todo_tools import TODOS_FILE_PATH
+
+    backend = InMemoryFileStore()
+    backend.store(
+        file_path=TODOS_FILE_PATH,
+        content=b'{"todos": [{"id": "1", "content": "do X", "status": "in_progress"}]}',
+        content_type="application/json",
+    )
+    file_store_config = FileStoreConfig(enabled=True, backend=backend, todo_enabled=True)
+
+    agent = Agent(name="Agent", llm=openai_node, tools=[], file_store=file_store_config, track_state=False)
+    agent._refresh_agent_state(2)
+    assert agent.state.current_loop == 2, "loop progress is tracked regardless of the flag"
+    assert agent.state.todos == [], "todos must not be read from the backend when tracking is off"
+
+    tracking_agent = Agent(name="Agent", llm=openai_node, tools=[], file_store=file_store_config)
+    tracking_agent._refresh_agent_state(2)
+    assert [t.id for t in tracking_agent.state.todos] == ["1"], "default agent still loads todos"
 
 
 def test_agent_state_updates_with_todos(openai_node):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Default behavior is unchanged (`track_state=True`); disabling only affects prompt content and todo loading for state display, not core agent execution paths.
> 
> **Overview**
> Adds an **`track_state`** flag on **`Agent`** (default **`true`**) so you can turn off the ephemeral **`[State: ...]`** block (loop progress and todos) on the last user message before each LLM call. When **`track_state`** is **`false`**, injection is skipped, todos are not loaded from the file/sandbox backend for prompting, and ReAct **todo** instructions tell the model to read the list from **`todo-write`** results instead of a state block that never appears.
> 
> **`ReactPromptConfig`** and prompt building now pick **`TODO_TOOLS_INSTRUCTIONS_TRACKED`** vs **`TODO_TOOLS_INSTRUCTIONS`** based on the flag. The file-storage example sets **`track_state: false`** with todos enabled, and integration tests cover prompt text, injection, and refresh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7019b78ca58eebdecc63e2f79d4505da775ddbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->