### PR TITLE
docs(readme): add missing import asyncio to async ReAct agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ print(result.output)
 An agent that has the access to E2B Code Interpreter and is capable of solving complex coding tasks.
 
 ```python
+import asyncio
+
 from dynamiq.nodes.llms.openai import OpenAI
 from dynamiq.connections import OpenAI as OpenAIConnection, E2B as E2BConnection
 from dynamiq.nodes.agents import Agent


### PR DESCRIPTION
### Problem

The **"Simple ReAct Agent with asynchronous execution"** example ends with:

```python
if __name__ == "__main__":
    asyncio.run(run_async_agent())
```

but the snippet never imports `asyncio` — its import block only pulls in `dynamiq` symbols. Copy-pasting the example exactly as written and running it raises:

```
NameError: name 'asyncio' is not defined
```

right at the final line, so the async quickstart does not run out of the box. This is the only snippet in the README that calls into the stdlib `asyncio` module, and it is the only one missing the corresponding import.

### Fix

Add a single `import asyncio` line to that snippet's import block (kept at the top as a stdlib import, separated from the `dynamiq` imports). One line, docs-only, no code/behavior change.

### Verification

- `grep -n asyncio README.md` before the change shows exactly one hit — the `asyncio.run(...)` call — and no `import asyncio` anywhere, confirming the reference is unresolved.
- After the change, `asyncio` resolves, and every other symbol used in the snippet (`OpenAI`, `OpenAIConnection`, `E2BConnection`, `Agent`, `E2BInterpreterTool`) is already imported in the same block, so the example is now self-contained.

Thanks for the great library!