### PR TITLE
fix(logging): demote PII-carrying INFO logs to DEBUG

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -284,7 +284,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
         """
         Logs reasoning step of agent.
 
-        Action name stays at INFO (truncated — LLM-generated in some modes).
+        Action name stays at INFO.
         Thought and action_input may contain user data and are logged at DEBUG.
 
         Args:
@@ -298,7 +298,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             self.name,
             self.id,
             loop_num,
-            str(action)[:120],
+            action,
         )
         logger.debug(
             "Agent %s - %s: Loop %s: Thought: %s | Action Input: %s",

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1801,9 +1801,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
             RuntimeError: If the maximum number of loops is reached without finding a final answer.
             Exception: If an error occurs during execution.
         """
-        if self.verbose:
-            logger.info(f"Agent {self.name} - {self.id}: Running ReAct strategy")
-
         self.state.max_loops = self.max_loops
 
         completed = self.get_start_iteration()

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -284,6 +284,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
         """
         Logs reasoning step of agent.
 
+        Action name stays at INFO (truncated — LLM-generated in some modes).
+        Thought and action_input may contain user data and are logged at DEBUG.
+
         Args:
             thought (str): Reasoning about next step.
             action (str): Chosen action.
@@ -291,28 +294,44 @@ class Agent(HistoryManagerMixin, BaseAgent):
             loop_num (int): Number of reasoning loop.
         """
         logger.info(
-            "\n------------------------------------------\n"
-            f"Agent {self.name}: Loop {loop_num}:\n"
-            f"Thought: {thought}\n"
-            f"Action: {action}\n"
-            f"Action Input: {action_input}"
-            "\n------------------------------------------"
+            "Agent %s - %s: Loop %s: Action: %s",
+            self.name,
+            self.id,
+            loop_num,
+            str(action)[:120],
+        )
+        logger.debug(
+            "Agent %s - %s: Loop %s: Thought: %s | Action Input: %s",
+            self.name,
+            self.id,
+            loop_num,
+            thought,
+            action_input,
         )
 
     def log_final_output(self, thought: str, final_output: str, loop_num: int) -> None:
         """
         Logs final output of the agent.
 
+        Emits a payload-free INFO line; thought and final answer go to DEBUG.
+
         Args:
             final_output (str): Final output of agent.
             loop_num (int): Number of reasoning loop
         """
         logger.info(
-            "\n------------------------------------------\n"
-            f"Agent {self.name}: Loop {loop_num}\n"
-            f"Thought: {thought}\n"
-            f"Final answer: {final_output}"
-            "\n------------------------------------------\n"
+            "Agent %s - %s: Loop %s: final answer produced",
+            self.name,
+            self.id,
+            loop_num,
+        )
+        logger.debug(
+            "Agent %s - %s: Loop %s: Thought: %s | Final answer: %s",
+            self.name,
+            self.id,
+            loop_num,
+            thought,
+            final_output,
         )
 
     def _emit_tool_input_error(
@@ -1732,7 +1751,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
         llm_reasoning = (
             llm_generated_output[:200] if llm_generated_output else str(llm_result.output.get("tool_calls", ""))[:200]
         )
-        logger.info(f"Agent {self.name} - {self.id}: Loop {loop_num}, reasoning:\n{llm_reasoning}...")
+        logger.debug(f"Agent {self.name} - {self.id}: Loop {loop_num}, reasoning:\n{llm_reasoning}...")
 
         # Append assistant message to conversation history BEFORE parsing
         # This ensures the LLM can see its own output during error recovery

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import io
 import json
+import logging
 import mimetypes
 import re
 from contextvars import ContextVar
@@ -720,16 +721,17 @@ class Agent(AgentIterativeCheckpointMixin, Node):
         """
         Executes the agent with the given input data.
         """
-        # Convert to dict only for logging (to avoid logging BytesIO objects)
-        log_data = input_data.model_dump()
-        if log_data.get("images"):
-            log_data["images"] = [f"image_{i}" for i in range(len(log_data["images"]))]
-        if log_data.get("videos"):
-            log_data["videos"] = [f"video_{i}" for i in range(len(log_data["videos"]))]
-        if log_data.get("files"):
-            log_data["files"] = [f"file_{i}" for i in range(len(log_data["files"]))]
-
-        logger.info(f"Agent {self.name} - {self.id}: started with input {log_data}")
+        logger.info(f"Agent {self.name} - {self.id}: started")
+        if logger.isEnabledFor(logging.DEBUG):
+            # Convert to dict only for logging (to avoid logging BytesIO objects)
+            log_data = input_data.model_dump()
+            if log_data.get("images"):
+                log_data["images"] = [f"image_{i}" for i in range(len(log_data["images"]))]
+            if log_data.get("videos"):
+                log_data["videos"] = [f"video_{i}" for i in range(len(log_data["videos"]))]
+            if log_data.get("files"):
+                log_data["files"] = [f"file_{i}" for i in range(len(log_data["files"]))]
+            logger.debug(f"Agent {self.name} - {self.id}: started with input {log_data}")
         self.reset_run_state()
 
         config = ensure_config(config)
@@ -950,7 +952,8 @@ class Agent(AgentIterativeCheckpointMixin, Node):
                         f"returning {len(sandbox_files)} requested file(s) from sandbox"
                     )
 
