### PR TITLE
docs: fix contributor documentation typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Good documentation is key to a successful project. If you find areas in our docu
    git clone https://github.com/YOUR-USERNAME/dynamiq
    ```
 
-3. Create a virtaul environment and install project requirements:
+3. Create a virtual environment and install project requirements:
    ```sh
    make install
    ```

--- a/examples/use_cases/customer_support/README.md
+++ b/examples/use_cases/customer_support/README.md
@@ -19,7 +19,7 @@ This directory contains an example of a bank customer support workflow built usi
 
 1. The user provides a query (e.g., "fast block my card").
 2. `RAG Agent` is invoked to find relevant documentation on how to proceed with request.
-3. `API Agent` starts with documentation provided by `RAG Agent`. It will gather required informatiom from user and execute operation with API.
+3. `API Agent` starts with documentation provided by `RAG Agent`. It will gather required information from user and execute operation with API.
 4. Upon completion of the operation, a concise summary of the request and its status will be provided.
 
 ## Usage


### PR DESCRIPTION
## Summary

- correct `virtaul` in the contributor setup steps
- correct `informatiom` in the customer support example guide

## Validation

- `uv run pre-commit run --files CONTRIBUTING.md examples/use_cases/customer_support/README.md`
- `uvx codespell CONTRIBUTING.md examples/use_cases/customer_support/README.md`