### PR TITLE
feat(audio): add MiniMax speech synthesis

### DIFF
--- a/dynamiq/connections/connections.py
+++ b/dynamiq/connections/connections.py
@@ -641,6 +641,38 @@ class ElevenLabs(Http):
         return self
 
 
+class MiniMaxRegion(str, enum.Enum):
+    """MiniMax API regions."""
+
+    GLOBAL = "global"
+    CHINA = "china"
+
+
+_MINIMAX_TTS_URL_BY_REGION = {
+    MiniMaxRegion.GLOBAL: "https://api.minimax.io/v1/t2a_v2",
+    MiniMaxRegion.CHINA: "https://api.minimaxi.com/v1/t2a_v2",
+}
+
+
+class MiniMax(Http):
+    """Represents an HTTP connection to the MiniMax speech synthesis API."""
+
+    region: MiniMaxRegion = MiniMaxRegion.GLOBAL
+    url: str = Field(default_factory=partial(get_env_var, "MINIMAX_TTS_URL", ""))
+    method: HTTPMethod = HTTPMethod.POST
+    api_key: str = Field(default_factory=partial(get_env_var, "MINIMAX_API_KEY"))
+
+    @model_validator(mode="after")
+    def setup_connection(self) -> "MiniMax":
+        """Select the regional endpoint and configure bearer authentication."""
+        if not self.url:
+            self.url = _MINIMAX_TTS_URL_BY_REGION[self.region]
+        self.headers.update({"Content-Type": "application/json"})
+        if self.api_key:
+            self.headers.update({"Authorization": f"Bearer {self.api_key}"})
+        return self
+
+
 class Pinecone(BaseApiKeyConnection):
     """
     Represents a connection to the Pinecone service.

--- a/dynamiq/nodes/audio/__init__.py
+++ b/dynamiq/nodes/audio/__init__.py
@@ -1,2 +1,3 @@
 from .elevenlabs import ElevenLabsSTS, ElevenLabsTTS, Voices
+from .minimax import MiniMaxAudioFormat, MiniMaxOutputFormat, MiniMaxSpeechModel, MiniMaxTTS
 from .whisper import WhisperSTT

--- a/dynamiq/nodes/audio/minimax.py
+++ b/dynamiq/nodes/audio/minimax.py
@@ -1,0 +1,174 @@
+import enum
+import io
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field
+
+from dynamiq.connections import MiniMax as MiniMaxConnection
+from dynamiq.nodes import ErrorHandling
+from dynamiq.nodes.exceptions import NodeFailedException
+from dynamiq.nodes.node import ConnectionNode, NodeGroup, ensure_config
+from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
+
+
+class MiniMaxSpeechModel(str, enum.Enum):
+    """MiniMax speech synthesis models."""
+
+    SPEECH_2_8_HD = "speech-2.8-hd"
+    SPEECH_2_8_TURBO = "speech-2.8-turbo"
+    SPEECH_2_6_HD = "speech-2.6-hd"
+    SPEECH_2_6_TURBO = "speech-2.6-turbo"
+    SPEECH_02_HD = "speech-02-hd"
+    SPEECH_02_TURBO = "speech-02-turbo"
+    SPEECH_01_HD = "speech-01-hd"
+    SPEECH_01_TURBO = "speech-01-turbo"
+
+
+class MiniMaxAudioFormat(str, enum.Enum):
+    """Supported MiniMax speech audio formats."""
+
+    MP3 = "mp3"
+    WAV = "wav"
+    FLAC = "flac"
+    PCM = "pcm"
+
+
+class MiniMaxOutputFormat(str, enum.Enum):
+    """MiniMax non-streaming response encodings."""
+
+    HEX = "hex"
+    URL = "url"
+
+
+_CONTENT_TYPE_BY_FORMAT = {
+    MiniMaxAudioFormat.MP3: "audio/mpeg",
+    MiniMaxAudioFormat.WAV: "audio/wav",
+    MiniMaxAudioFormat.FLAC: "audio/flac",
+    MiniMaxAudioFormat.PCM: "audio/pcm",
+}
+
+
+class MiniMaxTTSInputSchema(BaseModel):
+    """Input for MiniMax speech synthesis."""
+
+    text: str = Field(..., max_length=9999, description="Text to synthesize into speech.")
+    output_file_name: str | None = Field(
+        default=None,
+        description="Optional filename for the generated audio file.",
+    )
+
+
+class MiniMaxTTS(ConnectionNode):
+    """Synthesizes speech with the MiniMax synchronous text-to-audio API."""
+
+    group: Literal[NodeGroup.AUDIO] = NodeGroup.AUDIO
+    name: str = "minimax-tts"
+    connection: MiniMaxConnection | None = None
+    error_handling: ErrorHandling = Field(default_factory=lambda: ErrorHandling(timeout_seconds=600))
+    model: MiniMaxSpeechModel | str = MiniMaxSpeechModel.SPEECH_2_8_HD
+    stream: Literal[False] = Field(default=False, description="Use the synchronous non-streaming response.")
+    language_boost: str | None = Field(default=None, description="Language or dialect recognition boost.")
+    output_format: MiniMaxOutputFormat = MiniMaxOutputFormat.HEX
+    voice_setting: dict[str, Any] | None = Field(default=None, description="Voice selection and delivery settings.")
+    pronunciation_dict: dict[str, Any] | None = Field(default=None, description="Pronunciation replacements.")
+    audio_setting: dict[str, Any] = Field(
+        default_factory=lambda: {"format": MiniMaxAudioFormat.MP3.value},
+        description="Audio format, sample rate, bitrate, and channel settings.",
+    )
+    voice_modify: dict[str, Any] | None = Field(default=None, description="Voice effect settings.")
+    subtitle_enable: bool = Field(default=False, description="Include subtitle data in the response.")
+    output_file_name: str | None = None
+    input_schema: ClassVar[type[MiniMaxTTSInputSchema]] = MiniMaxTTSInputSchema
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize MiniMax speech synthesis.
+
+        Args:
+            **kwargs: Node configuration, including an optional client or connection.
+        """
+        if kwargs.get("client") is None and kwargs.get("connection") is None:
+            kwargs["connection"] = MiniMaxConnection()
+        super().__init__(**kwargs)
+
+    def execute(
+        self, input_data: MiniMaxTTSInputSchema, config: RunnableConfig = None, **kwargs
+    ) -> dict[str, bytes | list[io.BytesIO]]:
+        """Generate an audio file from text.
+
+        Args:
+            input_data: Text and optional output filename.
+            config: Runtime configuration.
+            **kwargs: Callback metadata.
+
+        Returns:
+            Raw audio bytes and a named in-memory audio file.
+
+        Raises:
+            NodeFailedException: If the API reports an error or returns malformed audio data.
+        """
+        config = ensure_config(config)
+        check_cancellation(config)
+        self.run_on_node_execute_run(config.callbacks, **kwargs)
+
+        request = {
+            "model": self.model.value if isinstance(self.model, MiniMaxSpeechModel) else self.model,
+            "text": input_data.text,
+            "stream": self.stream,
+            "output_format": self.output_format.value,
+            "audio_setting": self.audio_setting,
+            "subtitle_enable": self.subtitle_enable,
+        }
+        request.update(
+            {
+                key: value
+                for key, value in {
+                    "language_boost": self.language_boost,
+                    "voice_setting": self.voice_setting,
+                    "pronunciation_dict": self.pronunciation_dict,
+                    "voice_modify": self.voice_modify,
+                }.items()
+                if value is not None
+            }
+        )
+
+        response = self.client.request(
+            method=self.connection.method,
+            url=self.connection.url,
+            headers=self.connection.headers,
+            json={**request, **(self.connection.data or {})},
+        )
+        if response.status_code != 200:
+            response.raise_for_status()
+
+        body = response.json()
+        base = body.get("base_resp") or {}
+        data = body.get("data") or {}
+        if base.get("status_code") != 0 or data.get("status") != 2:
+            message = base.get("status_msg") or "The speech synthesis request did not complete."
+            raise NodeFailedException(message=f"MiniMax speech synthesis failed: {message}")
+
+        audio = data.get("audio")
+        if not isinstance(audio, str) or not audio:
+            raise NodeFailedException(message="MiniMax speech synthesis returned no audio data.")
+
+        if self.output_format == MiniMaxOutputFormat.URL:
+            audio_response = self.client.get(audio)
+            if audio_response.status_code != 200:
+                audio_response.raise_for_status()
+            audio_bytes = audio_response.content
+        else:
+            try:
+                audio_bytes = bytes.fromhex(audio)
+            except ValueError as error:
+                raise NodeFailedException(
+                    message="MiniMax speech synthesis returned invalid hex audio data."
+                ) from error
+
+        audio_format = MiniMaxAudioFormat(self.audio_setting.get("format", MiniMaxAudioFormat.MP3.value))
+        output_file_name = input_data.output_file_name or self.output_file_name or f"audio.{audio_format.value}"
+        audio_file = io.BytesIO(audio_bytes)
+        audio_file.name = output_file_name
+        audio_file.content_type = _CONTENT_TYPE_BY_FORMAT[audio_format]
+
+        return {"content": audio_bytes, "files": [audio_file]}