-            logger.info(f"Node {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
+            logger.info(f"Node {self.name} - {self.id}: finished")
+            logger.debug(f"Node {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
 
             self._maybe_surface_live_view(execution_result, shared_session_token)
             return execution_result
@@ -2037,7 +2040,8 @@ class Agent(AgentIterativeCheckpointMixin, Node):
                 logger.warning(f"Unsupported file type from tool '{tool.name}': {type(file)}")
 
         if stored_files:
-            logger.info(f"Tool '{tool.name}' generated {len(stored_files)} file(s): {stored_files}")
+            logger.info(f"Tool '{tool.name}' generated {len(stored_files)} file(s)")
+            logger.debug(f"Tool '{tool.name}' generated file(s): {stored_files}")
         return stored_files
 
     def _upload_files_to_sandbox(self, normalized_files: list) -> list[str]:
@@ -2621,18 +2625,16 @@ class AgentManager(Agent):
         self, input_data: AgentManagerInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Executes the manager agent with the given input data and action."""
-        log_data = dict(input_data).copy()
-
-        if log_data.get("images"):
-            log_data["images"] = [f"image_{i}" for i in range(len(log_data["images"]))]
-
-        if log_data.get("videos"):
-            log_data["videos"] = [f"video_{i}" for i in range(len(log_data["videos"]))]
-
-        if log_data.get("files"):
-            log_data["files"] = [f"file_{i}" for i in range(len(log_data["files"]))]
-
-        logger.info(f"Agent {self.name} - {self.id}: started with input {log_data}")
+        logger.info(f"Agent {self.name} - {self.id}: started")
+        if logger.isEnabledFor(logging.DEBUG):
+            log_data = dict(input_data).copy()
+            if log_data.get("images"):
+                log_data["images"] = [f"image_{i}" for i in range(len(log_data["images"]))]
+            if log_data.get("videos"):
+                log_data["videos"] = [f"video_{i}" for i in range(len(log_data["videos"]))]
+            if log_data.get("files"):
+                log_data["files"] = [f"file_{i}" for i in range(len(log_data["files"]))]
+            logger.debug(f"Agent {self.name} - {self.id}: started with input {log_data}")
         self.reset_run_state()
         config = config or RunnableConfig()
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -2649,7 +2651,8 @@ class AgentManager(Agent):
         execution_result = {
             "content": result,
         }
-        logger.info(f"Agent {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
+        logger.info(f"Agent {self.name} - {self.id}: finished")
+        logger.debug(f"Agent {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
 
         return execution_result
 

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -2,7 +2,6 @@ import base64
 import binascii
 import io
 import json
-import logging
 import mimetypes
 import re
 from contextvars import ContextVar
@@ -721,17 +720,6 @@ class Agent(AgentIterativeCheckpointMixin, Node):
         """
         Executes the agent with the given input data.
         """
-        logger.info(f"Agent {self.name} - {self.id}: started")
-        if logger.isEnabledFor(logging.DEBUG):
-            # Convert to dict only for logging (to avoid logging BytesIO objects)
-            log_data = input_data.model_dump()
-            if log_data.get("images"):
-                log_data["images"] = [f"image_{i}" for i in range(len(log_data["images"]))]
-            if log_data.get("videos"):
-                log_data["videos"] = [f"video_{i}" for i in range(len(log_data["videos"]))]
-            if log_data.get("files"):
-                log_data["files"] = [f"file_{i}" for i in range(len(log_data["files"]))]
-            logger.debug(f"Agent {self.name} - {self.id}: started with input {log_data}")
         self.reset_run_state()
 
         config = ensure_config(config)
@@ -951,9 +939,6 @@ class Agent(AgentIterativeCheckpointMixin, Node):
                         f"Agent {self.name} - {self.id}: "
                         f"returning {len(sandbox_files)} requested file(s) from sandbox"
                     )
-
-            logger.info(f"Node {self.name} - {self.id}: finished")
-            logger.debug(f"Node {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
 
             self._maybe_surface_live_view(execution_result, shared_session_token)
             return execution_result
@@ -2625,16 +2610,6 @@ class AgentManager(Agent):
         self, input_data: AgentManagerInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Executes the manager agent with the given input data and action."""
-        logger.info(f"Agent {self.name} - {self.id}: started")
-        if logger.isEnabledFor(logging.DEBUG):
-            log_data = dict(input_data).copy()
-            if log_data.get("images"):
-                log_data["images"] = [f"image_{i}" for i in range(len(log_data["images"]))]
-            if log_data.get("videos"):
-                log_data["videos"] = [f"video_{i}" for i in range(len(log_data["videos"]))]
-            if log_data.get("files"):
-                log_data["files"] = [f"file_{i}" for i in range(len(log_data["files"]))]
-            logger.debug(f"Agent {self.name} - {self.id}: started with input {log_data}")
         self.reset_run_state()
         config = config or RunnableConfig()
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -2648,13 +2623,9 @@ class AgentManager(Agent):
         _result_llm = self._actions[action](config=config, **kwargs)
         result = {"action": action, "result": _result_llm}
 
-        execution_result = {
+        return {
             "content": result,
         }
-        logger.info(f"Agent {self.name} - {self.id}: finished")
-        logger.debug(f"Agent {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
-
-        return execution_result
 
     def _plan(self, config: RunnableConfig, **kwargs) -> str:
         """Executes the 'plan' action."""

--- a/dynamiq/nodes/agents/orchestrators/orchestrator.py
+++ b/dynamiq/nodes/agents/orchestrators/orchestrator.py
@@ -336,7 +336,8 @@ class Orchestrator(IterativeCheckpointMixin, Node, ABC):
         Raises:
             OrchestratorError: If the orchestration process fails.
         """
-        logger.info(f"Orchestrator {self.name} - {self.id}: started with INPUT DATA:\n{input_data}")
+        logger.info(f"Orchestrator {self.name} - {self.id}: started")
+        logger.debug(f"Orchestrator {self.name} - {self.id}: started with INPUT DATA:\n{input_data}")
         resuming = self.is_resumed
         self.reset_run_state()
         if resuming:
@@ -359,7 +360,8 @@ class Orchestrator(IterativeCheckpointMixin, Node, ABC):
             **kwargs,
         )
 
-        logger.info(f"Orchestrator {self.name} - {self.id}: finished with RESULT:\n{str(output)[:200]}...")
+        logger.info(f"Orchestrator {self.name} - {self.id}: finished")
+        logger.debug(f"Orchestrator {self.name} - {self.id}: finished with RESULT:\n{str(output)[:200]}...")
         return output
 
     def parse_xml_content(self, text: str, tag: str) -> str:

--- a/dynamiq/nodes/agents/orchestrators/orchestrator.py
+++ b/dynamiq/nodes/agents/orchestrators/orchestrator.py
@@ -336,8 +336,6 @@ class Orchestrator(IterativeCheckpointMixin, Node, ABC):
         Raises:
             OrchestratorError: If the orchestration process fails.
         """
-        logger.info(f"Orchestrator {self.name} - {self.id}: started")
-        logger.debug(f"Orchestrator {self.name} - {self.id}: started with INPUT DATA:\n{input_data}")
         resuming = self.is_resumed
         self.reset_run_state()
         if resuming:
@@ -354,15 +352,11 @@ class Orchestrator(IterativeCheckpointMixin, Node, ABC):
         if self.streaming.enabled:
             self.setup_streaming()
 
-        output = self.run_flow(
+        return self.run_flow(
             input_task=input_task,
             config=config,
             **kwargs,
         )
-
-        logger.info(f"Orchestrator {self.name} - {self.id}: finished")
-        logger.debug(f"Orchestrator {self.name} - {self.id}: finished with RESULT:\n{str(output)[:200]}...")
-        return output
 
     def parse_xml_content(self, text: str, tag: str) -> str:
         """Extract content from XML-like tags."""

--- a/dynamiq/nodes/converters/multi_file_type_converter.py
+++ b/dynamiq/nodes/converters/multi_file_type_converter.py
@@ -613,7 +613,7 @@ class MultiFileTypeConverter(Node):
             )
 
             detected_type = file_type_extractor_result.get("type")
-            logger.info(f"Detected file type: {detected_type} for file: {filename}")
+            logger.debug(f"Detected file type: {detected_type} for file: {filename}")
 
             converter_template = self._select_converter(file, filename, detected_type)
             if converter_template is not None:
@@ -761,7 +761,7 @@ class MultiFileTypeConverter(Node):
             tuple: ``(documents, run_depends)`` from the conversion.
         """
         try:
-            logger.info(f"Attempting conversion with fallback converter for {filename}")
+            logger.debug(f"Attempting conversion with fallback converter for {filename}")
 
             converter_input = {"files": [file]}
             if metadata:

--- a/dynamiq/nodes/knowledge_graphs/retriever.py
+++ b/dynamiq/nodes/knowledge_graphs/retriever.py
@@ -758,7 +758,6 @@ class KnowledgeGraphRetriever(ConnectionNode):
 
     def execute(self, input_data: GraphRetrieverInputSchema, config: RunnableConfig = None, **kwargs) -> dict[str, Any]:
         """Retrieve filtered graph context for the query and render it as Documents."""
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
         config = ensure_config(config)
         self.reset_run_state()
         check_cancellation(config)

--- a/dynamiq/nodes/knowledge_graphs/writer.py
+++ b/dynamiq/nodes/knowledge_graphs/writer.py
@@ -574,7 +574,7 @@ class KnowledgeGraphWriter(Node):
             if score >= self.similarity_threshold and score > best_score:
                 best_id, best_score = cand_id, score
         if best_id:
-            logger.info(
+            logger.debug(
                 f"Node {self.name} - {self.id}: linking {name!r} -> existing node {best_id!r} "
                 f"(trigram={best_score:.2f})"
             )

--- a/dynamiq/nodes/knowledgebases/bedrock.py
+++ b/dynamiq/nodes/knowledgebases/bedrock.py
@@ -529,7 +529,6 @@ class BedrockKnowledgeBaseSearch(ConnectionNode):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         request = self._build_retrieve_request(input_data)
 

--- a/dynamiq/nodes/knowledgebases/knowledgebase_graph.py
+++ b/dynamiq/nodes/knowledgebases/knowledgebase_graph.py
@@ -117,7 +117,6 @@ class DynamiqKnowledgebaseGraphSearch(ConnectionNode):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         request_kwargs = self._build_request_kwargs(input_data)
 
@@ -138,7 +137,6 @@ class DynamiqKnowledgebaseGraphSearch(ConnectionNode):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         request_kwargs = self._build_request_kwargs(input_data)
         client = await self.get_async_client()

--- a/dynamiq/nodes/knowledgebases/knowledgebase_hybrid.py
+++ b/dynamiq/nodes/knowledgebases/knowledgebase_hybrid.py
@@ -298,7 +298,6 @@ class DynamiqKnowledgebaseHybridSearch(Node):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         run_depends = kwargs.get("run_depends", [])
         sub_kwargs = self._sub_run_kwargs(kwargs)
@@ -321,7 +320,6 @@ class DynamiqKnowledgebaseHybridSearch(Node):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         run_depends = kwargs.get("run_depends", [])
         sub_kwargs = self._sub_run_kwargs(kwargs)

--- a/dynamiq/nodes/knowledgebases/knowledgebase_vector.py
+++ b/dynamiq/nodes/knowledgebases/knowledgebase_vector.py
@@ -191,7 +191,6 @@ class DynamiqKnowledgebaseVectorSearch(ConnectionNode):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         request_kwargs = self._build_request_kwargs(input_data)
 
@@ -212,7 +211,6 @@ class DynamiqKnowledgebaseVectorSearch(ConnectionNode):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         request_kwargs = self._build_request_kwargs(input_data)
         client = await self.get_async_client()

--- a/dynamiq/nodes/knowledgebases/vertex.py
+++ b/dynamiq/nodes/knowledgebases/vertex.py
@@ -423,7 +423,6 @@ class VertexAIRagSearch(ConnectionNode):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         request = self._prepare_request(input_data)
 
@@ -448,7 +447,6 @@ class VertexAIRagSearch(ConnectionNode):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
 
         request = self._prepare_request(input_data)
 

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -1027,7 +1027,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
     def log_execution_start(self, input_data: Any) -> None:
         """Log a payload-free INFO start line; dump input at DEBUG when enabled."""
         run = current_node_run_id()
-        logger.info("Node %s - %s: run=%s started", self.name, self.id, run)
+        logger.info("Node %s - %s: run=%s started.", self.name, self.id, run)
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Node %s - %s: run=%s input: %s",
@@ -1040,7 +1040,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
     def log_execution_finish(self, result: Any) -> None:
         """Log a payload-free INFO finish line; dump result at DEBUG when enabled."""
         run = current_node_run_id()
-        logger.info("Node %s - %s: run=%s finished", self.name, self.id, run)
+        logger.info("Node %s - %s: run=%s finished.", self.name, self.id, run)
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Node %s - %s: run=%s result: %s",

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -834,7 +834,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             ),
         )
 
-        logger.info(f"Node {self.name} - {self.id}: sending approval.")
+        logger.info(self._node_run_log("sending approval."))
         check_cancellation(config)
 
         self.run_on_node_execute_stream(callbacks=config.callbacks, event=event, **kwargs)
@@ -893,7 +893,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             ApprovalInputData: Result of approval.
         """
         if self._pending_approval_response is not None:
-            logger.info(f"Node {self.name} - {self.id}: using stored approval response from checkpoint")
+            logger.info(self._node_run_log("using stored approval response from checkpoint."))
             approval_result = self._pending_approval_response
         else:
             message = Template(approval_config.msg_template).render(self.to_dict(), input_data=input_data)
@@ -921,8 +921,8 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         if approval_result.is_approved is None:
             approval_result.is_approved = approval_result.feedback == approval_config.accept_pattern
             decision = "approved" if approval_result.is_approved else "canceled"
-            logger.info("Node %s action was %s by human.", self.name, decision)
-            logger.debug("Node %s human feedback: %r", self.name, approval_result.feedback)
+            logger.info(self._node_run_log(f"action was {decision} by human."))
+            logger.debug(self._node_run_log(f"human feedback: {approval_result.feedback!r}"))
 
         return approval_result
 
@@ -1024,31 +1024,21 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                     return value
             return value
 
+    def _node_run_log(self, message: str) -> str:
+        """Format a node lifecycle log line with the active short run id."""
+        return f"Node {self.name} - {self.id}: run={current_node_run_id()} {message}"
+
     def log_execution_start(self, input_data: Any) -> None:
         """Log a payload-free INFO start line; dump input at DEBUG when enabled."""
-        run = current_node_run_id()
-        logger.info("Node %s - %s: run=%s started.", self.name, self.id, run)
+        logger.info(self._node_run_log("started."))
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "Node %s - %s: run=%s input: %s",
-                self.name,
-                self.id,
-                run,
-                self._dump_for_log(input_data),
-            )
+            logger.debug(self._node_run_log(f"input: {self._dump_for_log(input_data)}"))
 
     def log_execution_finish(self, result: Any) -> None:
         """Log a payload-free INFO finish line; dump result at DEBUG when enabled."""
-        run = current_node_run_id()
-        logger.info("Node %s - %s: run=%s finished.", self.name, self.id, run)
+        logger.info(self._node_run_log("finished."))
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "Node %s - %s: run=%s result: %s",
-                self.name,
-                self.id,
-                run,
-                self._dump_for_log(result),
-            )
+            logger.debug(self._node_run_log(f"result: {self._dump_for_log(result)}"))
 
     def _handle_skip(
         self,
@@ -1068,7 +1058,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             human_feedback=getattr(e, "human_feedback", None),
             **merged_kwargs,
         )
-        logger.info(f"Node {self.name} - {self.id}: execution skipped.")
+        logger.info(self._node_run_log("execution skipped."))
         return RunnableResult(
             status=RunnableStatus.SKIP,
             input=transformed_input,
@@ -1097,8 +1087,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         self._pending_approval_response = None
 
         logger.info(
-            f"Node {self.name} - {self.id}: {log_prefix}execution succeeded in "
-            f"{format_duration(time_start, datetime.now())}."
+            self._node_run_log(f"{log_prefix}execution succeeded in {format_duration(time_start, datetime.now())}.")
         )
         return RunnableResult(status=RunnableStatus.SUCCESS, input=dict(transformed_input), output=transformed_output)
 
@@ -1116,8 +1105,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
 
         self.run_on_node_error(callbacks=config.callbacks, error=e, input_data=transformed_input, **merged_kwargs)
         logger.error(
-            f"Node {self.name} - {self.id}: {log_prefix}execution failed in "
-            f"{format_duration(time_start, datetime.now())}. {e}"
+            self._node_run_log(f"{log_prefix}execution failed in {format_duration(time_start, datetime.now())}. {e}")
         )
         recoverable = isinstance(e, RecoverableAgentException)
         return RunnableResult(
@@ -1137,8 +1125,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         """Handle cooperative cancel — fire on_node_canceled, return CANCELED result."""
         self.run_on_node_canceled(callbacks=config.callbacks, **merged_kwargs)
         logger.info(
-            f"Node {self.name} - {self.id}: {log_prefix}execution canceled in "
-            f"{format_duration(time_start, datetime.now())}."
+            self._node_run_log(f"{log_prefix}execution canceled in {format_duration(time_start, datetime.now())}.")
         )
         return RunnableResult(
             status=RunnableStatus.CANCELED,
@@ -1173,7 +1160,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         time_start = datetime.now()
         config, merged_kwargs, depends_result = self._prepare_execution(input_data, config, depends_result, **kwargs)
         token = set_node_run_id(merged_kwargs["run_id"])
-        logger.info(f"Node {self.name} - {self.id}: run={current_node_run_id()} execution started.")
+        logger.info(self._node_run_log("execution started."))
 
         try:
             try:
@@ -1225,7 +1212,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         time_start = datetime.now()
         config, merged_kwargs, depends_result = self._prepare_execution(input_data, config, depends_result, **kwargs)
         token = set_node_run_id(merged_kwargs["run_id"])
-        logger.info(f"Node {self.name} - {self.id}: run={current_node_run_id()} async execution started.")
+        logger.info(self._node_run_log("async execution started."))
 
         try:
             try:
@@ -1341,7 +1328,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             parent = asyncio.current_task()
             if parent is not None and hasattr(parent, "uncancel"):
                 parent.uncancel()
-            logger.info(f"Node {self.name} - {self.id}: asyncio task canceled, draining thread.")
+            logger.info(self._node_run_log("asyncio task canceled, draining thread."))
             try:
                 return await task
             except BaseException:
@@ -1401,13 +1388,13 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                 try:
                     self.ensure_client()
                 except Exception as conn_error:
-                    logger.error(f"Node {self.name} - {self.id}: Failed to ensure client connection: {conn_error}")
+                    logger.error(self._node_run_log(f"Failed to ensure client connection: {conn_error}"))
                     error = conn_error
                     if attempt < n_attempt - 1:
                         time_to_sleep = self.error_handling.retry_interval_seconds * (
                             self.error_handling.backoff_rate**attempt
                         )
-                        logger.info(f"Node {self.name} - {self.id}: retrying connection in {time_to_sleep} seconds.")
+                        logger.info(self._node_run_log(f"retrying connection in {time_to_sleep} seconds."))
                         time.sleep(time_to_sleep)
                         continue
                     else:
@@ -1437,21 +1424,21 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                     error = e
                     timed_out = True
                     self.run_on_node_execute_error(config.callbacks, error, **merged_kwargs)
-                    logger.warning(f"Node {self.name} - {self.id}: timeout.")
+                    logger.warning(self._node_run_log("timeout."))
                 except Exception as e:
                     error = e
                     self.run_on_node_execute_error(config.callbacks, error, **merged_kwargs)
-                    logger.error(f"Node {self.name} - {self.id}: execution error: {e}")
+                    logger.error(self._node_run_log(f"execution error: {e}"))
 
                 # do not sleep after the last attempt
                 if attempt < n_attempt - 1:
                     time_to_sleep = self.error_handling.retry_interval_seconds * (
                         self.error_handling.backoff_rate**attempt
                     )
-                    logger.info(f"Node {self.name} - {self.id}: retrying in {time_to_sleep} seconds.")
+                    logger.info(self._node_run_log(f"retrying in {time_to_sleep} seconds."))
                     time.sleep(time_to_sleep)
 
-            logger.error(f"Node {self.name} - {self.id}: execution failed after {n_attempt} attempts.")
+            logger.error(self._node_run_log(f"execution failed after {n_attempt} attempts."))
             raise error
         finally:
             if executor is not None:
@@ -1524,13 +1511,13 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                 # Offload blocking client initialization to a thread to avoid blocking the event loop
                 await self._offload_to_executor(executor, self.ensure_client)
             except Exception as conn_error:
-                logger.error(f"Node {self.name} - {self.id}: Failed to ensure client connection: {conn_error}")
+                logger.error(self._node_run_log(f"Failed to ensure client connection: {conn_error}"))
                 error = conn_error
                 if attempt < n_attempt - 1:
                     time_to_sleep = self.error_handling.retry_interval_seconds * (
                         self.error_handling.backoff_rate**attempt
                     )
-                    logger.info(f"Node {self.name} - {self.id}: retrying connection in {time_to_sleep} seconds.")
+                    logger.info(self._node_run_log(f"retrying connection in {time_to_sleep} seconds."))
                     await asyncio.sleep(time_to_sleep)
                     continue
                 else:
@@ -1556,18 +1543,18 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             except asyncio.TimeoutError as e:
                 error = e
                 self.run_on_node_execute_error(config.callbacks, error, **merged_kwargs)
-                logger.warning(f"Node {self.name} - {self.id}: timeout.")
+                logger.warning(self._node_run_log("timeout."))
             except Exception as e:
                 error = e
                 self.run_on_node_execute_error(config.callbacks, error, **merged_kwargs)
-                logger.error(f"Node {self.name} - {self.id}: execution error: {e}")
+                logger.error(self._node_run_log(f"execution error: {e}"))
 
             if attempt < n_attempt - 1:
                 time_to_sleep = self.error_handling.retry_interval_seconds * (self.error_handling.backoff_rate**attempt)
-                logger.info(f"Node {self.name} - {self.id}: retrying in {time_to_sleep} seconds.")
+                logger.info(self._node_run_log(f"retrying in {time_to_sleep} seconds."))
                 await asyncio.sleep(time_to_sleep)
 
-        logger.error(f"Node {self.name} - {self.id}: execution failed after {n_attempt} attempts.")
+        logger.error(self._node_run_log(f"execution failed after {n_attempt} attempts."))
         raise error
 
     def get_context_for_input_schema(self) -> dict:
@@ -1617,7 +1604,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                     try:
                         checkpoint_ctx.save_on_input_timeout(self.id)
                     except Exception as e:
-                        logger.warning(f"Node {self.id}: checkpoint save on input-streaming timeout failed: {e}")
+                        logger.warning(self._node_run_log(f"checkpoint save on input-streaming timeout failed: {e}"))
                 raise InputStreamingTimeoutError(node_id=self.id, timeout=streaming.timeout)
 
             remaining = streaming.timeout - elapsed if streaming.timeout is not None else poll_interval
@@ -2142,19 +2129,18 @@ class ConnectionNode(Node, ABC):
         if self.is_client_closed():
             if self.connection is None:
                 logger.debug(
-                    f"Node {self.name} - {self.id}: Client connection is closed but no connection available "
-                    f"for reinitialization."
+                    self._node_run_log("Client connection is closed but no connection available for reinitialization.")
                 )
                 return
 
-            logger.warning(f"Node {self.name} - {self.id}: Client connection is closed. Reinitializing")
+            logger.warning(self._node_run_log("Client connection is closed. Reinitializing."))
             connection_manager = self._connection_manager or ConnectionManager()
 
             try:
                 self.client = connection_manager.get_connection_client(connection=self.connection)
-                logger.info(f"Node {self.name} - {self.id}: Client reinitialized successfully")
+                logger.info(self._node_run_log("Client reinitialized successfully."))
             except Exception as e:
-                logger.error(f"Node {self.name} - {self.id}: Failed to reinitialize client: {e}")
+                logger.error(self._node_run_log(f"Failed to reinitialize client: {e}"))
                 raise ConnectionManagerException(f"Failed to reinitialize client for node {self.name}: {e}") from e
 
 
@@ -2184,8 +2170,7 @@ class VectorStoreNode(ConnectionNode, BaseVectorStoreParams, ABC):
         vector_store = self.vector_store_cls(**vector_store_params)
 
         logger.debug(
-            f"Node {self.name} - {self.id}: connected to {self.vector_store_cls.__name__} vector store with"
-            f" {vector_store_params}"
+            self._node_run_log(f"connected to {self.vector_store_cls.__name__} vector store with {vector_store_params}")
         )
 
         return vector_store
@@ -2233,20 +2218,21 @@ class VectorStoreNode(ConnectionNode, BaseVectorStoreParams, ABC):
         if self.is_client_closed():
             if self.connection is None:
                 logger.debug(
-                    f"Node {self.name} - {self.id}: Vector store client connection is closed but no connection "
-                    f"available for reinitialization."
+                    self._node_run_log(
+                        "Vector store client connection is closed but no connection available for reinitialization."
+                    )
                 )
                 return
 
-            logger.warning(f"Node {self.name} - {self.id}: Vector store client connection is closed. Reinitializing")
+            logger.warning(self._node_run_log("Vector store client connection is closed. Reinitializing."))
             connection_manager = self._connection_manager or ConnectionManager()
 
             try:
                 self.client = connection_manager.get_connection_client(connection=self.connection)
                 self.vector_store = self.connect_to_vector_store()
-                logger.info(f"Node {self.name} - {self.id}: Vector store reinitialized successfully")
+                logger.info(self._node_run_log("Vector store reinitialized successfully."))
             except Exception as e:
-                logger.error(f"Node {self.name} - {self.id}: Failed to reinitialize vector store: {e}")
+                logger.error(self._node_run_log(f"Failed to reinitialize vector store: {e}"))
                 raise ConnectionManagerException(
                     f"Failed to reinitialize vector store for node {self.name}: {e}"
                 ) from e

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -3,6 +3,7 @@ import contextvars
 import copy
 import functools
 import inspect
+import logging
 import time
 from abc import ABC, abstractmethod
 from concurrent.futures import TimeoutError
@@ -60,6 +61,7 @@ from dynamiq.utils.duration import format_duration
 from dynamiq.utils.jsonpath import filter as jsonpath_filter
 from dynamiq.utils.jsonpath import mapper as jsonpath_mapper
 from dynamiq.utils.logger import logger
+from dynamiq.utils.run_context import current_node_run_id, reset_node_run_id, set_node_run_id
 from dynamiq.utils.utils import clear_annotation
 
 if TYPE_CHECKING:
@@ -917,18 +919,10 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         approval_result.data = {**input_data, **update_params}
 
         if approval_result.is_approved is None:
-            if approval_result.feedback == approval_config.accept_pattern:
-                logger.info(
-                    f"Node {self.name} action was approved by human "
-                    f"with provided feedback '{approval_result.feedback}'."
-                )
-                approval_result.is_approved = True
-            else:
-                approval_result.is_approved = False
-                logger.info(
-                    f"Node {self.name} action was canceled by human"
-                    f"with provided feedback '{approval_result.feedback}'."
-                )
+            approval_result.is_approved = approval_result.feedback == approval_config.accept_pattern
+            decision = "approved" if approval_result.is_approved else "canceled"
+            logger.info("Node %s action was %s by human.", self.name, decision)
+            logger.debug("Node %s human feedback: %r", self.name, approval_result.feedback)
 
         return approval_result
 
@@ -1012,6 +1006,42 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         if depends_result is None:
             depends_result = {}
         return config, merged_kwargs, depends_result
+
+    @staticmethod
+    def _dump_for_log(value: Any) -> Any:
+        """Serialize a value for DEBUG log payloads without raising on odd types."""
+        if hasattr(value, "model_dump"):
+            try:
+                return value.model_dump()
+            except Exception:
+                return value
+        return value
+
+    def log_execution_start(self, input_data: Any) -> None:
+        """Log a payload-free INFO start line; dump input at DEBUG when enabled."""
+        run = current_node_run_id()
+        logger.info("Node %s - %s: run=%s started", self.name, self.id, run)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Node %s - %s: run=%s input: %s",
+                self.name,
+                self.id,
+                run,
+                self._dump_for_log(input_data),
+            )
+
+    def log_execution_finish(self, result: Any) -> None:
+        """Log a payload-free INFO finish line; dump result at DEBUG when enabled."""
+        run = current_node_run_id()
+        logger.info("Node %s - %s: run=%s finished", self.name, self.id, run)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Node %s - %s: run=%s result: %s",
+                self.name,
+                self.id,
+                run,
+                self._dump_for_log(result),
+            )
 
     def _handle_skip(
         self,
@@ -1132,10 +1162,11 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         Returns:
             RunnableResult: Result of the node execution.
         """
-        logger.info(f"Node {self.name} - {self.id}: execution started.")
         transformed_input = input_data
         time_start = datetime.now()
         config, merged_kwargs, depends_result = self._prepare_execution(input_data, config, depends_result, **kwargs)
+        token = set_node_run_id(merged_kwargs["run_id"])
+        logger.info(f"Node {self.name} - {self.id}: run={current_node_run_id()} execution started.")
 
         try:
             try:
@@ -1164,6 +1195,8 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             return self._handle_canceled(config, time_start, "", **merged_kwargs)
         except Exception as e:
             return self._handle_failure(e, transformed_input, config, time_start, "", **merged_kwargs)
+        finally:
+            reset_node_run_id(token)
 
     async def _run_async_native(
         self,
@@ -1181,10 +1214,11 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         the provided executor when supplied, otherwise to the default asyncio
         thread pool via asyncio.to_thread.
         """
-        logger.info(f"Node {self.name} - {self.id}: async execution started.")
         transformed_input = input_data
         time_start = datetime.now()
         config, merged_kwargs, depends_result = self._prepare_execution(input_data, config, depends_result, **kwargs)
+        token = set_node_run_id(merged_kwargs["run_id"])
+        logger.info(f"Node {self.name} - {self.id}: run={current_node_run_id()} async execution started.")
 
         try:
             try:
@@ -1225,6 +1259,8 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
             return self._handle_canceled(config, time_start, "async ", **merged_kwargs)
         except Exception as e:
             return self._handle_failure(e, transformed_input, config, time_start, "async ", **merged_kwargs)
+        finally:
+            reset_node_run_id(token)
 
     @staticmethod
     async def _offload_to_executor(executor: "ThreadPoolExecutor | None", func: Callable, *args, **kwargs) -> Any:
@@ -1371,6 +1407,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                         raise
 
                 self.run_on_node_execute_start(config.callbacks, input_data, **merged_kwargs)
+                self.log_execution_start(input_data)
 
                 try:
                     if executor and timeout is not None:
@@ -1384,6 +1421,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                     else:
                         output = self.execute(input_data=input_data, config=config, **merged_kwargs)
 
+                    self.log_execution_finish(output)
                     self.run_on_node_execute_end(config.callbacks, output, **merged_kwargs)
                     return output
                 except CanceledException:
@@ -1492,6 +1530,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                     raise
 
             self.run_on_node_execute_start(config.callbacks, input_data, **merged_kwargs)
+            self.log_execution_start(input_data)
 
             try:
                 if timeout is not None:
@@ -1502,6 +1541,7 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
                 else:
                     output = await self.execute_async(input_data=input_data, config=config, **merged_kwargs)
 
+                self.log_execution_finish(output)
                 self.run_on_node_execute_end(config.callbacks, output, **merged_kwargs)
                 return output
             except CanceledException:

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -62,7 +62,7 @@ from dynamiq.utils.jsonpath import filter as jsonpath_filter
 from dynamiq.utils.jsonpath import mapper as jsonpath_mapper
 from dynamiq.utils.logger import logger
 from dynamiq.utils.run_context import current_node_run_id, reset_node_run_id, set_node_run_id
-from dynamiq.utils.utils import clear_annotation
+from dynamiq.utils.utils import clear_annotation, format_value_for_log
 
 if TYPE_CHECKING:
     from concurrent.futures import ThreadPoolExecutor
@@ -1009,13 +1009,20 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
 
     @staticmethod
     def _dump_for_log(value: Any) -> Any:
-        """Serialize a value for DEBUG log payloads without raising on odd types."""
-        if hasattr(value, "model_dump"):
-            try:
-                return value.model_dump()
-            except Exception:
-                return value
-        return value
+        """Serialize a value for log payloads without raising on odd types.
+
+        File-like inputs (``BytesIO`` / ``bytes``) are reduced to names via
+        :func:`format_value_for_log` so content is never written to logs.
+        """
+        try:
+            return format_value_for_log(value)
+        except Exception:
+            if hasattr(value, "model_dump"):
+                try:
+                    return value.model_dump()
+                except Exception:
+                    return value
+            return value
 
     def log_execution_start(self, input_data: Any) -> None:
         """Log a payload-free INFO start line; dump input at DEBUG when enabled."""

--- a/dynamiq/nodes/node.py
+++ b/dynamiq/nodes/node.py
@@ -4,6 +4,7 @@ import copy
 import functools
 import inspect
 import logging
+import reprlib
 import time
 from abc import ABC, abstractmethod
 from concurrent.futures import TimeoutError
@@ -66,6 +67,21 @@ from dynamiq.utils.utils import clear_annotation, format_value_for_log
 
 if TYPE_CHECKING:
     from concurrent.futures import ThreadPoolExecutor
+
+# Hard ceiling on a single payload log line. `_LOG_REPR` should keep output well under
+# this on realistic payloads; the cap is a backstop for shapes it does not anticipate.
+LOG_PAYLOAD_MAX_CHARS = 4000
+
+# Bounded renderer for payload dumps. Truncates while rendering (rather than stringifying
+# everything and slicing), so a huge node input/result cannot be fully materialized as text.
+_LOG_REPR = reprlib.Repr()
+_LOG_REPR.maxstring = 200
+_LOG_REPR.maxother = 100
+_LOG_REPR.maxlist = 5
+_LOG_REPR.maxtuple = 5
+_LOG_REPR.maxset = 5
+_LOG_REPR.maxdict = 20
+_LOG_REPR.maxlevel = 6
 
 
 def ensure_config(config: RunnableConfig = None) -> RunnableConfig:
@@ -1008,34 +1024,46 @@ class Node(BaseModel, Runnable, DryRunMixin, CheckpointNodeMixin, ABC):
         return config, merged_kwargs, depends_result
 
     @staticmethod
-    def _dump_for_log(value: Any) -> Any:
-        """Serialize a value for log payloads without raising on odd types.
+    def _dump_for_log(value: Any) -> str:
+        """Render a value for log payloads: file-safe, structurally truncated, size-capped.
 
         File-like inputs (``BytesIO`` / ``bytes``) are reduced to names via
-        :func:`format_value_for_log` so content is never written to logs.
+        :func:`format_value_for_log` so content is never written to logs. The result is
+        then rendered through :data:`_LOG_REPR` and hard-capped at
+        :data:`LOG_PAYLOAD_MAX_CHARS`, so a large node input or result cannot produce an
+        unbounded log line. Omitted items are marked with ``...`` by the renderer.
         """
         try:
-            return format_value_for_log(value)
+            dumped = format_value_for_log(value)
         except Exception:
+            dumped = value
             if hasattr(value, "model_dump"):
                 try:
-                    return value.model_dump()
+                    dumped = value.model_dump()
                 except Exception:
-                    return value
-            return value
+                    dumped = value
+
+        try:
+            rendered = _LOG_REPR.repr(dumped)
+        except Exception:
+            rendered = f"<unrenderable {type(dumped).__name__}>"
+
+        if len(rendered) > LOG_PAYLOAD_MAX_CHARS:
+            return f"{rendered[:LOG_PAYLOAD_MAX_CHARS]}... [truncated]"
+        return rendered
 
     def _node_run_log(self, message: str) -> str:
         """Format a node lifecycle log line with the active short run id."""
         return f"Node {self.name} - {self.id}: run={current_node_run_id()} {message}"
 
     def log_execution_start(self, input_data: Any) -> None:
-        """Log a payload-free INFO start line; dump input at DEBUG when enabled."""
+        """Log a payload-free INFO start line; dump a truncated input at DEBUG when enabled."""
         logger.info(self._node_run_log("started."))
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(self._node_run_log(f"input: {self._dump_for_log(input_data)}"))
 
     def log_execution_finish(self, result: Any) -> None:
-        """Log a payload-free INFO finish line; dump result at DEBUG when enabled."""
+        """Log a payload-free INFO finish line; dump a truncated result at DEBUG when enabled."""
         logger.info(self._node_run_log("finished."))
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(self._node_run_log(f"result: {self._dump_for_log(result)}"))

--- a/dynamiq/nodes/rankers/cohere.py
+++ b/dynamiq/nodes/rankers/cohere.py
@@ -58,7 +58,6 @@ class CohereReranker(Node):
         Returns:
             dict[str, Any]: A dictionary containing the reranked documents.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/nodes/retrievers/retriever.py
+++ b/dynamiq/nodes/retrievers/retriever.py
@@ -425,7 +425,6 @@ class VectorStoreRetriever(Node):
             dict[str, Any]: Result of the retrieval.
         """
 
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
         config = ensure_config(config)
         self.reset_run_state()
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -510,7 +509,6 @@ class VectorStoreRetriever(Node):
                 retrieved_documents,
                 metadata_fields=self._resolve_formatted_metadata_fields(),
             )
-            logger.info(f"Tool {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
 
             return {"content": result, "documents": retrieved_documents}
         except Exception as e:

--- a/dynamiq/nodes/tools/code_interpreter.py
+++ b/dynamiq/nodes/tools/code_interpreter.py
@@ -682,7 +682,6 @@ class BaseCodeInterpreterTool(ConnectionNode, abc.ABC):
         Raises:
             ToolExecutionException: If execution fails or invalid input provided.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n" f"{str(input_data.model_dump())[:300]}")
         config = ensure_config(config)
         check_cancellation(config)
 
@@ -850,7 +849,6 @@ class BaseCodeInterpreterTool(ConnectionNode, abc.ABC):
                 if files_list:
                     result_text += f"*Files uploaded: {', '.join(files_list)}*\n"
                     result_text += f"Note: Uploaded files are available under {self.input_dir}. "
-            logger.info(f"Tool {self.name} - {self.id}: finished with result:\n" f"{str(result_text)[:200]}...")
 
             return {"content": result_text, "files": files_bytesio}
 
@@ -862,7 +860,6 @@ class BaseCodeInterpreterTool(ConnectionNode, abc.ABC):
             except (json.JSONDecodeError, ValueError):
                 pass
 
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n" f"{str(content)[:200]}...")
         return {"content": content}
 
     def _create_sandbox_with_retry(self) -> Any:

--- a/dynamiq/nodes/tools/cua_desktop/cua_desktop.py
+++ b/dynamiq/nodes/tools/cua_desktop/cua_desktop.py
@@ -398,7 +398,7 @@ class CuaDesktopTool(ConnectionNode):
             except Exception as e:
                 reports.append({"name": name, "path": dest_path, "status": "error", "error": str(e)})
         if reports:
-            logger.info(f"CuaDesktopTool uploads: {reports}")
+            logger.debug(f"CuaDesktopTool uploads: {reports}")
             return reports
         return None
 
@@ -464,7 +464,6 @@ class CuaDesktopTool(ConnectionNode):
         Raises:
             ToolExecutionException: If the input is invalid or execution fails.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
         check_cancellation(config)
 
         await self._init_client()
@@ -473,15 +472,13 @@ class CuaDesktopTool(ConnectionNode):
         files_to_upload = self._filter_screenshots(input_data.files)
         uploads_report = None
         if files_to_upload:
-            logger.info(f"CuaDesktopTool uploading files: {files_to_upload}")
+            logger.debug(f"CuaDesktopTool uploading files: {files_to_upload}")
             uploads_report = await self._upload_files(files_to_upload)
 
         try:
             result = await self.execute_command(input_data, uploads_report)
         except Exception as e:
             raise ToolExecutionException(f"Error message: {e}", recoverable=True) from e
-
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
 
         files = None
         if isinstance(result, dict) and "files" in result:
@@ -510,7 +507,7 @@ class CuaDesktopTool(ConnectionNode):
             if hasattr(f, "name"):
                 # Skip files named screenshot.png or containing "screenshot" in the name
                 if isinstance(f.name, str) and "screenshot" in f.name.lower():
-                    logger.info(f"Filtering out screenshot file: {f.name}")
+                    logger.debug(f"Filtering out screenshot file: {f.name}")
                     continue
             filtered.append(f)
 
@@ -542,7 +539,8 @@ class CuaDesktopTool(ConnectionNode):
             )
 
         # Map actions to CUA Computer API
-        logger.info(f"CuaDesktopTool executing action={action_enum.value} params={params}")
+        logger.info(f"CuaDesktopTool executing action={action_enum.value}")
+        logger.debug(f"CuaDesktopTool executing action={action_enum.value} params={params}")
         files: list[io.BytesIO] | None = None
         if action_enum == CuaAction.MOVE_MOUSE:
             x, y = params["coordinates"]

--- a/dynamiq/nodes/tools/cypher_executor.py
+++ b/dynamiq/nodes/tools/cypher_executor.py
@@ -235,7 +235,6 @@ class CypherExecutor(ConnectionNode):
         Raises:
             ToolExecutionException: If execution fails or the graph store is not initialized.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -255,9 +254,6 @@ class CypherExecutor(ConnectionNode):
                 )
                 result_payload["mode"] = input_data.mode
                 result_payload["content"] = self._build_schema_content(result_payload)
-                logger.info(
-                    f"Tool {self.name} - {self.id}: finished successfully. Content: {result_payload['content']}"
-                )
                 return result_payload
 
             if isinstance(input_data.query, list):
@@ -276,9 +272,6 @@ class CypherExecutor(ConnectionNode):
                     "results": results,
                 }
                 result_payload["content"] = self._build_batch_content(results, input_data.graph_return_enabled)
-                logger.info(
-                    f"Tool {self.name} - {self.id}: finished successfully. Content: {result_payload['content']}"
-                )
                 return result_payload
 
             result_payload = self._execute_single(
@@ -290,7 +283,6 @@ class CypherExecutor(ConnectionNode):
                 writes_allowed=input_data.writes_allowed,
             )
             result_payload["mode"] = input_data.mode
-            logger.info(f"Tool {self.name} - {self.id}: finished successfully. Content: {result_payload['content']}")
             return result_payload
         except Exception as exc:  # noqa: BLE001
             logger.error(f"Tool {self.name} - {self.id}: failed to execute Cypher. Error: {exc}")

--- a/dynamiq/nodes/tools/daytona_sandbox.py
+++ b/dynamiq/nodes/tools/daytona_sandbox.py
@@ -57,7 +57,7 @@ class DaytonaInterpreterTool(BaseCodeInterpreterTool):
             code = vars_code + "\n" + code
 
         try:
-            logger.info(f"Executing Python code: {code}")
+            logger.debug(f"Executing Python code: {code}")
             result = sandbox.code_interpreter.run_code(code, timeout=timeout)
             output_parts = []
 

--- a/dynamiq/nodes/tools/e2b_desktop/e2b_desktop.py
+++ b/dynamiq/nodes/tools/e2b_desktop/e2b_desktop.py
@@ -41,7 +41,6 @@ ACTION_SCHEMA_MAP: dict[E2BAction, type] = {
     E2BAction.LAUNCH: E2BLaunchSchema,
 }
 
-
 DESCRIPTION_E2B_DESKTOP = """## Sandbox Desktop Tool
 ### Overview
 Use this tool to control a virtual desktop by performing `computer`
@@ -323,7 +322,7 @@ class E2BDesktopTool(ConnectionNode):
                 reports.append({"name": name, "path": dest_path, "status": "error", "error": str(e)})
         if reports:
             self._uploads_report = reports
-            logger.info(f"E2BDesktopTool uploads: {reports}")
+            logger.debug(f"E2BDesktopTool uploads: {reports}")
 
     async def _init_client(self):
         """Initialize E2B desktop sandbox and stream (idempotent)."""
@@ -375,13 +374,12 @@ class E2BDesktopTool(ConnectionNode):
         Raises:
             ToolExecutionException: If the input is invalid or execution fails.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
         check_cancellation(config)
 
         await self._init_client()
 
         if input_data.files:
-            logger.info(f"E2BDesktopTool uploading files: {input_data.files}")
+            logger.debug(f"E2BDesktopTool uploading files: {input_data.files}")
             await self._upload_files(input_data.files)
         # E2B sandbox is initialized in _init_client; no separate VM instance step
 
@@ -392,8 +390,6 @@ class E2BDesktopTool(ConnectionNode):
                 raise ToolExecutionException(f"Error message: {e}", recoverable=True) from e
         else:
             raise ToolExecutionException(f"Invalid action_type: {input_data.action_type}", recoverable=True)
-
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
 
         # If inner result contains files, lift them to top-level for agent processing
         files = None
@@ -433,7 +429,8 @@ class E2BDesktopTool(ConnectionNode):
             )
 
         # Map actions to E2B Sandbox API
-        logger.info(f"E2BDesktopTool executing action={action_enum.value} params={params}")
+        logger.info(f"E2BDesktopTool executing action={action_enum.value}")
+        logger.debug(f"E2BDesktopTool executing action={action_enum.value} params={params}")
         files: list[io.BytesIO] | None = None
         if action_enum == E2BAction.MOVE_MOUSE:
             x, y = params["coordinates"]

--- a/dynamiq/nodes/tools/e2b_sandbox.py
+++ b/dynamiq/nodes/tools/e2b_sandbox.py
@@ -56,7 +56,7 @@ class E2BInterpreterTool(BaseCodeInterpreterTool):
             code = vars_code + "\n" + code
 
         try:
-            logger.info(f"Executing Python code: {code}")
+            logger.debug(f"Executing Python code: {code}")
             execution = sandbox.run_code(code, timeout=timeout)
             output_parts = []
 

--- a/dynamiq/nodes/tools/exa_search.py
+++ b/dynamiq/nodes/tools/exa_search.py
@@ -592,7 +592,6 @@ class ExaTool(ConnectionNode):
             }
             output = {"content": result}
 
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
         return output
 
     def execute(self, input_data: ExaInputSchema, config: RunnableConfig | None = None, **kwargs) -> dict[str, Any]:
@@ -601,7 +600,6 @@ class ExaTool(ConnectionNode):
 
         Input parameters override node parameters when provided.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         check_cancellation(config)
@@ -627,7 +625,6 @@ class ExaTool(ConnectionNode):
         self, input_data: ExaInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Native async execution path mirroring ``execute``."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/nodes/tools/file_tools.py
+++ b/dynamiq/nodes/tools/file_tools.py
@@ -104,7 +104,7 @@ def detect_file_type(file: BytesIO, filename: str) -> FileType | None:
 
         for file_type, extensions in EXTENSION_MAP.items():
             if file_ext in extensions:
-                logger.info(f"Detected file type: {file_type} for file: {filename}")
+                logger.debug(f"Detected file type: {file_type} for file: {filename}")
                 return file_type
 
         logger.warning(f"Unknown file extension: {file_ext} for file: {filename}")
@@ -692,7 +692,6 @@ class FileReadTool(Node):
         For large files, returns first, middle, and last chunks instead of full content.
         Automatically detects file type and extracts text content when possible.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -1063,7 +1062,7 @@ class FileReadTool(Node):
                 },
                 overwrite=True,
             )
-            logger.info(f"Tool {self.name} - {self.id}: cached extracted text at {cache_path}")
+            logger.debug(f"Tool {self.name} - {self.id}: cached extracted text at {cache_path}")
             return cache_path
         except Exception as exc:
             logger.warning(f"Tool {self.name} - {self.id}: failed to cache extracted text for {original_path}: {exc}")
@@ -1099,13 +1098,13 @@ class FileReadTool(Node):
         return content
 
     def _log_text_preview(self, text: str, context: str, limit: int = 200) -> None:
-        """Emit a short preview of extracted text so logs show what was parsed."""
+        """Emit a short preview of extracted text at DEBUG so logs show what was parsed."""
         if not text:
             return
         preview = text.strip().replace("\n", " ")
         preview = preview[:limit]
         suffix = "..." if len(text.strip()) > limit else ""
-        logger.info(
+        logger.debug(
             f"Tool {self.name} - {self.id}: {context} preview ({min(len(preview), limit)} chars) => {preview}{suffix}"
         )
 
@@ -1267,7 +1266,6 @@ class FileWriteTool(Node):
         Raises:
             ToolExecutionException: On file I/O errors or failed edit pre-checks.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         if input_data.file_path.startswith(f"{RESERVED_AGENT_PATH_PREFIX}/"):
             raise ToolExecutionException(
@@ -1321,7 +1319,6 @@ class FileWriteTool(Node):
         )
 
         message = f"File '{input_data.file_path}' written successfully"
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(file_info)[:200]}...")
 
         return {
             "content": message,
@@ -1492,7 +1489,6 @@ class FileSearchTool(Node):
         config: RunnableConfig | None = None,
         **kwargs,
     ) -> dict[str, Any]:
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -1682,7 +1678,7 @@ class FileSearchTool(Node):
                 text = raw.decode("utf-8", errors="ignore")
                 if text:
                     if candidate.endswith(EXTRACTED_TEXT_SUFFIX):
-                        logger.info(
+                        logger.debug(
                             f"Tool {self.name} - {self.id}: using cached extracted text for search: {candidate}"
                         )
                     return text, candidate
@@ -1738,8 +1734,6 @@ class FileListTool(Node):
         **kwargs,
     ) -> dict[str, Any]:
 
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
-
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
@@ -1754,7 +1748,6 @@ class FileListTool(Node):
             else:
                 files_string = "No files are currently available in the file store."
 
-            logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{files_string}")
             return {"content": files_string}
 
         except Exception as e:

--- a/dynamiq/nodes/tools/firecrawl.py
+++ b/dynamiq/nodes/tools/firecrawl.py
@@ -348,14 +348,12 @@ class FirecrawlTool(ConnectionNode):
         else:
             result = {"success": scrape_result.get("success", False), "url": url, **(scrape_result.get("data") or {})}
             output = {"content": result}
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
         return output
 
     def execute(
         self, input_data: FirecrawlInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Execute the scraping tool with the provided input data."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         check_cancellation(config)
@@ -381,7 +379,6 @@ class FirecrawlTool(ConnectionNode):
         self, input_data: FirecrawlInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Native async execution path mirroring ``execute``."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/nodes/tools/firecrawl_search.py
+++ b/dynamiq/nodes/tools/firecrawl_search.py
@@ -252,14 +252,12 @@ class FirecrawlSearchTool(ConnectionNode):
             result = self._format_agent_response(query, data)
         else:
             result = {"success": search_result.get("success", False), "query": query, "data": data}
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
         return {"content": result}
 
     def execute(
         self, input_data: FirecrawlSearchInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Execute the search tool with the provided input data."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         check_cancellation(config)
@@ -285,7 +283,6 @@ class FirecrawlSearchTool(ConnectionNode):
         self, input_data: FirecrawlSearchInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Native async execution path mirroring ``execute``."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/nodes/tools/function_tool.py
+++ b/dynamiq/nodes/tools/function_tool.py
@@ -7,7 +7,6 @@ from dynamiq.nodes import ErrorHandling, NodeGroup
 from dynamiq.nodes.node import Node, ensure_config
 from dynamiq.runnables import RunnableConfig
 from dynamiq.types.cancellation import check_cancellation
-from dynamiq.utils.logger import logger
 
 T = TypeVar("T")
 
@@ -67,14 +66,12 @@ Examples:
         :param config: Optional configuration for the runnable instance.
         :return: Dictionary with the execution result.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         result = self.run_func(input_data, config=config, **kwargs)
 
-        logger.info(f"Tool {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
         return {"content": result}
 
     def get_schema(self):

--- a/dynamiq/nodes/tools/http_api_call.py
+++ b/dynamiq/nodes/tools/http_api_call.py
@@ -237,7 +237,6 @@ class HttpApiCall(ConnectionNode):
             raise ValueError(
                 f"Response type must be one of the following: {', '.join(allowed_types)}"
             )
-        logger.info(f"Tool {self.name} - {self.id}: finished with RESULT:\n" f"{str(content)[:200]}...")
         return {"content": content, "status_code": response.status_code}
 
     def execute(self, input_data: HttpApiCallInputSchema, config: RunnableConfig = None, **kwargs):
@@ -259,7 +258,6 @@ class HttpApiCall(ConnectionNode):
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n" f"{input_data.model_dump()}")
 
         request_kwargs = self._build_request_kwargs(input_data)
 
@@ -278,7 +276,6 @@ class HttpApiCall(ConnectionNode):
         """Native async execution path mirroring ``execute``."""
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n" f"{input_data.model_dump()}")
 
         request_kwargs = self._build_request_kwargs(input_data)
         client = await self.get_async_client()

--- a/dynamiq/nodes/tools/human_feedback.py
+++ b/dynamiq/nodes/tools/human_feedback.py
@@ -210,7 +210,6 @@ Important:
         Returns:
             str: The user's input.
         """
-        logger.debug(f"Tool {self.name} - {self.id}: started with prompt {prompt}")
         check_cancellation(config)
 
         streaming = getattr(config.nodes_override.get(self.id), "streaming", None) or self.streaming
@@ -324,7 +323,6 @@ Important:
         Returns:
             dict[str, Any]: A dictionary containing the result under the 'content' key.
         """
-        logger.debug(f"Tool {self.name} - {self.id}: started with input data {input_data.model_dump()}")
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -334,7 +332,6 @@ Important:
 
         if action == HumanFeedbackAction.ASK:
             result = self._execute_ask(input_text, config, **kwargs)
-            logger.debug(f"Tool {self.name} - {self.id}: finished with result {result}")
             return {"content": result}
         elif action == HumanFeedbackAction.INFO:
             self._execute_send(input_text, config, **kwargs)

--- a/dynamiq/nodes/tools/jina.py
+++ b/dynamiq/nodes/tools/jina.py
@@ -235,7 +235,6 @@ class JinaScrapeTool(ConnectionNode):
                     "remove_selector": headers.get("X-Remove-Selector"),
                 },
             }
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
         return {"content": result}
 
     def execute(self, input_data: JinaScrapeInputSchema, config: RunnableConfig = None, **kwargs) -> dict[str, Any]:
@@ -250,7 +249,6 @@ class JinaScrapeTool(ConnectionNode):
         Returns:
             dict[str, Any]: Dictionary containing the scraped content and metadata
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         check_cancellation(config)
@@ -277,7 +275,6 @@ class JinaScrapeTool(ConnectionNode):
         self, input_data: JinaScrapeInputSchema, config: RunnableConfig = None, **kwargs
     ) -> dict[str, Any]:
         """Native async execution path mirroring ``execute``."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -666,7 +663,6 @@ class JinaSearchTool(ConnectionNode):
                 "include_full_content": include_full,
             }
 
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
         return {"content": result}
 
     def execute(self, input_data: JinaSearchInputSchema, config: RunnableConfig = None, **kwargs) -> dict[str, Any]:
