### PR TITLE
fix(agents): give the code executor its file store on an empty store

### DIFF
--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -1544,6 +1544,13 @@ class Agent(AgentIterativeCheckpointMixin, Node):
         if not tool.is_files_allowed:
             return
 
+        # Wiring the store is independent of whether anything is in it: a
+        # PythonCodeExecutor refuses to run without one, and the store is empty
+        # on any run where the user uploaded no files — which is most of them.
+        if isinstance(tool, PythonCodeExecutor) and not tool.file_store and self.file_store_backend:
+            tool.file_store = self.file_store_backend
+            logger.debug(f"Agent {self.name} - {self.id}: injected file_store into PythonCodeExecutor tool {tool.name}")
+
         file_paths = self._extract_file_paths_from_input(tool, merged_input)
 
         if self.sandbox_backend and file_paths:
@@ -1575,10 +1582,6 @@ class Agent(AgentIterativeCheckpointMixin, Node):
 
         if isinstance(tool, Python):
             merged_input["files"] = files
-
-        if isinstance(tool, PythonCodeExecutor) and not tool.file_store and self.file_store_backend:
-            tool.file_store = self.file_store_backend
-            logger.debug(f"Agent {self.name} - {self.id}: injected file_store into PythonCodeExecutor tool {tool.name}")
 
     def _run_tool(
         self,

--- a/tests/unit/nodes/agents/test_python_code_executor_file_store_wiring.py
+++ b/tests/unit/nodes/agents/test_python_code_executor_file_store_wiring.py
@@ -1,0 +1,72 @@
+import pytest
+
+from dynamiq.connections import OpenAI as OpenAIConnection
+from dynamiq.nodes.agents import Agent
+from dynamiq.nodes.llms import OpenAI
+from dynamiq.nodes.tools.python_code_executor import PythonCodeExecutor
+from dynamiq.storages.file.base import FileStoreConfig
+from dynamiq.storages.file.in_memory import InMemoryFileStore
+
+
+@pytest.fixture
+def test_llm():
+    return OpenAI(connection=OpenAIConnection(api_key="test-api-key"), model="gpt-4o", max_tokens=100, temperature=0)
+
+
+def _agent_with_store(llm, tool, store):
+    return Agent(
+        name="Agent",
+        llm=llm,
+        role="r",
+        tools=[tool],
+        file_store=(
+            FileStoreConfig(enabled=True, backend=store)
+            if store
+            else FileStoreConfig(enabled=False, backend=InMemoryFileStore())
+        ),
+    )
+
+
+def test_file_store_injected_when_store_is_empty(test_llm):
+    """The first run of any agent: the store is enabled but nothing was uploaded.
+
+    PythonCodeExecutor refuses to run without a file store, so an empty store is
+    the case that has to work, not the exception.
+    """
+    tool = PythonCodeExecutor(name="code-interpreter")
+    store = InMemoryFileStore()
+    agent = _agent_with_store(test_llm, tool, store)
+
+    agent._inject_files_into_tool(tool, {})
+
+    assert tool.file_store is store
+
+
+def test_file_store_injected_when_store_has_files(test_llm):
+    tool = PythonCodeExecutor(name="code-interpreter")
+    store = InMemoryFileStore()
+    store.store("notes.txt", b"hello")
+    agent = _agent_with_store(test_llm, tool, store)
+
+    agent._inject_files_into_tool(tool, {})
+
+    assert tool.file_store is store
+
+
+def test_tool_keeps_its_own_file_store(test_llm):
+    own_store = InMemoryFileStore()
+    tool = PythonCodeExecutor(name="code-interpreter", file_store=own_store)
+    agent = _agent_with_store(test_llm, tool, InMemoryFileStore())
+
+    agent._inject_files_into_tool(tool, {})
+
+    assert tool.file_store is own_store
+
+
+def test_nothing_injected_without_an_agent_file_store(test_llm):
+    tool = PythonCodeExecutor(name="code-interpreter")
+    agent = _agent_with_store(test_llm, tool, None)
+
+    agent._inject_files_into_tool(tool, {})
+
+    assert tool.file_store is None


### PR DESCRIPTION
## Problem

An agent with a `PythonCodeExecutor` tool and a file store enabled fails on any run where nothing has been uploaded:

```
PythonCodeExecutor requires a configured file_store.
```

Which is most runs — "write and run some code" does not involve a file.

The tool refuses to run without a store:

```python
# dynamiq/nodes/tools/python_code_executor.py
if not self.file_store:
    raise ToolExecutionException("PythonCodeExecutor requires a configured file_store.", recoverable=False)
```

and the only place that ever gives it one is `Agent._inject_files_into_tool`. That line sits at the end of the method, after an early return taken when the store is empty:

```python
elif self.file_store_backend:
    files = self.file_store_backend.list_files_bytes()
    ...
if not files:
    return                      # <- empty store leaves here
...
if isinstance(tool, PythonCodeExecutor) and not tool.file_store and self.file_store_backend:
    tool.file_store = self.file_store_backend   # <- never reached
```

So the store is wired only as a side effect of there being files to map, and configuring one correctly is not enough to make the tool run. Uploading any file makes the same agent work, which is the tell.

`examples/use_cases/agents_use_cases/agent_coder.py` is built exactly this way — `PythonCodeExecutor()` with no store, plus `file_store=FileStoreConfig(enabled=True, ...)` on the agent — so it fails on a first prompt too.

## Fix

Move the injection above the guard. Wiring the store is independent of whether anything is in it; file collection and mapping are untouched.

```diff
         if not tool.is_files_allowed:
             return
 
+        if isinstance(tool, PythonCodeExecutor) and not tool.file_store and self.file_store_backend:
+            tool.file_store = self.file_store_backend
+            logger.debug(...)
+
         file_paths = self._extract_file_paths_from_input(tool, merged_input)
```

A tool given its own `file_store` still keeps it, and an agent without a store still injects nothing — both conditions were already in the guard and are unchanged.

## Tests

`tests/unit/nodes/agents/test_python_code_executor_file_store_wiring.py` covers the four cases: empty store, store with files, a tool carrying its own store, and an agent with no store. The first fails on `main` and passes here; the other three pass either way and are there to pin the behaviour that must not change.

Ran `tests/unit/nodes/agents` and `tests/unit/nodes/tools` with and without the change and diffed the failures: no test fails that did not already fail on `main`, and the only difference is the new empty-store case going green. `flake8` clean on both files.

## Not covered

`PythonCodeExecutor` used standalone, outside an agent, still has nothing to inject a store for it. Worth a default in-memory store if that is a use case worth supporting, but it is a separate change.