### PR TITLE
fix: preserve json text in graph state inputs

### DIFF
--- a/dynamiq/nodes/agents/orchestrators/graph_state.py
+++ b/dynamiq/nodes/agents/orchestrators/graph_state.py
@@ -18,6 +18,16 @@ from dynamiq.types.cancellation import CanceledException
 from dynamiq.utils.logger import logger
 
 
+def _parse_manager_agent_input(result: str) -> Any:
+    normalized_result = result.strip()
+    if normalized_result.startswith("```") and normalized_result.endswith("```"):
+        opening_fence, separator, fenced_result = normalized_result.partition("\n")
+        if separator and opening_fence.strip().lower() in {"```", "```json"}:
+            normalized_result = fenced_result.rsplit("```", 1)[0].strip()
+
+    return json.loads(normalized_result)["input"]
+
+
 class StateInputSchema(BaseModel):
     context: dict[str, Any] = Field(..., description="Previous context objects.")
     chat_history: list[dict[str, Any]] = Field(..., description="Previous chat history.")
@@ -197,13 +207,7 @@ class GraphState(Node):
 
                 try:
                     agent_input = {
-                        "input": json.loads(
-                            manager_result.output.get("content")
-                            .get("result")
-                            .replace("json", "")
-                            .replace("```", "")
-                            .strip()
-                        )["input"]
+                        "input": _parse_manager_agent_input(manager_result.output.get("content").get("result"))
                     }
                 except Exception as e:
                     logger.error(f"GraphOrchestrator: Error when parsing response about next state {e}")

--- a/tests/unit/nodes/agents/test_graph_state.py
+++ b/tests/unit/nodes/agents/test_graph_state.py
@@ -1,0 +1,19 @@
+import json
+
+import pytest
+
+from dynamiq.nodes.agents.orchestrators.graph_state import _parse_manager_agent_input
+
+
+@pytest.mark.parametrize(
+    ("manager_result", "expected_input"),
+    [
+        (json.dumps({"input": "Analyze this json document"}), "Analyze this json document"),
+        (json.dumps({"input": "Explain ```json fenced output"}), "Explain ```json fenced output"),
+        (f"```\n{json.dumps({'input': 'Analyze this json document'})}\n```", "Analyze this json document"),
+        (f"```json\n{json.dumps({'input': 'Analyze this json document'})}\n```", "Analyze this json document"),
+        (f"```JSON\n{json.dumps({'input': 'Analyze this json document'})}\n```", "Analyze this json document"),
+    ],
+)
+def test_parse_manager_agent_input_preserves_json_substring(manager_result: str, expected_input: str):
+    assert _parse_manager_agent_input(manager_result) == expected_input


### PR DESCRIPTION
Fixes #891.

## Summary

- parse manager assignments from plain JSON or a complete Markdown JSON fence
- stop globally removing `json` and backtick substrings from the model response
- preserve valid business text such as `Analyze this json document`
- add regression coverage for plain JSON, unlabelled fences, and lowercase or uppercase JSON fences

## Validation

- `uv run pytest tests/unit/nodes/agents/test_graph_state.py tests/integration/nodes/orchestrators/test_graph_orchestrators.py -q` - 8 passed
- `uv run pre-commit run --files dynamiq/nodes/agents/orchestrators/graph_state.py tests/unit/nodes/agents/test_graph_state.py` - all hooks passed

## Compatibility

No public API or dependency changes. Existing plain JSON and fenced JSON responses remain supported.