@@ -681,7 +677,6 @@ class JinaSearchTool(ConnectionNode):
         Returns:
             dict[str, Any]: A dictionary containing the search results.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -712,7 +707,6 @@ class JinaSearchTool(ConnectionNode):
         self, input_data: JinaSearchInputSchema, config: RunnableConfig = None, **kwargs
     ) -> dict[str, Any]:
         """Native async execution path mirroring ``execute``."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/nodes/tools/llm_summarizer.py
+++ b/dynamiq/nodes/tools/llm_summarizer.py
@@ -9,7 +9,6 @@ from dynamiq.nodes.node import NodeDependency, ensure_config
 from dynamiq.prompts import Message, Prompt
 from dynamiq.runnables import RunnableConfig, RunnableStatus
 from dynamiq.types.cancellation import check_cancellation
-from dynamiq.utils.logger import logger
 
 
 class SummarizerCheckpointState(BaseCheckpointState):
@@ -220,10 +219,6 @@ Parameter Guide:
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
         input_text = input_data.input
-        logger.debug(
-            f"Tool {self.name} - {self.id}: started with input text length: {len(input_text)}, "
-            f"word count: {len(input_text.split())}"
-        )
 
         words = input_text.split()
         if len(words) > self.chunk_size:
@@ -239,8 +234,4 @@ Parameter Guide:
         else:
             summary = self._process_chunk(input_text, config, **kwargs)
 
-        logger.debug(
-            f"Tool {self.name} - {self.id}: finished with result length: {len(summary)}, "
-            f"word count: {len(summary.split())}"
-        )
         return {"content": summary}

--- a/dynamiq/nodes/tools/long_term_memory.py
+++ b/dynamiq/nodes/tools/long_term_memory.py
@@ -9,7 +9,6 @@ from dynamiq.nodes.node import Node, ensure_config
 from dynamiq.nodes.types import NodeGroup
 from dynamiq.runnables import RunnableConfig
 from dynamiq.types.cancellation import check_cancellation
-from dynamiq.utils.logger import logger
 
 REMEMBER_DESCRIPTION = """Persist a durable fact about the current user to long-term memory.
 