--- a/tests/integration/nodes/audio/test_minimax.py
+++ b/tests/integration/nodes/audio/test_minimax.py
@@ -1,0 +1,129 @@
+from io import BytesIO
+
+import pytest
+
+from dynamiq import Workflow, connections
+from dynamiq.flows import Flow
+from dynamiq.nodes.audio import MiniMaxAudioFormat, MiniMaxOutputFormat, MiniMaxSpeechModel, MiniMaxTTS
+from dynamiq.nodes.audio.minimax import MiniMaxTTSInputSchema
+from dynamiq.nodes.exceptions import NodeFailedException
+from dynamiq.runnables import RunnableStatus
+
+
+def test_minimax_tts_decodes_hex_audio_and_sends_supported_fields(requests_mock) -> None:
+    audio = b"generated audio"
+    connection = connections.MiniMax(api_key="api-key")
+    node = MiniMaxTTS(
+        connection=connection,
+        voice_setting={"voice_id": "English_expressive_narrator"},
+        pronunciation_dict={"tone": ["Dynamiq/dynamic"]},
+        audio_setting={"format": "mp3", "sample_rate": 32000, "bitrate": 128000, "channel": 1},
+        voice_modify={"pitch": 1},
+        language_boost="auto",
+        subtitle_enable=True,
+    )
+    call = requests_mock.post(
+        connection.url,
+        json={
+            "data": {"audio": audio.hex(), "status": 2},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        },
+    )
+
+    workflow = Workflow(flow=Flow(nodes=[node]))
+    result = workflow.run(input_data={"text": "Hello", "output_file_name": "speech.mp3"})
+
+    assert result.status == RunnableStatus.SUCCESS
+    output = result.output[node.id]["output"]
+    assert output["content"] == audio
+    assert isinstance(output["files"][0], BytesIO)
+    assert output["files"][0].name == "speech.mp3"
+    assert output["files"][0].content_type == "audio/mpeg"
+    assert call.last_request.headers["Authorization"] == "Bearer api-key"
+    assert call.last_request.json() == {
+        "model": "speech-2.8-hd",
+        "text": "Hello",
+        "stream": False,
+        "language_boost": "auto",
+        "output_format": "hex",
+        "voice_setting": {"voice_id": "English_expressive_narrator"},
+        "pronunciation_dict": {"tone": ["Dynamiq/dynamic"]},
+        "audio_setting": {"format": "mp3", "sample_rate": 32000, "bitrate": 128000, "channel": 1},
+        "voice_modify": {"pitch": 1},
+        "subtitle_enable": True,
+    }
+
+
+def test_minimax_tts_uses_china_endpoint_and_downloads_url_audio(requests_mock) -> None:
+    audio = b"wave audio"
+    connection = connections.MiniMax(region=connections.MiniMaxRegion.CHINA, api_key="api-key")
+    node = MiniMaxTTS(
+        connection=connection,
+        output_format=MiniMaxOutputFormat.URL,
+        audio_setting={"format": MiniMaxAudioFormat.WAV.value},
+    )
+    audio_url = "https://audio.example.test/generated.wav"
+    call = requests_mock.post(
+        "https://api.minimaxi.com/v1/t2a_v2",
+        json={
+            "data": {"audio": audio_url, "status": 2},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        },
+    )
+    download = requests_mock.get(audio_url, content=audio)
+
+    result = Workflow(flow=Flow(nodes=[node])).run(input_data={"text": "Hello"})
+
+    output = result.output[node.id]["output"]
+    assert call.called_once
+    assert download.called_once
+    assert output["content"] == audio
+    assert output["files"][0].name == "audio.wav"
+    assert output["files"][0].content_type == "audio/wav"
+
+
+def test_minimax_tts_raises_for_api_failure(requests_mock) -> None:
+    connection = connections.MiniMax(api_key="api-key")
+    node = MiniMaxTTS(connection=connection)
+    requests_mock.post(
+        connection.url,
+        json={
+            "data": {"audio": "", "status": 1},
+            "base_resp": {"status_code": 1008, "status_msg": "insufficient balance"},
+        },
+    )
+    node.init_components()
+
+    with pytest.raises(NodeFailedException, match="insufficient balance"):
+        node.execute(MiniMaxTTSInputSchema(text="Hello"))
+
+
+def test_minimax_tts_exposes_current_speech_models() -> None:
+    assert {model.value for model in MiniMaxSpeechModel} == {
+        "speech-2.8-hd",
+        "speech-2.8-turbo",
+        "speech-2.6-hd",
+        "speech-2.6-turbo",
+        "speech-02-hd",
+        "speech-02-turbo",
+        "speech-01-hd",
+        "speech-01-turbo",
+    }
+
+
+def test_minimax_tts_yaml_round_trip(tmp_path) -> None:
+    node = MiniMaxTTS(
+        connection=connections.MiniMax(region=connections.MiniMaxRegion.CHINA, api_key="api-key"),
+        model=MiniMaxSpeechModel.SPEECH_2_8_TURBO,
+        audio_setting={"format": MiniMaxAudioFormat.FLAC.value},
+    )
+    workflow = Workflow(flow=Flow(nodes=[node]))
+    yaml_path = tmp_path / "minimax-tts.yaml"
+
+    workflow.to_yaml_file(str(yaml_path))
+    loaded = Workflow.from_yaml_file(str(yaml_path), init_components=False).flow.nodes[0]
+
+    assert isinstance(loaded, MiniMaxTTS)
+    assert loaded.model == MiniMaxSpeechModel.SPEECH_2_8_TURBO
+    assert loaded.audio_setting == {"format": "flac"}
+    assert loaded.connection.region == connections.MiniMaxRegion.CHINA


### PR DESCRIPTION
Reason: Dynamiq's audio node layer does not currently support MiniMax speech synthesis across its global and China API regions.

This adds:
- a regional MiniMax HTTP connection using bearer authentication
- a MiniMax text-to-speech node with the current speech model catalog and supported request controls
- parsing for hex and URL audio responses, plus focused tests for requests, errors, regions, and YAML round-tripping

Checks:
- `uv run pytest tests/integration/nodes/audio/test_minimax.py -q`
- `uv run pytest tests/integration/nodes/audio/test_elevenlabs.py tests/integration/nodes/audio/test_whisper.py tests/integration/nodes/audio/test_minimax.py -q`
- `uv run pre-commit run --files dynamiq/connections/connections.py dynamiq/nodes/audio/__init__.py dynamiq/nodes/audio/minimax.py tests/integration/nodes/audio/test_minimax.py`