@@ -136,7 +135,6 @@ class RememberFactTool(_LongTermMemoryTool):
     def execute(
         self, input_data: RememberFactInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
-        logger.debug(f"Tool {self.name} - {self.id}: started")
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -161,7 +159,6 @@ class RecallFactsTool(_LongTermMemoryTool):
     def execute(
         self, input_data: RecallFactsInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
-        logger.debug(f"Tool {self.name} - {self.id}: started")
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -440,7 +440,6 @@ class MCPTool(ConnectionNode):
         Returns:
             dict[str, Any]: A dictionary containing the tool's output.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump(by_alias=True)}")
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
 
@@ -478,7 +477,6 @@ class MCPTool(ConnectionNode):
         else:
             content = extract_text_from_mcp_content(result.content)
 
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(content)[:200]}...")
         output = {"content": content}
         if self.is_optimized_for_agents:
             output["raw_response"] = raw_response

--- a/dynamiq/nodes/tools/python.py
+++ b/dynamiq/nodes/tools/python.py
@@ -297,7 +297,6 @@ class Python(Node):
         Returns:
             Any: The result from code execution.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n" f"{input_data.model_dump()}")
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -327,8 +326,6 @@ class Python(Node):
             error_msg = f"Code execution error: {str(e)}"
             logger.error(error_msg)
             raise ToolExecutionException(error_msg, recoverable=True)
-
-        logger.info(f"Tool {self.name} - {self.id}: finished with RESULT:\n" f"{str(result)[:200]}...")
 
         if isinstance(result, dict) and "content" in result:
             if self.is_optimized_for_agents:

--- a/dynamiq/nodes/tools/python_code_executor.py
+++ b/dynamiq/nodes/tools/python_code_executor.py
@@ -304,12 +304,6 @@ class PythonCodeExecutor(Node):
     def execute(
         self, input_data: PythonCodeExecutorInputSchema, config: RunnableConfig = None, **kwargs
     ) -> dict[str, Any]:
-        code_preview = input_data.code.strip().replace("\n", "\\n")[:200]
-        logger.info(f"Tool {self.name} - {self.id}: started with code length={len(input_data.code)}")
-        logger.debug(
-            f"Tool {self.name} - {self.id}: code preview="
-            f"'{code_preview}{'...' if len(input_data.code) > 200 else ''}'"
-        )
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -394,11 +388,6 @@ class PythonCodeExecutor(Node):
             sanitized_content = self._sanitize_output(content)
             if stdout_value:
                 logger.debug(f"Tool {self.name} - {self.id}: captured stdout ({len(stdout_value)} chars).")
-            keys_repr = (
-                list(sanitized_content.keys()) if isinstance(sanitized_content, dict) else type(sanitized_content)
-            )
-            logger.info(f"Tool {self.name} - {self.id}: finished execution with keys {keys_repr}")
-            logger.debug(f"Tool {self.name} - {self.id}: result preview={self._preview_for_log(sanitized_content)}")
             return {"content": sanitized_content}
         finally:
             os.chdir(original_cwd)
@@ -745,13 +734,3 @@ class PythonCodeExecutor(Node):
         if isinstance(value, tuple):
             return tuple(self._stringify_keys(item) for item in value)
         return value
-
-    def _preview_for_log(self, value: Any, limit: int = 200) -> str:
-        try:
-            serialized = json.dumps(value)
-        except Exception:
-            serialized = str(value)
-        serialized = serialized.replace("\n", "\\n")
-        if len(serialized) > limit:
-            return f"'{serialized[:limit]}...'"
-        return f"'{serialized}'"

--- a/dynamiq/nodes/tools/python_code_executor.py
+++ b/dynamiq/nodes/tools/python_code_executor.py
@@ -305,9 +305,10 @@ class PythonCodeExecutor(Node):
         self, input_data: PythonCodeExecutorInputSchema, config: RunnableConfig = None, **kwargs
     ) -> dict[str, Any]:
         code_preview = input_data.code.strip().replace("\n", "\\n")[:200]
-        logger.info(
-            f"Tool {self.name} - {self.id}: started with code length={len(input_data.code)} "
-            f"preview='{code_preview}{'...' if len(input_data.code) > 200 else ''}'"
+        logger.info(f"Tool {self.name} - {self.id}: started with code length={len(input_data.code)}")
+        logger.debug(
+            f"Tool {self.name} - {self.id}: code preview="
+            f"'{code_preview}{'...' if len(input_data.code) > 200 else ''}'"
         )
         config = ensure_config(config)
         check_cancellation(config)
@@ -396,10 +397,8 @@ class PythonCodeExecutor(Node):
             keys_repr = (
                 list(sanitized_content.keys()) if isinstance(sanitized_content, dict) else type(sanitized_content)
             )
-            logger.info(
-                f"Tool {self.name} - {self.id}: finished execution with keys {keys_repr} "
-                f"preview={self._preview_for_log(sanitized_content)}"
-            )
+            logger.info(f"Tool {self.name} - {self.id}: finished execution with keys {keys_repr}")
+            logger.debug(f"Tool {self.name} - {self.id}: result preview={self._preview_for_log(sanitized_content)}")
             return {"content": sanitized_content}
         finally:
             os.chdir(original_cwd)

--- a/dynamiq/nodes/tools/python_monty.py
+++ b/dynamiq/nodes/tools/python_monty.py
@@ -99,10 +99,6 @@ class PythonMonty(Node):
         Raises:
             ToolExecutionException: If ``pydantic_monty`` is unavailable or the user code fails.
         """
-        logger.info(
-            f"Tool {self.name} - {self.id}: started with INPUT DATA:\n"
-            f"{input_data.model_dump() if hasattr(input_data, 'model_dump') else input_data}"
-        )
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -133,7 +129,6 @@ class PythonMonty(Node):
             logger.error(error_msg)
             raise ToolExecutionException(error_msg, recoverable=True) from e
 
-        logger.info(f"Tool {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
         return self._format_result(result)
 
     def _format_result(self, result: Any) -> Any:

--- a/dynamiq/nodes/tools/scale_serp.py
+++ b/dynamiq/nodes/tools/scale_serp.py
@@ -218,7 +218,6 @@ class ScaleSerpTool(ConnectionNode):
         """
         Executes the search using the Scale SERP API and returns the formatted results.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         check_cancellation(config)
@@ -238,7 +237,6 @@ class ScaleSerpTool(ConnectionNode):
         self, input_data: ScaleSerpInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Native async execution path mirroring ``execute``."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/nodes/tools/skills_tool.py
+++ b/dynamiq/nodes/tools/skills_tool.py
@@ -125,9 +125,13 @@ class SkillsTool(Node):
         one_line = instructions.instructions.replace("\n", " ").strip()
         preview = (one_line[:50] + "...") if len(one_line) > 50 else one_line
         logger.info(
-            "SkillsTool - get: skill=%s -> content received (%d chars), preview: %s",
+            "SkillsTool - get: skill=%s -> content received (%d chars)",
             skill_name,
             len(instructions.instructions),
+        )
+        logger.debug(
+            "SkillsTool - get: skill=%s preview: %s",
+            skill_name,
             preview,
         )
         return {"content": out}

--- a/dynamiq/nodes/tools/sql_executor.py
+++ b/dynamiq/nodes/tools/sql_executor.py
@@ -92,7 +92,6 @@ class SQLExecutor(ConnectionNode):
         return "\n\n".join(formatted_results)
 
     def execute(self, input_data: SQLInputSchema, config: RunnableConfig = None, **kwargs) -> dict[str, Any]:
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         check_cancellation(config)

--- a/dynamiq/nodes/tools/stagehand.py
+++ b/dynamiq/nodes/tools/stagehand.py
@@ -98,7 +98,6 @@ performance, use this option only when necessary, such as when encountering an i
    }
    ```
 
-
 ### Tips
 
 - !!! Always divide complex tasks into clear, isolated actions. For example:
@@ -414,9 +413,9 @@ class Stagehand(ConnectionNode):
         if self._steel_browser_session is None:
             self._steel_browser_session = await self._steel_client.sessions.create(**self.connection.session_config)
             if hasattr(self._steel_browser_session, "id"):
-                logger.info(f"Steel session created: {self._steel_browser_session.id}")
+                logger.debug(f"Steel session created: {self._steel_browser_session.id}")
             if hasattr(self._steel_browser_session, "session_viewer_url"):
-                logger.info(f"Steel session viewer: {self._steel_browser_session.session_viewer_url}")
+                logger.debug(f"Steel session viewer: {self._steel_browser_session.session_viewer_url}")
         return self._steel_browser_session
 
     def _upload_file_bytes_to_steel_browser_session(self, session_id: str, file_bytes: bytes, file_name: str) -> dict:
@@ -434,7 +433,7 @@ class Stagehand(ConnectionNode):
         response.raise_for_status()
         payload = response.json()
         if isinstance(payload, dict):
-            logger.info(f"Steel session files: {payload.get('data') or []}")
+            logger.debug(f"Steel session files: {payload.get('data') or []}")
             return payload.get("data") or []
         return []
 
@@ -505,7 +504,7 @@ class Stagehand(ConnectionNode):
                     file_obj.getvalue(),
                     file_obj.name,
                 )
-                logger.info(f"Uploaded {file_obj.name} to Steel session: {result}")
+                logger.debug(f"Uploaded {file_obj.name} to Steel session: {result}")
             return
 
         for file_obj in files:
@@ -513,7 +512,7 @@ class Stagehand(ConnectionNode):
                 file_obj.name = "uploaded_file"
 
             result = await self._browserbase_client.sessions.uploads.create(self._session_id, file=file_obj)
-            logger.info(f"Uploaded {file_obj.name}: {result}")
+            logger.debug(f"Uploaded {file_obj.name}: {result}")
 
     async def _init_client(
         self,
@@ -599,7 +598,7 @@ class Stagehand(ConnectionNode):
                         self._live_view_url = debug_info.debuggerFullscreenUrl
 
             if self._live_view_url:
-                logger.info(f"Live view URL: {self._live_view_url}")
+                logger.debug(f"Live view URL: {self._live_view_url}")
         except Exception as e:
             logger.warning(f"Could not fetch live view URL: {e}")
 
@@ -721,7 +720,6 @@ class Stagehand(ConnectionNode):
         Raises:
             ToolExecutionException: If the input is invalid or execution fails.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
         config = ensure_config(config)
         check_cancellation(config)
         shared_browser = await self._acquire_shared_browser()
@@ -779,13 +777,13 @@ class Stagehand(ConnectionNode):
 
                 file_chooser = await fc_info.value
                 if file_chooser:
-                    logger.info(f"{self.id} - {self.name} - Uploading file {input_data.files.name}")
+                    logger.debug(f"{self.id} - {self.name} - Uploading file {input_data.files.name}")
 
                     # Read file content and automatically detect MIME type
                     file_content = input_data.files.getvalue()
                     mime_type = guess_mime_type_from_bytes(file_content, input_data.files.name)
 
-                    logger.info(f"Detected MIME type: {mime_type} for file: {input_data.files.name}")
+                    logger.debug(f"Detected MIME type: {mime_type} for file: {input_data.files.name}")
 
                     await file_chooser.set_files(
                         [{"name": input_data.files.name, "mimeType": mime_type, "buffer": file_content}]
@@ -807,8 +805,6 @@ class Stagehand(ConnectionNode):
             StagehandActionType.UPLOAD,
         ):
             screenshot = await self._take_screenshot()
-
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
 
         response: dict[str, Any] = {"content": result}
         if files:

--- a/dynamiq/nodes/tools/tavily.py
+++ b/dynamiq/nodes/tools/tavily.py
@@ -272,7 +272,6 @@ class TavilyTool(ConnectionNode):
         Returns:
             dict[str, Any]: The result of the search operation.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         check_cancellation(config)
@@ -297,7 +296,6 @@ class TavilyTool(ConnectionNode):
         self, input_data: TavilyInputSchema, config: RunnableConfig | None = None, **kwargs
     ) -> dict[str, Any]:
         """Native async execution path mirroring ``execute``."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
 
         config = ensure_config(config)
         check_cancellation(config)
@@ -383,7 +381,5 @@ class TavilyTool(ConnectionNode):
                 "auto_parameters": auto_parameters or {},
                 "search_parameters": request_payload,
             }
-
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
 
         return {"content": result}

--- a/dynamiq/nodes/tools/thinking_tool.py
+++ b/dynamiq/nodes/tools/thinking_tool.py
@@ -213,8 +213,6 @@ Examples:
         context = input_data.context
         focus = input_data.focus
 
-        logger.debug(f"Tool {self.name} - {self.id}: started thinking process for thought: '{thought[:100]}...'")
-
         context_section = self._build_context_section(context, focus)
 
         prompt_content = self.prompt_template.format(thought=thought, context_section=context_section)

--- a/dynamiq/nodes/tools/zenrows.py
+++ b/dynamiq/nodes/tools/zenrows.py
@@ -80,7 +80,6 @@ class ZenRowsTool(ConnectionNode):
             result = f"## Source URL\n{input_data.url}\n\n## Scraped Result\n\n{scrape_result}\n"
         else:
             result = {"url": input_data.url, "content": scrape_result}
-        logger.info(f"Tool {self.name} - {self.id}: finished with result:\n{str(result)[:200]}...")
         return {"content": result}
 
     def _wrap_request_exception(self, exc: Exception) -> ToolExecutionException:
@@ -103,7 +102,6 @@ class ZenRowsTool(ConnectionNode):
         Returns:
             dict[str, Any]: A dictionary containing the URL and the scraped content.
         """
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -120,7 +118,6 @@ class ZenRowsTool(ConnectionNode):
         self, input_data: ZenRowsInputSchema, config: RunnableConfig = None, **kwargs
     ) -> dict[str, Any]:
         """Native async execution path mirroring ``execute``."""
-        logger.info(f"Tool {self.name} - {self.id}: started with input:\n{input_data.model_dump()}")
         config = ensure_config(config)
         check_cancellation(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/nodes/writers/writer.py
+++ b/dynamiq/nodes/writers/writer.py
@@ -186,7 +186,6 @@ class VectorStoreWriter(Node):
             dict[str, Any]: Result of the writing operation.
         """
 
-        logger.info(f"Tool {self.name} - {self.id}: started with INPUT DATA:\n{input_data.model_dump()}")
         config = ensure_config(config)
         self.reset_run_state()
         self.run_on_node_execute_run(config.callbacks, **kwargs)
@@ -217,7 +216,6 @@ class VectorStoreWriter(Node):
             logger.debug(f"Tool {self.name} - {self.id}: wrote {upserted_count} documents to vector store")
 
             result = {"upserted_count": upserted_count}
-            logger.info(f"Tool {self.name} - {self.id}: finished with RESULT:\n{str(result)[:200]}...")
 
             return result
         except Exception as e:

--- a/dynamiq/sandboxes/tools/shell.py
+++ b/dynamiq/sandboxes/tools/shell.py
@@ -125,7 +125,8 @@ class SandboxShellTool(Node):
         Returns:
             Dictionary with stdout, stderr, and exit_code from command execution.
         """
-        logger.info(f"Tool {self.name} - {self.id}: executing command: {input_data.command[:100]}...")
+        logger.info(f"Tool {self.name} - {self.id}: executing command")
+        logger.debug(f"Tool {self.name} - {self.id}: executing command: {input_data.command[:100]}...")
 
         config = ensure_config(config)
         self.run_on_node_execute_run(config.callbacks, **kwargs)

--- a/dynamiq/utils/__init__.py
+++ b/dynamiq/utils/__init__.py
@@ -6,6 +6,7 @@ from .utils import (
     encode,
     encode_reversible,
     format_value,
+    format_value_for_log,
     generate_uuid,
     is_called_from_async_context,
     merge,

--- a/dynamiq/utils/run_context.py
+++ b/dynamiq/utils/run_context.py
@@ -1,9 +1,9 @@
 """Per-node-run correlation id for log lines.
 
 Set by ``Node.run_sync`` / ``Node._run_async_native`` after ``_prepare_execution``
-mints ``run_id``, so helpers like ``log_execution_start`` / ``log_execution_finish``
-(and private format helpers that never receive ``kwargs``) can tag matching
-started/finished lines without threading the id through every signature.
+mints ``run_id``, so ``Node._node_run_log`` and related helpers can tag every
+lifecycle line (start/finish, retries, errors, skip/cancel) without threading
+the id through every signature.
 """
 
 from contextvars import ContextVar, Token

--- a/dynamiq/utils/run_context.py
+++ b/dynamiq/utils/run_context.py
@@ -1,0 +1,28 @@
+"""Per-node-run correlation id for log lines.
+
+Set by ``Node.run_sync`` / ``Node._run_async_native`` after ``_prepare_execution``
+mints ``run_id``, so helpers like ``log_execution_start`` / ``log_execution_finish``
+(and private format helpers that never receive ``kwargs``) can tag matching
+started/finished lines without threading the id through every signature.
+"""
+
+from contextvars import ContextVar, Token
+from uuid import UUID
+
+_current_node_run_id: ContextVar[str | None] = ContextVar("dynamiq_node_run_id", default=None)
+
+
+def set_node_run_id(run_id: UUID | str) -> Token:
+    """Bind the active node run id for the current context. Returns a reset token."""
+    return _current_node_run_id.set(str(run_id))
+
+
+def reset_node_run_id(token: Token) -> None:
+    """Restore the previous node run id using the token from ``set_node_run_id``."""
+    _current_node_run_id.reset(token)
+
+
+def current_node_run_id() -> str:
+    """Short form of the active node run id, or ``-`` when unset."""
+    run_id = _current_node_run_id.get()
+    return run_id[:8] if run_id else "-"

--- a/dynamiq/utils/utils.py
+++ b/dynamiq/utils/utils.py
@@ -153,6 +153,46 @@ def serialize_files_in_value(value: Any) -> Any:
     return value
 
 
+def _file_name_for_log(file_obj: Any, index: int | None = None) -> str:
+    """Return a log-safe label for a file-like object (name only, never content)."""
+    name = getattr(file_obj, "name", None)
+    if name:
+        return str(name)
+    if index is not None:
+        return f"file_{index}"
+    return "<unnamed file>"
+
+
+def format_value_for_log(value: Any) -> Any:
+    """Recursively replace BytesIO/bytes with file names for safe logging.
+
+    Mirrors :func:`serialize_files_in_value` structure but never embeds file content —
+    only ``name`` (or a ``file_{i}`` / ``<unnamed file>`` placeholder).
+    """
+    if isinstance(value, BytesIO):
+        return _file_name_for_log(value)
+    if isinstance(value, bytes):
+        return f"<bytes len={len(value)}>"
+    if isinstance(value, dict):
+        return {k: format_value_for_log(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [
+            _file_name_for_log(item, i) if isinstance(item, BytesIO) else format_value_for_log(item)
+            for i, item in enumerate(value)
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            _file_name_for_log(item, i) if isinstance(item, BytesIO) else format_value_for_log(item)
+            for i, item in enumerate(value)
+        )
+    if isinstance(value, BaseModel):
+        data = {k: format_value_for_log(getattr(value, k)) for k in type(value).model_fields}
+        if value.model_extra:
+            data.update({k: format_value_for_log(v) for k, v in value.model_extra.items()})
+        return data
+    return value
+
+
 def encode_bytes(value: bytes) -> str:
     """
     Encode a bytes object to an encoded string (lossy - for display/tracing).

--- a/tests/unit/nodes/test_node.py
+++ b/tests/unit/nodes/test_node.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 import time
+from io import BytesIO
 from queue import Queue
 from threading import Event
 from typing import ClassVar
@@ -10,7 +11,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from dynamiq.connections import OpenAI as OpenAIConnection
 from dynamiq.nodes.llms.openai import OpenAI
-from dynamiq.nodes.node import ErrorHandling, Node, NodeGroup
+from dynamiq.nodes.node import LOG_PAYLOAD_MAX_CHARS, ErrorHandling, Node, NodeGroup
 from dynamiq.runnables import RunnableConfig, RunnableResult, RunnableStatus
 from dynamiq.types.cancellation import check_cancellation
 from dynamiq.types.streaming import StreamingConfig, StreamingEventMessage
@@ -977,3 +978,50 @@ def test_clone_shared_survives_multiple_clones():
     assert clone1.shared is node.shared
     assert clone2.shared is node.shared
     assert clone3.shared is node.shared, "Shared reference was lost when cloning a clone."
+
+
+def test_dump_for_log_caps_large_payload():
+    """A large node result must never render an unbounded DEBUG log line."""
+    payload = {
+        "content": "formatted answer " * 500,
+        "documents": [
+            {"content": "lorem ipsum " * 200, "embedding": [0.1] * 1536, "metadata": {"source": f"doc{i}.pdf"}}
+            for i in range(100)
+        ],
+    }
+    untruncated = len(str(payload))
+    rendered = Node._dump_for_log(payload)
+
+    assert untruncated > 100_000, "Fixture is too small to exercise truncation."
+    assert len(rendered) <= LOG_PAYLOAD_MAX_CHARS
+    assert "..." in rendered, "Truncation points should be marked so readers know data was omitted."
+
+
+def test_dump_for_log_keeps_small_payload_intact():
+    """Payloads under the limits must not be mangled by the bounded renderer."""
+    rendered = Node._dump_for_log({"query": "who is on call?", "top_k": 3})
+
+    assert "who is on call?" in rendered
+    assert "3" in rendered
+    assert "[truncated]" not in rendered
+
+
+def test_dump_for_log_never_writes_file_content():
+    """BytesIO must be reduced to its name, and raw bytes to a length marker."""
+    named = BytesIO(b"super secret file body")
+    named.name = "report.pdf"
+
+    rendered = Node._dump_for_log({"files": [named], "blob": b"super secret raw body"})
+
+    assert "report.pdf" in rendered
+    assert "secret" not in rendered, "File content leaked into the log payload."
+
+
+def test_dump_for_log_survives_unrenderable_value():
+    """A value whose repr raises must not break node logging."""
+
+    class Exploding:
+        def __repr__(self):
+            raise RuntimeError("boom")
+
+    assert Node._dump_for_log({"bad": Exploding()})


### PR DESCRIPTION
## Summary

INFO logs were leaking PII and other sensitive payloads (tool inputs/results, agent thoughts, file contents, final answers). This PR makes the default INFO stream safe for production while keeping full detail available at DEBUG, correlated by a short per-node `run=` id.

### What changed

- **Payload-free INFO / payload at DEBUG**
  - Node start/finish: INFO has `run=<id> started.` / `finished.`; input and result dump only at DEBUG.
  - Agent reasoning: INFO keeps `Loop N: Action: <tool>` and `final answer produced`; Thought, Action Input, and Final answer move to DEBUG.
- **Centralized node lifecycle logging**
  - Start/finish (and related lifecycle lines) go through `Node._node_run_log` / helpers in `execute_with_retry` and `execute_async_with_retry`.
  - Removed duplicate per-tool / per-node “started with input” / “finished with RESULT” logs from execute methods.
- **Safe file logging**
  - New `format_value_for_log`: `BytesIO` → file name, `bytes` → `<bytes len=N>` (no binary/content in logs).
- **Run-id correlation on all node lifecycle paths**
  - Same short `run=` on started/finished, retries, errors, timeouts, succeed/fail/skip/cancel, approvals, and connection reinit.
  - Retries share one `run=` for the outer node run (per-attempt IDs remain in tracing as `execution_run_id`).
- **Cleanup**
  - Dropped the always-true “Running ReAct strategy” INFO line (ReAct is the only agent strategy).
  - Stopped truncating action names in INFO logs.
  - Punctuated start/finish lines for consistency (`started.` / `finished.`).

Set `DEBUG=1` (or equivalent logging config) to see inputs/results, thoughts, and action inputs.