### PR TITLE
fix(agents): execute every requested tool call and pair results by id

### DIFF
--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -610,22 +610,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
         return self
 
-    def _acknowledge_pending_fc_tool_calls(self, content: str) -> None:
-        """Answer and clear any pending FC tool_call ids with a neutral stub.
-
-        Keeps OpenAI's function-calling protocol valid when tool calls are
-        abandoned without execution (e.g. the model returned ``provide_final_answer``
-        alongside other tool calls), so no unpaired ``tool_call`` is left to 400 a
-        subsequent request and recovery for unrelated errors is not misdirected to
-        these ids.
-        """
-        pending_ids = getattr(self, "_pending_fc_tool_call_ids", None) or []
-        for tc_id in pending_ids:
-            self._prompt.messages.append(
-                Message(role=MessageRole.TOOL, content=content, tool_call_id=tc_id, static=True)
-            )
-        self._pending_fc_tool_call_ids = []
-
     def _append_recovery_instruction(
         self,
         *,
@@ -890,10 +874,8 @@ class Agent(HistoryManagerMixin, BaseAgent):
                                 static=True,
                             )
                         )
-                        # An answer batched with tool calls was written before those results
-                        # existed, so it cannot be informed by them and is not accepted.
-                        # Saying so is what lets the model answer for real on the next step
-                        # instead of re-emitting the same batch.
+                        # Declined when batched with tools: the answer predates their
+                        # results. Saying so is what stops the model re-emitting the batch.
                         final_answer_reply = (
                             "Not accepted: you requested tools in this same step, so this answer was "
                             "written before their results existed. Their results follow — answer "
@@ -996,7 +978,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
         final_answer_call = next((tc for tc in tool_calls if tc.function.name.strip() == "provide_final_answer"), None)
 
         if final_answer_call is not None and not actual_tool_calls:
-            self._acknowledge_pending_fc_tool_calls("Skipped — superseded by a final-answer call.")
             final_args = final_answer_call.function.parse_as_final_answer()
             thought = final_args.thought
             self._requested_output_files = self._parse_output_files_csv(final_args.output_files)
@@ -1524,7 +1505,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
         self,
         tool_result: Any,
         ordered_results: list[dict[str, Any]] | None = None,
-        tool_name: str | None = None,
         success: Any = None,
     ) -> None:
         """Append tool observations to prompt history.
@@ -1566,7 +1546,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                             else mark_tool_failure(str(tool_result), success)
                         ),
                         tool_call_id=tc_id,
-                        name=result.get("tool_name") if result else tool_name,
+                        name=result.get("tool_name") if result else None,
                         static=True,
                     )
                 )
@@ -1595,7 +1575,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             logger.error(error_message)
             # Emitted, not added as a bare observation: the batch never ran, so every id
             # in it is answered with the parse error that applies to all of them.
-            self._emit_tool_observations(error_message, tool_name=PARALLEL_TOOL_NAME, success=False)
+            self._emit_tool_observations(error_message, success=False)
             return None
 
     def _check_subagent_limits(self, tools_data: list[dict[str, Any]], action: str) -> str | None:
@@ -1723,7 +1703,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             if subagent_error:
                 # Emitted, not added as a bare observation: no call ran, so every id in
                 # the batch is answered with the refusal that applies to all of them.
-                self._emit_tool_observations(subagent_error, tool_name=action, success=False)
+                self._emit_tool_observations(subagent_error, success=False)
                 return None
 
             ordered_results: list[dict[str, Any]] = []
@@ -1734,11 +1714,27 @@ class Agent(HistoryManagerMixin, BaseAgent):
                     tools_data, thought, loop_num, config, **kwargs
                 )
             else:
-                tool_result, _, is_delegated, tool_success, _ = self._execute_single_tool(
+                tool_result, tool_files, is_delegated, tool_success, _ = self._execute_single_tool(
                     action, action_input, thought, loop_num, config, **kwargs
                 )
                 if is_delegated:
                     return tool_result
+                # Wrapped in the same shape ``_execute_tools`` produces, so one executed
+                # call reaches its own id the same way a batch does. Only when this step
+                # is that call: compaction also lands here, having filtered a batch whose
+                # other ids it cannot answer.
+                pending_ids = self._current_tool_call_ids()
+                if len(pending_ids) == 1:
+                    ordered_results = [
+                        {
+                            "order": 0,
+                            "tool_call_id": pending_ids[0],
+                            "tool_name": action,
+                            "success": tool_success,
+                            "result": tool_result,
+                            "files": tool_files,
+                        }
+                    ]
 
             if skipped_tools:
                 skipped_notice = (
@@ -1748,7 +1744,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 )
                 tool_result = f"{tool_result}{skipped_notice}" if tool_result else skipped_notice
 
-            self._emit_tool_observations(tool_result, ordered_results, tool_name=action, success=tool_success)
+            self._emit_tool_observations(tool_result, ordered_results, success=tool_success)
 
         # else: No action or no tools available - no reasoning to stream
 

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -2389,11 +2389,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
         # Refused before execution: _execute_single_tool streams the delegated answer.
         if len(prepared_tools) > 1:
-            executable: list[dict[str, Any]] = []
             for tool_payload in prepared_tools:
                 tool = self.tool_by_names.get(self.sanitize_tool_name(tool_payload["name"]))
                 if not self._should_delegate_final(tool, tool_payload["input"]):
-                    executable.append(tool_payload)
                     continue
                 refusal = (
                     f"'{tool_payload['name']}' was not executed: delegate_final cannot be combined with "
@@ -2401,6 +2399,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                     "again without delegate_final to use its output as an observation."
                 )
                 logger.warning(f"Agent {self.name} - {self.id}: {refusal}")
+                tool_payload["refused"] = True
                 all_results.append(
                     {
                         "order": tool_payload["order"],
@@ -2411,7 +2410,11 @@ class Agent(HistoryManagerMixin, BaseAgent):
                         "files": [],
                     }
                 )
-            prepared_tools = executable
+
+        # Refused calls stay in prepared_tools so the batch stream keeps one entry per requested
+        # call: dropping them shifts every later tool onto a tool_run_id the client already bound
+        # to a different tool. Only execution skips them.
+        executable = [tp for tp in prepared_tools if not tp.get("refused")]
 
         def _execute_single_tool_to_result(tool_payload: dict[str, Any], **extra) -> dict[str, Any]:
             """Execute a single tool and wrap the result as a dict."""
@@ -2449,8 +2452,8 @@ class Agent(HistoryManagerMixin, BaseAgent):
                     prepared_tools, thought, loop_num, config, **kwargs
                 )
 
-                parallel_group = [tp for tp in prepared_tools if self._is_tool_parallel_eligible(tp["name"])]
-                sequential_group = [tp for tp in prepared_tools if not self._is_tool_parallel_eligible(tp["name"])]
+                parallel_group = [tp for tp in executable if self._is_tool_parallel_eligible(tp["name"])]
+                sequential_group = [tp for tp in executable if not self._is_tool_parallel_eligible(tp["name"])]
 
                 if sequential_group:
                     seq_names = [tp["name"] for tp in sequential_group]

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -174,6 +174,25 @@ class AgentState(BaseModel):
 
 UNKNOWN_TOOL_NAME = "unknown_tool"
 
+# Prefixed onto a tool result the model would otherwise read as a success. Applied
+# wherever a single result reaches the model without a status of its own: each
+# `role: tool` message in function-calling mode, and the legacy single-tool
+# `Observation:` message. Batched observations already carry their own per-tool
+# SUCCESS/ERROR header and are left alone. Successful results are never modified.
+TOOL_ERROR_PREFIX = "[tool_error]"
+
+
+def mark_tool_failure(content: str, success: Any) -> str:
+    """Tag a failed tool result so the model can tell it apart from a success.
+
+    Only ``success is False`` counts as a failure: ``None`` means the caller reported no
+    status, and is left alone rather than guessed at. Already-tagged content is returned
+    unchanged so repeated passes cannot stack prefixes.
+    """
+    if success is False and not content.startswith(TOOL_ERROR_PREFIX):
+        return f"{TOOL_ERROR_PREFIX} {content}"
+    return content
+
 
 class ReactStep(BaseModel):
     """Outcome of one ReAct reasoning step, in one of three shapes:
@@ -842,6 +861,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
                     for tc in tool_calls:
                         function_name = tc["function"]["name"].strip()
                         tc_id = tc.get("id") or generate_uuid()
+                        # Written back so the parse pass below reads the same id rather
+                        # than minting a second one for a provider that sent none.
+                        tc["id"] = tc_id
                         raw_args = tc["function"]["arguments"]
                         arguments_str = raw_args if isinstance(raw_args, str) else json.dumps(raw_args)
                         entry = {
@@ -855,9 +877,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                         if function_name == "provide_final_answer":
                             payload.append(entry)
                             fa_stub_ids.append(tc_id)
-                        elif self.parallel_tool_calls_enabled or not pending_ids:
-                            # Only the first non-final-answer call is kept when parallel
-                            # execution is disabled
+                        else:
                             payload.append(entry)
                             pending_ids.append(tc_id)
                     if payload:
@@ -870,11 +890,22 @@ class Agent(HistoryManagerMixin, BaseAgent):
                                 static=True,
                             )
                         )
+                        # An answer batched with tool calls was written before those results
+                        # existed, so it cannot be informed by them and is not accepted.
+                        # Saying so is what lets the model answer for real on the next step
+                        # instead of re-emitting the same batch.
+                        final_answer_reply = (
+                            "Not accepted: you requested tools in this same step, so this answer was "
+                            "written before their results existed. Their results follow — answer "
+                            "again using them."
+                            if pending_ids
+                            else "Acknowledged."
+                        )
                         for fa_id in fa_stub_ids:
                             self._prompt.messages.append(
                                 Message(
                                     role=MessageRole.TOOL,
-                                    content="Acknowledged.",
+                                    content=final_answer_reply,
                                     tool_call_id=fa_id,
                                     name="provide_final_answer",
                                     static=True,
@@ -954,27 +985,28 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 recoverable=True,
             )
 
-        first_call = tool_calls[0]
-        action = first_call.function.name.strip()
+        actual_tool_calls = [tc for tc in tool_calls if tc.function.name.strip() != "provide_final_answer"]
 
-        if action == "provide_final_answer":
+        # A model may put its final answer anywhere in the batch — llama-3.3-70b puts it
+        # last — so position is not used to find it. It is accepted only when nothing else
+        # was requested: an answer batched with tool calls was written before those results
+        # existed, so returning it hands back a guess and discards the work that would have
+        # informed it. Batched with tools, the tools run and the model answers on the next
+        # loop, told why the finish was declined (see _append_assistant_message).
+        final_answer_call = next((tc for tc in tool_calls if tc.function.name.strip() == "provide_final_answer"), None)
+
+        if final_answer_call is not None and not actual_tool_calls:
             self._acknowledge_pending_fc_tool_calls("Skipped — superseded by a final-answer call.")
-            final_args = first_call.function.parse_as_final_answer()
+            final_args = final_answer_call.function.parse_as_final_answer()
             thought = final_args.thought
             self._requested_output_files = self._parse_output_files_csv(final_args.output_files)
             self.log_final_output(thought, final_args.answer, loop_num)
             return thought, "final_answer", final_args.answer
 
-        actual_tool_calls = [tc for tc in tool_calls if tc.function.name.strip() != "provide_final_answer"]
-
-        if len(actual_tool_calls) > 1 and not self.parallel_tool_calls_enabled:
-            logger.warning(
-                f"Agent {self.name} - {self.id}: LLM returned {len(actual_tool_calls)} tool calls "
-                f"but parallel_tool_calls_enabled is False. Only the first tool call will be executed, "
-                f"remaining {len(actual_tool_calls) - 1} call(s) will be dropped."
-            )
-
-        if len(actual_tool_calls) > 1 and self.parallel_tool_calls_enabled:
+        # Every call the model asked for is executed. ``parallel_tool_calls_enabled``
+        # decides whether they run concurrently or one after another (see
+        # ``_is_tool_parallel_eligible``), never whether they run at all.
+        if len(actual_tool_calls) > 1:
             tool_items = []
             for tc in actual_tool_calls:
                 tc_name = tc.function.name.strip()
@@ -995,6 +1027,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                         name=tc_name,
                         input=tc_input,
                         thought=args.thought,
+                        tool_call_id=tc.id,
                     )
                 )
             thought = "\n".join(item.thought for item in tool_items if item.thought)
@@ -1049,8 +1082,19 @@ class Agent(HistoryManagerMixin, BaseAgent):
         except (json.JSONDecodeError, ValueError) as e:
             raise ActionParsingException(f"Error parsing action. {e}", recoverable=True)
 
-        if "action" not in llm_generated_output_json or "thought" not in llm_generated_output_json:
-            raise ActionParsingException("No action or thought provided.", recoverable=True)
+        # Valid JSON is not necessarily an object: `null`, a bare list, or a string all
+        # parse cleanly and then fail the membership test below with a TypeError, which is
+        # not recoverable and ends the run. Treated as a parse failure like any other, so
+        # the model gets a chance to answer again.
+        if not isinstance(llm_generated_output_json, dict):
+            raise ActionParsingException("Expected a JSON object containing 'thought' and 'action'.", recoverable=True)
+
+        # `action_input` belongs in the same check: the schema marks it required, and
+        # reading it below without one is a KeyError, which is not recoverable and ends the
+        # run, where a model that simply left a key out should just be asked again.
+        missing = [key for key in ("thought", "action", "action_input") if key not in llm_generated_output_json]
+        if missing:
+            raise ActionParsingException(f"Missing required field(s): {', '.join(missing)}.", recoverable=True)
 
         thought = llm_generated_output_json["thought"]
         action = llm_generated_output_json["action"]
@@ -1464,48 +1508,73 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 return [tc_id for tc in msg.tool_calls if (tc_id := tc.get("id")) is not None and tc_id not in answered]
         return []
 
+    def _current_tool_call_ids(self) -> list[str]:
+        """Ids still awaiting a reply: the live stash, or read back from history.
+
+        The stash is lost across a checkpoint/resume, so it cannot be the only source.
+        Both the side that stamps ids onto results and the side that consumes them read
+        from here, so the two always agree on which call is which.
+        """
+        pending = getattr(self, "_pending_fc_tool_call_ids", None) or []
+        if not pending and self.inference_mode == InferenceMode.FUNCTION_CALLING:
+            pending = self._unanswered_tool_call_ids()
+        return pending
+
     def _emit_tool_observations(
         self,
         tool_result: Any,
         ordered_results: list[dict[str, Any]] | None = None,
         tool_name: str | None = None,
+        success: Any = None,
     ) -> None:
         """Append tool observations to prompt history.
 
-        In FUNCTION_CALLING mode with stashed tool_call_ids, emits one
-        ``role: "tool"`` message per id (per-tool result for parallel runs,
-        the combined result for single-tool runs) — required by OpenAI's
-        function-calling protocol. Falls back to the legacy ``role: "user"``
-        ``Observation: ...`` message in all other cases.
+        In FUNCTION_CALLING mode every pending tool_call_id gets a reply, because a
+        request carrying an unanswered one is rejected by the provider outright.
+
+        Results are matched to ids by the ``tool_call_id`` each result carries, never by
+        position, so a batch that comes back out of order, partially, or not at all still
+        reaches the right calls. An id with no result of its own gets ``tool_result`` —
+        on the paths that end a batch early that is the explanation covering all of them.
+        A result that arrives without an id therefore costs that call its content, but
+        can never hand it another tool's output.
+
+        Every reply carries its status, so a failed call does not read as a result.
+
+        Falls back to the legacy ``role: "user"`` ``Observation: ...`` message in all
+        other cases.
+
+        Args:
+            success: Status of ``tool_result``, for the ids answered with it. Per-call
+                results carry their own; ``None`` means no status was reported.
         """
-        pending_ids = getattr(self, "_pending_fc_tool_call_ids", None) or []
-        if self.inference_mode == InferenceMode.FUNCTION_CALLING and not pending_ids:
-            pending_ids = self._unanswered_tool_call_ids()
+        pending_ids = self._current_tool_call_ids()
         if self.inference_mode == InferenceMode.FUNCTION_CALLING and pending_ids:
-            if ordered_results and len(ordered_results) == len(pending_ids):
-                for tc_id, result in zip(pending_ids, ordered_results):
-                    self._prompt.messages.append(
-                        Message(
-                            role=MessageRole.TOOL,
-                            content=str(result.get("result", "")),
-                            tool_call_id=tc_id,
-                            name=result.get("tool_name"),
-                            static=True,
-                        )
-                    )
-            else:
+            by_id = {
+                tc_id: result
+                for result in (ordered_results or [])
+                if (tc_id := result.get("tool_call_id")) is not None
+            }
+            for tc_id in pending_ids:
+                result = by_id.get(tc_id)
                 self._prompt.messages.append(
                     Message(
                         role=MessageRole.TOOL,
-                        content=str(tool_result),
-                        tool_call_id=pending_ids[0],
-                        name=tool_name,
+                        content=(
+                            mark_tool_failure(str(result.get("result", "")), result.get("success"))
+                            if result
+                            else mark_tool_failure(str(tool_result), success)
+                        ),
+                        tool_call_id=tc_id,
+                        name=result.get("tool_name") if result else tool_name,
                         static=True,
                     )
                 )
             self._pending_fc_tool_call_ids = []
             return
-        self._add_observation(tool_result)
+        # Batched observations already carry a per-tool SUCCESS/ERROR header, and arrive
+        # with success=None, so only a single tool's result is tagged here.
+        self._add_observation(mark_tool_failure(str(tool_result), success) if success is False else tool_result)
 
     def _validate_parallel_tool_input(self, action_input: Any) -> list[dict[str, Any]] | None:
         """Validate and parse parallel tool input schema.
@@ -1524,7 +1593,9 @@ class Agent(HistoryManagerMixin, BaseAgent):
         except Exception as e:
             error_message = f"Invalid parallel tool input: {e}"
             logger.error(error_message)
-            self._add_observation(error_message)
+            # Emitted, not added as a bare observation: the batch never ran, so every id
+            # in it is answered with the parse error that applies to all of them.
+            self._emit_tool_observations(error_message, tool_name=PARALLEL_TOOL_NAME, success=False)
             return None
 
     def _check_subagent_limits(self, tools_data: list[dict[str, Any]], action: str) -> str | None:
@@ -1650,20 +1721,20 @@ class Agent(HistoryManagerMixin, BaseAgent):
             # Check subagent invocation limits before executing
             subagent_error = self._check_subagent_limits(tools_data, action)
             if subagent_error:
-                self._add_observation(subagent_error)
+                # Emitted, not added as a bare observation: no call ran, so every id in
+                # the batch is answered with the refusal that applies to all of them.
+                self._emit_tool_observations(subagent_error, tool_name=action, success=False)
                 return None
 
             ordered_results: list[dict[str, Any]] = []
-            if (
-                self.sanitize_tool_name(action) == PARALLEL_TOOL_NAME
-                and self.parallel_tool_calls_enabled
-                and not skip_parallel
-            ):
+            # Stays None on the batch path, where each result carries its own status.
+            tool_success: Any = None
+            if self.sanitize_tool_name(action) == PARALLEL_TOOL_NAME and not skip_parallel:
                 tool_result, _, ordered_results = self._execute_tools(
                     tools_data, thought, loop_num, config, **kwargs
                 )
             else:
-                tool_result, _, is_delegated, _, _ = self._execute_single_tool(
+                tool_result, _, is_delegated, tool_success, _ = self._execute_single_tool(
                     action, action_input, thought, loop_num, config, **kwargs
                 )
                 if is_delegated:
@@ -1677,7 +1748,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 )
                 tool_result = f"{tool_result}{skipped_notice}" if tool_result else skipped_notice
 
-            self._emit_tool_observations(tool_result, ordered_results, tool_name=action)
+            self._emit_tool_observations(tool_result, ordered_results, tool_name=action, success=tool_success)
 
         # else: No action or no tools available - no reasoning to stream
 
@@ -2282,7 +2353,14 @@ class Agent(HistoryManagerMixin, BaseAgent):
             aggregated[unique_key] = files
 
     def _is_tool_parallel_eligible(self, tool_name: str) -> bool:
-        """Check if a tool is eligible for parallel execution based on its is_parallel_execution_allowed flag."""
+        """Check whether a tool may run concurrently with the rest of its batch.
+
+        Both gates must allow it: the agent-level ``parallel_tool_calls_enabled`` and the
+        tool's own ``is_parallel_execution_allowed``. A tool that fails either one still
+        runs — just in the sequential phase.
+        """
+        if not self.parallel_tool_calls_enabled:
+            return False
         tool = self.tool_by_names.get(self.sanitize_tool_name(tool_name))
         return tool.is_parallel_execution_allowed if tool else False
 
@@ -2330,6 +2408,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 all_results.append(
                     {
                         "order": idx,
+                        "tool_call_id": td.get("tool_call_id"),
                         "tool_name": tool_name or UNKNOWN_TOOL_NAME,
                         "success": False,
                         "result": error_message,
@@ -2338,7 +2417,13 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 )
                 continue
             prepared_tools.append(
-                {"order": idx, "name": tool_name, "input": tool_input, "thought": td.get("thought", "")}
+                {
+                    "order": idx,
+                    "tool_call_id": td.get("tool_call_id"),
+                    "name": tool_name,
+                    "input": tool_input,
+                    "thought": td.get("thought", ""),
+                }
             )
 
         def _execute_single_tool_to_result(tool_payload: dict[str, Any], **extra) -> dict[str, Any]:
@@ -2355,6 +2440,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             )
             return {
                 "order": tool_payload["order"],
+                "tool_call_id": tool_payload.get("tool_call_id"),
                 "tool_name": tool_payload["name"],
                 "tool_run_id": tool_payload.get("tool_run_id"),
                 "success": success,
@@ -2379,14 +2465,23 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
                 if sequential_group:
                     seq_names = [tp["name"] for tp in sequential_group]
-                    logger.info(
-                        f"Agent {self.name} - {self.id}: tools excluded from parallel execution "
-                        f"(is_parallel_execution_allowed=False): {seq_names}"
+                    reason = (
+                        "parallel_tool_calls_enabled=False"
+                        if not self.parallel_tool_calls_enabled
+                        else "is_parallel_execution_allowed=False"
                     )
+                    logger.info(f"Agent {self.name} - {self.id}: running sequentially ({reason}): {seq_names}")
 
                 # Phase 1: run parallel-eligible tools concurrently
                 if len(parallel_group) > 1:
-                    max_workers = len(parallel_group)
+                    # Bound the pool: the model decides how many tools to call, not how
+                    # many threads to spawn. Excess calls queue.
+                    max_workers = min(len(parallel_group), self.max_parallel_tool_calls)
+                    if len(parallel_group) > max_workers:
+                        logger.info(
+                            f"Agent {self.name} - {self.id}: {len(parallel_group)} parallel tool calls "
+                            f"queued across {max_workers} workers (max_parallel_tool_calls)."
+                        )
                     with ContextAwareThreadPoolExecutor(max_workers=max_workers) as executor:
                         future_map = {}
                         for tool_payload in parallel_group:

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -174,20 +174,14 @@ class AgentState(BaseModel):
 
 UNKNOWN_TOOL_NAME = "unknown_tool"
 
-# Prefixed onto a tool result the model would otherwise read as a success. Applied
-# wherever a single result reaches the model without a status of its own: each
-# `role: tool` message in function-calling mode, and the legacy single-tool
-# `Observation:` message. Batched observations already carry their own per-tool
-# SUCCESS/ERROR header and are left alone. Successful results are never modified.
 TOOL_ERROR_PREFIX = "[tool_error]"
 
 
 def mark_tool_failure(content: str, success: Any) -> str:
     """Tag a failed tool result so the model can tell it apart from a success.
 
-    Only ``success is False`` counts as a failure: ``None`` means the caller reported no
-    status, and is left alone rather than guessed at. Already-tagged content is returned
-    unchanged so repeated passes cannot stack prefixes.
+    Only ``success is False`` counts as a failure; ``None`` is left alone. Already-tagged
+    content is returned unchanged so repeated passes cannot stack prefixes.
     """
     if success is False and not content.startswith(TOOL_ERROR_PREFIX):
         return f"{TOOL_ERROR_PREFIX} {content}"
@@ -845,8 +839,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                     for tc in tool_calls:
                         function_name = tc["function"]["name"].strip()
                         tc_id = tc.get("id") or generate_uuid()
-                        # Written back so the parse pass below reads the same id rather
-                        # than minting a second one for a provider that sent none.
+                        # Written back so the parse pass below reuses this id.
                         tc["id"] = tc_id
                         raw_args = tc["function"]["arguments"]
                         arguments_str = raw_args if isinstance(raw_args, str) else json.dumps(raw_args)
@@ -874,8 +867,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                                 static=True,
                             )
                         )
-                        # Declined when batched with tools: the answer predates their
-                        # results. Saying so is what stops the model re-emitting the batch.
+                        # Declined when batched with tools: the answer predates their results.
                         final_answer_reply = (
                             "Not accepted: you requested tools in this same step, so this answer was "
                             "written before their results existed. Their results follow — answer "
@@ -969,12 +961,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
         actual_tool_calls = [tc for tc in tool_calls if tc.function.name.strip() != "provide_final_answer"]
 
-        # A model may put its final answer anywhere in the batch — llama-3.3-70b puts it
-        # last — so position is not used to find it. It is accepted only when nothing else
-        # was requested: an answer batched with tool calls was written before those results
-        # existed, so returning it hands back a guess and discards the work that would have
-        # informed it. Batched with tools, the tools run and the model answers on the next
-        # loop, told why the finish was declined (see _append_assistant_message).
+        # Searched by name, not position: llama-3.3-70b puts it last.
         final_answer_call = next((tc for tc in tool_calls if tc.function.name.strip() == "provide_final_answer"), None)
 
         if final_answer_call is not None and not actual_tool_calls:
@@ -984,9 +971,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             self.log_final_output(thought, final_args.answer, loop_num)
             return thought, "final_answer", final_args.answer
 
-        # Every call the model asked for is executed. ``parallel_tool_calls_enabled``
-        # decides whether they run concurrently or one after another (see
-        # ``_is_tool_parallel_eligible``), never whether they run at all.
+        # parallel_tool_calls_enabled decides concurrency, not whether calls run at all.
         if len(actual_tool_calls) > 1:
             tool_items = []
             for tc in actual_tool_calls:
@@ -1063,16 +1048,11 @@ class Agent(HistoryManagerMixin, BaseAgent):
         except (json.JSONDecodeError, ValueError) as e:
             raise ActionParsingException(f"Error parsing action. {e}", recoverable=True)
 
-        # Valid JSON is not necessarily an object: `null`, a bare list, or a string all
-        # parse cleanly and then fail the membership test below with a TypeError, which is
-        # not recoverable and ends the run. Treated as a parse failure like any other, so
-        # the model gets a chance to answer again.
+        # `null`, a list or a string parse cleanly, then raise TypeError below.
         if not isinstance(llm_generated_output_json, dict):
             raise ActionParsingException("Expected a JSON object containing 'thought' and 'action'.", recoverable=True)
 
-        # `action_input` belongs in the same check: the schema marks it required, and
-        # reading it below without one is a KeyError, which is not recoverable and ends the
-        # run, where a model that simply left a key out should just be asked again.
+        # Checked up front: reading a missing key below raises an unrecoverable KeyError.
         missing = [key for key in ("thought", "action", "action_input") if key not in llm_generated_output_json]
         if missing:
             raise ActionParsingException(f"Missing required field(s): {', '.join(missing)}.", recoverable=True)
@@ -1493,8 +1473,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
         """Ids still awaiting a reply: the live stash, or read back from history.
 
         The stash is lost across a checkpoint/resume, so it cannot be the only source.
-        Both the side that stamps ids onto results and the side that consumes them read
-        from here, so the two always agree on which call is which.
         """
         pending = getattr(self, "_pending_fc_tool_call_ids", None) or []
         if not pending and self.inference_mode == InferenceMode.FUNCTION_CALLING:
@@ -1509,20 +1487,11 @@ class Agent(HistoryManagerMixin, BaseAgent):
     ) -> None:
         """Append tool observations to prompt history.
 
-        In FUNCTION_CALLING mode every pending tool_call_id gets a reply, because a
-        request carrying an unanswered one is rejected by the provider outright.
-
-        Results are matched to ids by the ``tool_call_id`` each result carries, never by
-        position, so a batch that comes back out of order, partially, or not at all still
-        reaches the right calls. An id with no result of its own gets ``tool_result`` —
-        on the paths that end a batch early that is the explanation covering all of them.
-        A result that arrives without an id therefore costs that call its content, but
-        can never hand it another tool's output.
-
-        Every reply carries its status, so a failed call does not read as a result.
-
-        Falls back to the legacy ``role: "user"`` ``Observation: ...`` message in all
-        other cases.
+        In FUNCTION_CALLING mode every pending tool_call_id gets a reply, since a request
+        carrying an unanswered one is rejected by the provider. Results are matched by id
+        rather than position; an id with no result of its own is answered with
+        ``tool_result``. Falls back to the legacy ``role: "user"``
+        ``Observation: ...`` message in all other cases.
 
         Args:
             success: Status of ``tool_result``, for the ids answered with it. Per-call
@@ -1552,8 +1521,6 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 )
             self._pending_fc_tool_call_ids = []
             return
-        # Batched observations already carry a per-tool SUCCESS/ERROR header, and arrive
-        # with success=None, so only a single tool's result is tagged here.
         self._add_observation(mark_tool_failure(str(tool_result), success) if success is False else tool_result)
 
     def _validate_parallel_tool_input(self, action_input: Any) -> list[dict[str, Any]] | None:
@@ -1573,8 +1540,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
         except Exception as e:
             error_message = f"Invalid parallel tool input: {e}"
             logger.error(error_message)
-            # Emitted, not added as a bare observation: the batch never ran, so every id
-            # in it is answered with the parse error that applies to all of them.
+            # Emitted, not added as a bare observation: every id in the batch needs a reply.
             self._emit_tool_observations(error_message, success=False)
             return None
 
@@ -1701,8 +1667,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
             # Check subagent invocation limits before executing
             subagent_error = self._check_subagent_limits(tools_data, action)
             if subagent_error:
-                # Emitted, not added as a bare observation: no call ran, so every id in
-                # the batch is answered with the refusal that applies to all of them.
+                # Emitted, not added as a bare observation: every id in the batch needs a reply.
                 self._emit_tool_observations(subagent_error, success=False)
                 return None
 
@@ -1713,10 +1678,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 tool_result, _, ordered_results = self._execute_tools(
                     tools_data, thought, loop_num, config, **kwargs
                 )
-                # A batch reduced to a single call still delegates; a wider one had its
-                # delegation declined before execution (see ``_execute_tools``). Returned
-                # the same way the single-tool path does — the answer is already streamed,
-                # so continuing the loop would hand the client a second one.
+                # The answer is already streamed; continuing would produce a second one.
                 delegated = next((r for r in ordered_results if r.get("is_delegated")), None)
                 if delegated is not None:
                     return delegated.get("result")
@@ -1726,10 +1688,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 )
                 if is_delegated:
                     return tool_result
-                # Wrapped in the same shape ``_execute_tools`` produces, so one executed
-                # call reaches its own id the same way a batch does. Only when this step
-                # is that call: compaction also lands here, having filtered a batch whose
-                # other ids it cannot answer.
+                # Wrapped in the shape _execute_tools produces, so the result reaches its id.
                 pending_ids = self._current_tool_call_ids()
                 if len(pending_ids) == 1:
                     ordered_results = [
@@ -2358,9 +2317,8 @@ class Agent(HistoryManagerMixin, BaseAgent):
     def _is_tool_parallel_eligible(self, tool_name: str) -> bool:
         """Check whether a tool may run concurrently with the rest of its batch.
 
-        Both gates must allow it: the agent-level ``parallel_tool_calls_enabled`` and the
-        tool's own ``is_parallel_execution_allowed``. A tool that fails either one still
-        runs — just in the sequential phase.
+        Both ``parallel_tool_calls_enabled`` and the tool's own
+        ``is_parallel_execution_allowed`` must allow it; otherwise it runs sequentially.
         """
         if not self.parallel_tool_calls_enabled:
             return False
@@ -2429,14 +2387,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 }
             )
 
-        # ``delegate_final`` makes a call answer for the whole step, so it is honoured only
-        # when it is the step's only call. Batched with others it is refused *without being
-        # executed*: its answer would predate its siblings' results — the same reason a
-        # batched ``provide_final_answer`` is declined (see ``_handle_function_calling_mode``)
-        # — and running it anyway would bill a sub-agent whose output nobody reads. The
-        # refusal cannot wait until afterwards: ``_execute_single_tool`` logs and streams the
-        # delegated answer as it returns, so by then the client already has an answer.
-        # Its siblings still run; the refused call is what its own tool_call_id is told.
+        # Refused before execution: _execute_single_tool streams the delegated answer.
         if len(prepared_tools) > 1:
             executable: list[dict[str, Any]] = []
             for tool_payload in prepared_tools:
@@ -2483,10 +2434,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 "result": tool_result,
                 "files": tool_files,
                 "dependency": dependency,
-                # Carried up so the caller can end the loop with this result. Dropping it
-                # here would leave the loop running after ``_execute_single_tool`` has
-                # already logged and streamed this as the run's answer, and the client
-                # would be handed a second one.
+                # Carried up so the caller can end the loop; the answer is already streamed.
                 "is_delegated": is_delegated,
             }
 
@@ -2515,8 +2463,7 @@ class Agent(HistoryManagerMixin, BaseAgent):
 
                 # Phase 1: run parallel-eligible tools concurrently
                 if len(parallel_group) > 1:
-                    # Bound the pool: the model decides how many tools to call, not how
-                    # many threads to spawn. Excess calls queue.
+                    # Bounded: the model decides how many tools to call, not thread count.
                     max_workers = min(len(parallel_group), self.max_parallel_tool_calls)
                     if len(parallel_group) > max_workers:
                         logger.info(

--- a/dynamiq/nodes/agents/agent.py
+++ b/dynamiq/nodes/agents/agent.py
@@ -1713,6 +1713,13 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 tool_result, _, ordered_results = self._execute_tools(
                     tools_data, thought, loop_num, config, **kwargs
                 )
+                # A batch reduced to a single call still delegates; a wider one had its
+                # delegation declined before execution (see ``_execute_tools``). Returned
+                # the same way the single-tool path does — the answer is already streamed,
+                # so continuing the loop would hand the client a second one.
+                delegated = next((r for r in ordered_results if r.get("is_delegated")), None)
+                if delegated is not None:
+                    return delegated.get("result")
             else:
                 tool_result, tool_files, is_delegated, tool_success, _ = self._execute_single_tool(
                     action, action_input, thought, loop_num, config, **kwargs
@@ -2422,9 +2429,42 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 }
             )
 
+        # ``delegate_final`` makes a call answer for the whole step, so it is honoured only
+        # when it is the step's only call. Batched with others it is refused *without being
+        # executed*: its answer would predate its siblings' results — the same reason a
+        # batched ``provide_final_answer`` is declined (see ``_handle_function_calling_mode``)
+        # — and running it anyway would bill a sub-agent whose output nobody reads. The
+        # refusal cannot wait until afterwards: ``_execute_single_tool`` logs and streams the
+        # delegated answer as it returns, so by then the client already has an answer.
+        # Its siblings still run; the refused call is what its own tool_call_id is told.
+        if len(prepared_tools) > 1:
+            executable: list[dict[str, Any]] = []
+            for tool_payload in prepared_tools:
+                tool = self.tool_by_names.get(self.sanitize_tool_name(tool_payload["name"]))
+                if not self._should_delegate_final(tool, tool_payload["input"]):
+                    executable.append(tool_payload)
+                    continue
+                refusal = (
+                    f"'{tool_payload['name']}' was not executed: delegate_final cannot be combined with "
+                    "other tool calls. Call it on its own to return its answer directly, or call it "
+                    "again without delegate_final to use its output as an observation."
+                )
+                logger.warning(f"Agent {self.name} - {self.id}: {refusal}")
+                all_results.append(
+                    {
+                        "order": tool_payload["order"],
+                        "tool_call_id": tool_payload.get("tool_call_id"),
+                        "tool_name": tool_payload["name"],
+                        "success": False,
+                        "result": refusal,
+                        "files": [],
+                    }
+                )
+            prepared_tools = executable
+
         def _execute_single_tool_to_result(tool_payload: dict[str, Any], **extra) -> dict[str, Any]:
             """Execute a single tool and wrap the result as a dict."""
-            tool_result, tool_files, _, success, dependency = self._execute_single_tool(
+            tool_result, tool_files, is_delegated, success, dependency = self._execute_single_tool(
                 tool_payload["name"],
                 tool_payload["input"],
                 tool_payload.get("thought") or thought or "",
@@ -2443,6 +2483,11 @@ class Agent(HistoryManagerMixin, BaseAgent):
                 "result": tool_result,
                 "files": tool_files,
                 "dependency": dependency,
+                # Carried up so the caller can end the loop with this result. Dropping it
+                # here would leave the loop running after ``_execute_single_tool`` has
+                # already logged and streamed this as the run's answer, and the client
+                # would be handed a second one.
+                "is_delegated": is_delegated,
             }
 
         sequential_group: list[dict[str, Any]] = []

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -257,8 +257,16 @@ class Agent(AgentIterativeCheckpointMixin, Node):
     )
     parallel_tool_calls_enabled: bool = Field(
         default=False,
-        description="Enable multi-tool execution in a single step. "
-        "When True, the agent can call multiple tools in parallel.",
+        description="Run a step's tool calls concurrently. When False, every requested "
+        "tool still runs, one after another — the flag controls how they run, never "
+        "whether they run. Outside FUNCTION_CALLING mode, enabling it also adds the "
+        "`run-parallel` tool, which is what lets the model request a batch at all.",
+    )
+    max_parallel_tool_calls: int = Field(
+        default=8,
+        ge=1,
+        description="Upper bound on tools executing concurrently in one step. Calls beyond "
+        "the limit queue and run as workers free up; none are dropped.",
     )
     memory: Memory | None = Field(None, description="Memory node for the agent.")
     memory_limit: int = Field(100, description="Maximum number of messages to retrieve from memory")
@@ -439,7 +447,10 @@ class Agent(AgentIterativeCheckpointMixin, Node):
             use_native_parallel = inference_mode == InferenceMode.FUNCTION_CALLING
             if not use_native_parallel:
                 self.tools = [t for t in self.tools if t.name != PARALLEL_TOOL_NAME]
-                self.tools.append(ParallelToolCallsTool())
+                # Nothing to batch without real tools -- injecting it would advertise a
+                # tool, and the whole tools prompt block, to an agent that has none.
+                if self.tools:
+                    self.tools.append(ParallelToolCallsTool())
 
         if self._skills_should_init():
             self._init_skills()

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -442,6 +442,9 @@ class Agent(AgentIterativeCheckpointMixin, Node):
             if self.file_store.agent_file_write_enabled:
                 self.tools.append(FileWriteTool(file_store=self.file_store_backend))
 
+        if self._skills_should_init():
+            self._init_skills()
+
         if self.parallel_tool_calls_enabled:
             inference_mode = getattr(self, "inference_mode", None)
             use_native_parallel = inference_mode == InferenceMode.FUNCTION_CALLING
@@ -452,8 +455,6 @@ class Agent(AgentIterativeCheckpointMixin, Node):
                 if self.tools:
                     self.tools.append(ParallelToolCallsTool())
 
-        if self._skills_should_init():
-            self._init_skills()
         self._init_prompt_blocks()
         if self._skills_should_init():
             self._apply_skills_to_prompt()

--- a/dynamiq/nodes/agents/base.py
+++ b/dynamiq/nodes/agents/base.py
@@ -450,8 +450,8 @@ class Agent(AgentIterativeCheckpointMixin, Node):
             use_native_parallel = inference_mode == InferenceMode.FUNCTION_CALLING
             if not use_native_parallel:
                 self.tools = [t for t in self.tools if t.name != PARALLEL_TOOL_NAME]
-                # Nothing to batch without real tools -- injecting it would advertise a
-                # tool, and the whole tools prompt block, to an agent that has none.
+                # Nothing to batch without real tools. Runs after _init_skills so a
+                # skills-only agent is not treated as tool-less.
                 if self.tools:
                     self.tools.append(ParallelToolCallsTool())
 

--- a/dynamiq/nodes/agents/components/schema_generator.py
+++ b/dynamiq/nodes/agents/components/schema_generator.py
@@ -109,6 +109,16 @@ def build_final_answer_function_schema(response_format: dict | type[BaseModel] |
 PRIORITY_FIELDS = ("brief",)
 
 
+def _is_accessible_to_agent(field: Any) -> bool:
+    """True unless the field is marked ``is_accessible_to_agent=False``.
+
+    Applied to nested model fields as well as top-level ones: this renderer walks
+    ``model_fields`` rather than generating JSON schema, so a field left out of the
+    schema by other means is still described here unless the flag is honoured.
+    """
+    return not field.json_schema_extra or field.json_schema_extra.get("is_accessible_to_agent", True)
+
+
 def _reorder_fields(fields: dict) -> list[tuple[str, Any]]:
     """Reorder fields so that priority fields (e.g. brief) come first."""
     priority = [(k, v) for k, v in fields.items() if k in PRIORITY_FIELDS]
@@ -131,7 +141,7 @@ def generate_input_formats(tools: list[Node], sanitize_tool_name: Callable[[str]
     for tool in tools:
         params = []
         for name, field in _reorder_fields(tool.resolved_input_schema.model_fields):
-            if not field.json_schema_extra or field.json_schema_extra.get("is_accessible_to_agent", True):
+            if _is_accessible_to_agent(field):
                 args = get_args(field.annotation)
                 if get_origin(field.annotation) in (Union, types.UnionType):
                     type_str = str(field.annotation)
@@ -141,6 +151,7 @@ def generate_input_formats(tools: list[Node], sanitize_tool_name: Callable[[str]
                     nested_fields = [
                         f"{fn}: {getattr(fi.annotation, '__name__', str(fi.annotation))} - {fi.description or ''}"
                         for fn, fi in args[0].model_fields.items()
+                        if _is_accessible_to_agent(fi)
                     ]
                     type_str = f"list[{{{', '.join(nested_fields)}}}, ...]"
                 else:

--- a/dynamiq/nodes/tools/parallel_tool_calls.py
+++ b/dynamiq/nodes/tools/parallel_tool_calls.py
@@ -3,7 +3,6 @@
 from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic.json_schema import SkipJsonSchema
 
 from dynamiq.nodes import Node, NodeGroup
 from dynamiq.nodes.types import ActionType
@@ -23,11 +22,8 @@ class ToolCallItem(BaseModel):
         description="Input parameters for the tool as key-value pairs",
     )
     thought: str = Field(default="", description="Reasoning for this tool call.")
-    # The provider's id for this call, in FUNCTION_CALLING mode. Carried with the call so
-    # its result can be paired back to it by id rather than by position, which execution
-    # order does not preserve. SkipJsonSchema keeps it out of the schema shown to the
-    # model — the other inference modes author this object themselves and have no ids.
-    tool_call_id: SkipJsonSchema[str | None] = None
+    # Agent-owned: set in FUNCTION_CALLING mode to pair results back to calls.
+    tool_call_id: str | None = Field(default=None, json_schema_extra={"is_accessible_to_agent": False})
 
     model_config = ConfigDict(extra="forbid")
 

--- a/dynamiq/nodes/tools/parallel_tool_calls.py
+++ b/dynamiq/nodes/tools/parallel_tool_calls.py
@@ -3,6 +3,7 @@
 from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from dynamiq.nodes import Node, NodeGroup
 from dynamiq.nodes.types import ActionType
@@ -22,6 +23,11 @@ class ToolCallItem(BaseModel):
         description="Input parameters for the tool as key-value pairs",
     )
     thought: str = Field(default="", description="Reasoning for this tool call.")
+    # The provider's id for this call, in FUNCTION_CALLING mode. Carried with the call so
+    # its result can be paired back to it by id rather than by position, which execution
+    # order does not preserve. SkipJsonSchema keeps it out of the schema shown to the
+    # model — the other inference modes author this object themselves and have no ids.
+    tool_call_id: SkipJsonSchema[str | None] = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
+++ b/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
@@ -285,16 +285,21 @@ class TestFunctionCallingProtocolEmission:
         assert fa_stub.role == MessageRole.TOOL
         assert fa_stub.tool_call_id == "call_fa"
         assert fa_stub.name == "provide_final_answer"
-        assert fa_stub.content == "Acknowledged."
+        # Batched alongside tool calls, so the answer was written before their results
+        # existed. Declining it is what makes the next step answer from real results.
+        assert fa_stub.content.startswith("Not accepted:")
 
         # Pending stash holds ONLY real-tool ids (FA is acknowledged inline, not pending).
         # Stale id from previous loop is gone.
         assert agent._pending_fc_tool_call_ids == ["call_a", "call_b"]
 
-    def test_append_assistant_message_drops_extra_calls_when_parallel_disabled(self):
-        """Regression: when parallel is disabled and the LLM still returns multiple
-        non-final-answer tool calls, only the first one may be recorded in the assistant
-        message."""
+    def test_append_assistant_message_records_every_call_when_parallel_disabled(self):
+        """Regression: the extra calls used to be erased here, which is what made the loss
+        silent — the transcript showed one call requested and one answered, so the provider
+        raised nothing and the model could not tell work had gone missing.
+
+        ``parallel_tool_calls_enabled=False`` means "do not run these concurrently", not
+        "discard them", so history must record every call the model asked for."""
         from dynamiq.nodes.agents.agent import Agent
         from dynamiq.nodes.types import InferenceMode
 
@@ -318,17 +323,14 @@ class TestFunctionCallingProtocolEmission:
         Agent._append_assistant_message(agent, llm_result, llm_generated_output="")
 
         assistant = agent._prompt.messages[0]
-        # Only call_a (first non-FA) and call_fa survive in the assistant payload —
-        # call_b is dropped at source so no orphan tool_call_id is left behind.
-        assert [tc["id"] for tc in assistant.tool_calls] == ["call_a", "call_fa"]
-        # Pending ids match: only call_a will get a tool response from execution;
-        # call_fa is acknowledged inline.
-        assert agent._pending_fc_tool_call_ids == ["call_a"]
+        assert [tc["id"] for tc in assistant.tool_calls] == ["call_a", "call_b", "call_fa"]
+        # Both real calls await a result; call_fa is acknowledged inline.
+        assert agent._pending_fc_tool_call_ids == ["call_a", "call_b"]
 
     def test_emit_tool_observations_parallel_pairs_ids_results_and_names(self):
         """In FC mode, parallel observations must produce one role:'tool' message per
-        pending id, paired with the matching ordered_result (id ↔ result by index),
-        carrying tool_call_id, content, and name. Stash must be cleared after."""
+        pending id, paired with the result carrying that id, with tool_call_id, content,
+        and name. Stash must be cleared after."""
         from dynamiq.nodes.agents.agent import Agent
         from dynamiq.nodes.types import InferenceMode
         from dynamiq.prompts.prompts import MessageRole
@@ -338,10 +340,11 @@ class TestFunctionCallingProtocolEmission:
         agent._prompt = MagicMock()
         agent._prompt.messages = []
         agent._pending_fc_tool_call_ids = ["call_a", "call_b"]
+        agent._current_tool_call_ids = lambda: agent._pending_fc_tool_call_ids
 
         ordered_results = [
-            {"tool_name": "CatFacts", "result": "Cats sleep 12-16h", "success": True, "files": []},
-            {"tool_name": "DogFacts", "result": "Dogs have 40x smell", "success": True, "files": []},
+            {"tool_call_id": "call_a", "tool_name": "CatFacts", "result": "Cats sleep 12-16h", "success": True},
+            {"tool_call_id": "call_b", "tool_name": "DogFacts", "result": "Dogs have 40x smell", "success": True},
         ]
 
         Agent._emit_tool_observations(
@@ -359,3 +362,415 @@ class TestFunctionCallingProtocolEmission:
         )
         # Stash must be empty so the next loop doesn't see stale ids.
         assert agent._pending_fc_tool_call_ids == []
+
+
+class TestEveryPendingIdIsAnswered:
+    """A request carrying an unanswered tool_call_id is rejected by the provider, so any
+    path that ends a batch early must still reply to the calls it did not run."""
+
+    @staticmethod
+    def _agent(pending_ids):
+        from dynamiq.nodes.types import InferenceMode
+
+        agent = MagicMock()
+        agent.inference_mode = InferenceMode.FUNCTION_CALLING
+        agent._prompt = MagicMock()
+        agent._prompt.messages = []
+        agent._pending_fc_tool_call_ids = list(pending_ids)
+        agent._current_tool_call_ids = lambda: agent._pending_fc_tool_call_ids
+        return agent
+
+    def test_results_are_matched_by_id_not_position(self):
+        """The pool returns in completion order, so a result's position in the list says
+        nothing about which call it belongs to. Only the id it carries does."""
+        from dynamiq.nodes.agents.agent import Agent
+
+        agent = self._agent(["call_a", "call_b", "call_c"])
+        # Deliberately shuffled: pairing by position here would answer every call wrongly.
+        ordered_results = [
+            {"tool_call_id": "call_c", "tool_name": "Fetch", "result": "c-result"},
+            {"tool_call_id": "call_a", "tool_name": "Search", "result": "a-result"},
+            {"tool_call_id": "call_b", "tool_name": "Dogs", "result": "b-result"},
+        ]
+
+        Agent._emit_tool_observations(agent, tool_result="unused", ordered_results=ordered_results)
+
+        assert [(m.tool_call_id, m.name, m.content) for m in agent._prompt.messages] == [
+            ("call_a", "Search", "a-result"),
+            ("call_b", "Dogs", "b-result"),
+            ("call_c", "Fetch", "c-result"),
+        ]
+        assert agent._pending_fc_tool_call_ids == []
+
+    def test_ids_without_a_result_get_the_step_message(self):
+        """Nothing ran — the batch was refused before execution — so every id is answered
+        with the refusal, which applies to all of them equally."""
+        from dynamiq.nodes.agents.agent import Agent
+        from dynamiq.prompts.prompts import MessageRole
+
+        agent = self._agent(["call_a", "call_b", "call_c"])
+
+        Agent._emit_tool_observations(
+            agent, tool_result="Sub-agent invocation limit exceeded.", tool_name="researcher"
+        )
+
+        assert [m.tool_call_id for m in agent._prompt.messages] == ["call_a", "call_b", "call_c"]
+        assert all(m.role == MessageRole.TOOL for m in agent._prompt.messages)
+        assert all(m.content == "Sub-agent invocation limit exceeded." for m in agent._prompt.messages)
+        assert agent._pending_fc_tool_call_ids == []
+
+    def test_partial_results_pair_and_the_rest_are_explained(self):
+        """A batch that only partly reported still answers every id: the reported call
+        gets its own result, the others the step's message."""
+        from dynamiq.nodes.agents.agent import Agent
+
+        agent = self._agent(["call_a", "call_b"])
+        ordered_results = [{"tool_call_id": "call_b", "tool_name": "Dogs", "result": "dogs"}]
+
+        Agent._emit_tool_observations(agent, tool_result="batch ended early", ordered_results=ordered_results)
+
+        assert [(m.tool_call_id, m.content) for m in agent._prompt.messages] == [
+            ("call_a", "batch ended early"),
+            ("call_b", "dogs"),
+        ]
+
+    def test_a_result_without_an_id_is_never_misattributed(self):
+        """An unstamped result costs that call its content. It must never be handed to a
+        different call — losing information beats fabricating it."""
+        from dynamiq.nodes.agents.agent import Agent
+
+        agent = self._agent(["call_a", "call_b"])
+        ordered_results = [
+            {"tool_name": "Search", "result": "a-result"},
+            {"tool_name": "Dogs", "result": "b-result"},
+        ]
+
+        Agent._emit_tool_observations(agent, tool_result="no result reported", ordered_results=ordered_results)
+
+        assert [m.content for m in agent._prompt.messages] == ["no result reported"] * 2
+
+
+class TestFinalAnswerMustStandAlone:
+    """An answer batched with tool calls was written in the same step that requested them,
+    so it cannot have used their results. Returning it hands back a guess and discards the
+    work that would have informed it.
+
+    Position carries no meaning — llama-3.3-70b puts the answer last, gpt-4o first — so it
+    is found by name. Anchoring on index 0 made the outcome depend on ordering: answer
+    first returned a guess and dropped the tools, answer last dropped the answer and looped
+    to max_loops on the same input."""
+
+    @staticmethod
+    def _call(name, args, call_id):
+        return {"id": call_id, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+
+    def _parse(self, calls):
+        from dynamiq.nodes.agents.agent import Agent
+
+        agent = _make_agent()
+        agent.tool_by_names = {}
+        return Agent._handle_function_calling_mode(agent, SimpleNamespace(output={"tool_calls": calls}), loop_num=1)
+
+    def test_an_answer_on_its_own_is_honored(self):
+        _, action, answer = self._parse([self._call("provide_final_answer", {"thought": "t", "answer": "done"}, "f")])
+        assert (action, answer) == ("final_answer", "done")
+
+    @pytest.mark.parametrize("position", ["first", "last", "middle"])
+    def test_a_batched_answer_is_declined_wherever_it_sits(self, position):
+        tools = [self._call("probe", {"thought": "t", "i": i}, f"t{i}") for i in (1, 2)]
+        final = self._call("provide_final_answer", {"thought": "t", "answer": "done"}, "f")
+        batch = {"first": [final, *tools], "last": [*tools, final], "middle": [tools[0], final, tools[1]]}[position]
+
+        _, action, _ = self._parse(batch)
+
+        assert action == PARALLEL_TOOL_NAME, "the tools must run rather than be discarded"
+
+    def test_a_single_tool_alongside_the_answer_still_runs(self):
+        _, action, _ = self._parse(
+            [
+                self._call("provide_final_answer", {"thought": "t", "answer": "done"}, "f"),
+                self._call("probe", {"thought": "t", "i": 1}, "a"),
+            ]
+        )
+        assert action == "probe"
+
+
+class TestStructuredOutputSurvivesOddJson:
+    """`null`, a bare list and a quoted string all parse as valid JSON and then failed a
+    membership test with TypeError; a response without `action_input` failed the read below
+    it with KeyError. Neither is recoverable, so both ended the run — where a model that
+    returned the wrong shape should simply be asked again."""
+
+    def _parse(self, payload):
+        from dynamiq.nodes.agents.agent import Agent
+
+        return Agent._handle_structured_output_mode(_make_agent(), payload, loop_num=1)
+
+    @pytest.mark.parametrize("payload", ["null", "[1, 2]", '"just a string"'])
+    def test_valid_json_that_is_not_an_object_is_recoverable(self, payload):
+        with pytest.raises(ActionParsingException) as exc:
+            self._parse(payload)
+        assert exc.value.recoverable
+
+    def test_missing_fields_are_named(self):
+        with pytest.raises(ActionParsingException) as exc:
+            self._parse(json.dumps({"thought": "t"}))
+        assert "action" in str(exc.value) and "action_input" in str(exc.value)
+        assert exc.value.recoverable
+
+    def test_a_complete_response_still_parses(self):
+        thought, action, action_input = self._parse(
+            json.dumps({"thought": "t", "action": "probe", "action_input": {"i": 1}})
+        )
+        assert (thought, action, action_input) == ("t", "probe", {"i": 1})
+
+
+class TestFailedToolResultsAreMarked:
+    """The status of a call is computed either way; in FUNCTION_CALLING mode it used to be
+    dropped, so the same failure produced a status-carrying transcript in the other modes
+    and a bare one here. The marker also gives failures a stable token to count, which the
+    rendered exception name is not."""
+
+    def test_failures_are_tagged_and_successes_are_untouched(self):
+        from dynamiq.nodes.agents.agent import TOOL_ERROR_PREFIX, Agent
+
+        agent = TestEveryPendingIdIsAnswered._agent(["call_ok", "call_bad"])
+        ordered_results = [
+            {"tool_call_id": "call_ok", "tool_name": "Search", "result": "3 results", "success": True},
+            {"tool_call_id": "call_bad", "tool_name": "Fetch", "result": "ToolExecutionException: 500", "success": False},
+        ]
+
+        Agent._emit_tool_observations(agent, tool_result="unused", ordered_results=ordered_results)
+
+        ok, bad = agent._prompt.messages
+        assert ok.content == "3 results", "a successful result must not be modified"
+        assert bad.content == f"{TOOL_ERROR_PREFIX} ToolExecutionException: 500"
+
+    def test_unreported_status_is_left_alone(self):
+        """``None`` means the caller reported no status. Guessing would tag successes."""
+        from dynamiq.nodes.agents.agent import TOOL_ERROR_PREFIX, Agent
+
+        agent = TestEveryPendingIdIsAnswered._agent(["call_a"])
+        ordered_results = [{"tool_call_id": "call_a", "tool_name": "Search", "result": "partial"}]
+
+        Agent._emit_tool_observations(agent, tool_result="unused", ordered_results=ordered_results)
+
+        assert agent._prompt.messages[0].content == "partial"
+        assert TOOL_ERROR_PREFIX not in agent._prompt.messages[0].content
+
+    def test_ids_answered_by_the_step_message_use_its_status(self):
+        """A refused batch is a failure, and every id it answers must say so."""
+        from dynamiq.nodes.agents.agent import TOOL_ERROR_PREFIX, Agent
+
+        agent = TestEveryPendingIdIsAnswered._agent(["call_a", "call_b"])
+
+        Agent._emit_tool_observations(
+            agent, tool_result="Sub-agent invocation limit exceeded.", tool_name="researcher", success=False
+        )
+
+        assert all(m.content.startswith(TOOL_ERROR_PREFIX) for m in agent._prompt.messages)
+
+    def test_marker_is_not_stacked(self):
+        """Repeated passes over the same content must not accumulate prefixes."""
+        from dynamiq.nodes.agents.agent import TOOL_ERROR_PREFIX, mark_tool_failure
+
+        once = mark_tool_failure("boom", False)
+        assert mark_tool_failure(once, False) == once
+        assert once.count(TOOL_ERROR_PREFIX) == 1
+
+
+class TestNoToolCallIsDropped:
+    """``parallel_tool_calls_enabled`` controls *how* a step's tool calls run, never
+    *whether* they run. These drive a real Agent against a scripted LLM, so they cover the
+    whole path — parsing, batching, execution, and the replies the model reads back."""
+
+    @staticmethod
+    def _agent_with_probe(probe, **kwargs):
+        import threading
+        import time
+        from typing import ClassVar
+
+        from pydantic import BaseModel
+
+        from dynamiq import connections
+        from dynamiq.nodes import llms
+        from dynamiq.nodes.agents import Agent
+        from dynamiq.nodes.node import Node, NodeGroup
+        from dynamiq.nodes.types import InferenceMode
+
+        lock = threading.Lock()
+
+        class _Input(BaseModel):
+            i: int = 0
+
+        class ProbeTool(Node):
+            group: NodeGroup = NodeGroup.TOOLS
+            name: str = "probe"
+            description: str = "records execution"
+            input_schema: ClassVar[type[BaseModel]] = _Input
+            is_parallel_execution_allowed: bool = True
+
+            def execute(self, input_data, config=None, **kw):
+                with lock:
+                    probe["inflight"] += 1
+                    probe["peak"] = max(probe["peak"], probe["inflight"])
+                time.sleep(0.01)
+                with lock:
+                    probe["inflight"] -= 1
+                    probe["order"].append(input_data.i)
+                return {"content": f"done-{input_data.i}"}
+
+        return Agent(
+            id="agent",
+            name="agent",
+            llm=llms.OpenAI(
+                id="llm",
+                model="gpt-4o-mini",
+                connection=connections.OpenAI(api_key="not-used"),
+                is_postponed_component_init=True,
+            ),
+            tools=[ProbeTool()],
+            inference_mode=InferenceMode.FUNCTION_CALLING,
+            max_loops=3,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _run(agent, n_calls):
+        from litellm import ModelResponse
+
+        turns = [
+            [
+                {
+                    "id": f"call_{i}",
+                    "type": "function",
+                    "function": {"name": "probe", "arguments": json.dumps({"thought": f"t{i}", "i": i})},
+                }
+                for i in range(n_calls)
+            ],
+            [
+                {
+                    "id": "call_final",
+                    "type": "function",
+                    "function": {
+                        "name": "provide_final_answer",
+                        "arguments": json.dumps({"thought": "done", "answer": "ok"}),
+                    },
+                }
+            ],
+        ]
+        state = {"n": 0}
+
+        def _completion(stream=False, *a, **kw):
+            calls = turns[min(state["n"], len(turns) - 1)]
+            state["n"] += 1
+            return ModelResponse(choices=[{"message": {"content": None, "tool_calls": calls}}])
+
+        with patch("dynamiq.nodes.llms.base.BaseLLM._completion", side_effect=_completion):
+            return agent.run(input_data={"input": "go"})
+
+    def test_every_call_runs_when_parallel_is_disabled(self):
+        """The batch used to execute one call and discard the rest."""
+        probe = {"inflight": 0, "peak": 0, "order": []}
+        agent = self._agent_with_probe(probe, parallel_tool_calls_enabled=False)
+
+        self._run(agent, 5)
+
+        assert probe["order"] == [0, 1, 2, 3, 4], "every call must run, in the order requested"
+        assert probe["peak"] == 1, "disabled must still mean sequential, not concurrent"
+
+    def test_every_tool_call_id_receives_a_reply(self):
+        """Recording all N calls is only safe if all N get answered — an unanswered
+        tool_call_id makes the next provider request invalid."""
+        from dynamiq.prompts.prompts import MessageRole
+
+        probe = {"inflight": 0, "peak": 0, "order": []}
+        agent = self._agent_with_probe(probe, parallel_tool_calls_enabled=False)
+
+        self._run(agent, 4)
+
+        requested, answered = [], set()
+        for m in agent._prompt.messages:
+            if m.role == MessageRole.ASSISTANT and m.tool_calls:
+                requested.extend(tc["id"] for tc in m.tool_calls)
+            if m.role == MessageRole.TOOL and m.tool_call_id:
+                answered.add(m.tool_call_id)
+
+        assert requested, "expected the assistant message to record its tool calls"
+        assert [r for r in requested if r not in answered] == []
+
+    def test_each_reply_carries_its_own_call_result(self):
+        """Answers must reach the call that produced them, not merely exist."""
+        from dynamiq.prompts.prompts import MessageRole
+
+        probe = {"inflight": 0, "peak": 0, "order": []}
+        agent = self._agent_with_probe(probe, parallel_tool_calls_enabled=False)
+
+        self._run(agent, 3)
+
+        by_id = {m.tool_call_id: m.content for m in agent._prompt.messages if m.role == MessageRole.TOOL}
+        for i in range(3):
+            assert by_id[f"call_{i}"] == f"done-{i}"
+
+
+class TestParallelToolConcurrencyIsBounded:
+    """``max_parallel_tool_calls`` bounds the thread pool, so the model decides how many
+    tools to call but not how many threads the process spawns."""
+
+    def test_pool_is_capped_and_no_call_is_dropped(self):
+        import threading
+        import time
+        from typing import ClassVar
+
+        from pydantic import BaseModel
+
+        from dynamiq import connections
+        from dynamiq.nodes import llms
+        from dynamiq.nodes.agents import Agent
+        from dynamiq.nodes.node import Node, NodeGroup
+        from dynamiq.nodes.types import InferenceMode
+        from dynamiq.runnables import RunnableConfig
+
+        lock = threading.Lock()
+        stats = {"inflight": 0, "peak": 0, "completed": 0}
+
+        class _ProbeInput(BaseModel):
+            i: int = 0
+
+        class ProbeTool(Node):
+            group: NodeGroup = NodeGroup.TOOLS
+            name: str = "probe"
+            description: str = "records concurrency"
+            input_schema: ClassVar[type[BaseModel]] = _ProbeInput
+            is_parallel_execution_allowed: bool = True
+
+            def execute(self, input_data, config=None, **kwargs):
+                with lock:
+                    stats["inflight"] += 1
+                    stats["peak"] = max(stats["peak"], stats["inflight"])
+                time.sleep(0.02)
+                with lock:
+                    stats["inflight"] -= 1
+                    stats["completed"] += 1
+                return {"content": f"done-{input_data.i}"}
+
+        agent = Agent(
+            id="agent",
+            name="agent",
+            llm=llms.OpenAI(
+                id="llm",
+                model="gpt-4o-mini",
+                connection=connections.OpenAI(api_key="not-used"),
+                is_postponed_component_init=True,
+            ),
+            tools=[ProbeTool()],
+            inference_mode=InferenceMode.FUNCTION_CALLING,
+            parallel_tool_calls_enabled=True,
+            max_parallel_tool_calls=3,
+        )
+
+        tools_data = [{"name": "probe", "input": {"i": i}, "thought": f"t{i}"} for i in range(12)]
+        agent._execute_tools(tools_data, "batch", 1, RunnableConfig())
+
+        assert stats["completed"] == 12, "capping must queue calls, never drop them"
+        assert stats["peak"] <= 3, "more tools ran at once than max_parallel_tool_calls allows"

--- a/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
+++ b/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
@@ -537,7 +537,8 @@ class TestFailedToolResultsAreMarked:
         agent = TestEveryPendingIdIsAnswered._agent(["call_ok", "call_bad"])
         ordered_results = [
             {"tool_call_id": "call_ok", "tool_name": "Search", "result": "3 results", "success": True},
-            {"tool_call_id": "call_bad", "tool_name": "Fetch", "result": "ToolExecutionException: 500", "success": False},
+            {"tool_call_id": "call_bad", "tool_name": "Fetch", "result": "ToolExecutionException: 500",
+             "success": False},
         ]
 
         Agent._emit_tool_observations(agent, tool_result="unused", ordered_results=ordered_results)

--- a/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
+++ b/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
@@ -285,8 +285,7 @@ class TestFunctionCallingProtocolEmission:
         assert fa_stub.role == MessageRole.TOOL
         assert fa_stub.tool_call_id == "call_fa"
         assert fa_stub.name == "provide_final_answer"
-        # Batched alongside tool calls, so the answer was written before their results
-        # existed. Declining it is what makes the next step answer from real results.
+        # Batched with tool calls, so the answer predates their results.
         assert fa_stub.content.startswith("Not accepted:")
 
         # Pending stash holds ONLY real-tool ids (FA is acknowledged inline, not pending).
@@ -294,9 +293,7 @@ class TestFunctionCallingProtocolEmission:
         assert agent._pending_fc_tool_call_ids == ["call_a", "call_b"]
 
     def test_append_assistant_message_records_every_call_when_parallel_disabled(self):
-        """Regression: the extra calls used to be erased here, which is what made the loss
-        silent — the transcript showed one call requested and one answered, so the provider
-        raised nothing and the model could not tell work had gone missing.
+        """Regression: extra calls used to be erased here, so the loss was silent.
 
         ``parallel_tool_calls_enabled=False`` means "do not run these concurrently", not
         "discard them", so history must record every call the model asked for."""
@@ -449,14 +446,9 @@ class TestEveryPendingIdIsAnswered:
 
 
 class TestFinalAnswerMustStandAlone:
-    """An answer batched with tool calls was written in the same step that requested them,
-    so it cannot have used their results. Returning it hands back a guess and discards the
-    work that would have informed it.
+    """An answer batched with tool calls predates their results, so it is declined.
 
-    Position carries no meaning — llama-3.3-70b puts the answer last, gpt-4o first — so it
-    is found by name. Anchoring on index 0 made the outcome depend on ordering: answer
-    first returned a guess and dropped the tools, answer last dropped the answer and looped
-    to max_loops on the same input."""
+    It is found by name, not position: llama-3.3-70b puts it last, gpt-4o first."""
 
     @staticmethod
     def _call(name, args, call_id):
@@ -494,10 +486,8 @@ class TestFinalAnswerMustStandAlone:
 
 
 class TestStructuredOutputSurvivesOddJson:
-    """`null`, a bare list and a quoted string all parse as valid JSON and then failed a
-    membership test with TypeError; a response without `action_input` failed the read below
-    it with KeyError. Neither is recoverable, so both ended the run — where a model that
-    returned the wrong shape should simply be asked again."""
+    """`null`, a bare list, a quoted string and a missing `action_input` used to raise
+    unrecoverable TypeError/KeyError, ending the run instead of asking the model again."""
 
     def _parse(self, payload):
         from dynamiq.nodes.agents.agent import Agent
@@ -524,10 +514,8 @@ class TestStructuredOutputSurvivesOddJson:
 
 
 class TestFailedToolResultsAreMarked:
-    """The status of a call is computed either way; in FUNCTION_CALLING mode it used to be
-    dropped, so the same failure produced a status-carrying transcript in the other modes
-    and a bare one here. The marker also gives failures a stable token to count, which the
-    rendered exception name is not."""
+    """The status is computed either way, but FUNCTION_CALLING mode used to drop it, so the
+    same failure read as a plain result here and as a failure in every other mode."""
 
     def test_failures_are_tagged_and_successes_are_untouched(self):
         from dynamiq.nodes.agents.agent import TOOL_ERROR_PREFIX, Agent
@@ -578,8 +566,7 @@ class TestFailedToolResultsAreMarked:
 
 class TestNoToolCallIsDropped:
     """``parallel_tool_calls_enabled`` controls *how* a step's tool calls run, never
-    *whether* they run. These drive a real Agent against a scripted LLM, so they cover the
-    whole path — parsing, batching, execution, and the replies the model reads back."""
+    *whether* they run. Driven against a scripted LLM, so the whole path is covered."""
 
     @staticmethod
     def _agent_with_probe(probe, **kwargs):
@@ -776,9 +763,8 @@ class TestParallelToolConcurrencyIsBounded:
 
 class TestDelegateFinalMustStandAlone:
     """``delegate_final`` answers for the whole step, so it is only honoured when it is the
-    step's only call. Batched with other tools it is refused before it runs — otherwise the
-    sub-agent's answer is logged and streamed as the run's answer while the ReAct loop keeps
-    going, and the client is handed a second, different answer."""
+    step's only call. Batched with others it is refused before it runs, since the answer is
+    streamed as it returns and the loop would then produce a second one."""
 
     @staticmethod
     def _parent_with_sub_agent(probe, **kwargs):
@@ -908,10 +894,63 @@ class TestDelegateFinalMustStandAlone:
         assert answer == "SUB ANSWER", "a delegated result must end the loop, not become an observation"
 
 
+class TestAgentOwnedFieldsStayOutOfThePrompt:
+    """``tool_call_id`` is agent bookkeeping. The modes shown ``run-parallel`` author its
+    argument themselves and have no provider ids, so the field must not be described."""
+
+    def test_tool_call_id_is_not_described_to_the_model(self):
+        from dynamiq.nodes.agents.components.schema_generator import generate_input_formats
+        from dynamiq.nodes.tools.parallel_tool_calls import ParallelToolCallsTool
+
+        rendered = generate_input_formats([ParallelToolCallsTool()], lambda n: n)
+
+        assert "tool_call_id" not in rendered, f"agent-owned field reached the prompt: {rendered}"
+        for shown in ("name:", "input:", "thought:"):
+            assert shown in rendered, f"{shown} must still be described, got {rendered}"
+
+    def test_the_field_still_exists_for_the_agent_to_set(self):
+        """Hiding it from the description must not stop FUNCTION_CALLING from carrying it;
+        ``extra='forbid'`` would reject the id outright if the field were removed."""
+        from dynamiq.nodes.tools.parallel_tool_calls import ToolCallItem
+
+        item = ToolCallItem(name="probe", input={"i": 1}, thought="t", tool_call_id="call_1")
+
+        assert item.model_dump()["tool_call_id"] == "call_1"
+
+    def test_nested_visible_fields_are_still_rendered(self):
+        """The filter is per-field, not a blanket skip of the nested branch."""
+        from typing import Any, ClassVar
+
+        from pydantic import BaseModel, Field
+
+        from dynamiq.nodes.agents.components.schema_generator import generate_input_formats
+        from dynamiq.nodes.node import Node, NodeGroup
+
+        class _Item(BaseModel):
+            shown: str = Field(..., description="visible one")
+            hidden: str | None = Field(default=None, json_schema_extra={"is_accessible_to_agent": False})
+
+        class _Schema(BaseModel):
+            items: list[_Item] = Field(..., description="the items")
+
+        class _Tool(Node):
+            group: NodeGroup = NodeGroup.TOOLS
+            name: str = "probe"
+            description: str = "d"
+            input_schema: ClassVar[type[BaseModel]] = _Schema
+
+            def execute(self, input_data, config=None, **kw) -> Any:
+                return {}
+
+        rendered = generate_input_formats([_Tool()], lambda n: n)
+
+        assert "shown: str - visible one" in rendered, rendered
+        assert "hidden" not in rendered, rendered
+
+
 class TestParallelToolInjectionSeesEveryTool:
-    """``run-parallel`` is withheld only from an agent that truly has nothing to batch, so
-    the emptiness check has to run after every tool is in place — ``SkillsTool`` is appended
-    late enough that a skills-only agent used to be treated as tool-less."""
+    """``run-parallel`` is withheld only from an agent with nothing to batch, so the
+    emptiness check must run after ``SkillsTool`` is appended."""
 
     @staticmethod
     def _agent(tools, **kwargs):

--- a/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
+++ b/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
@@ -410,9 +410,7 @@ class TestEveryPendingIdIsAnswered:
 
         agent = self._agent(["call_a", "call_b", "call_c"])
 
-        Agent._emit_tool_observations(
-            agent, tool_result="Sub-agent invocation limit exceeded.", tool_name="researcher"
-        )
+        Agent._emit_tool_observations(agent, tool_result="Sub-agent invocation limit exceeded.")
 
         assert [m.tool_call_id for m in agent._prompt.messages] == ["call_a", "call_b", "call_c"]
         assert all(m.role == MessageRole.TOOL for m in agent._prompt.messages)
@@ -565,9 +563,7 @@ class TestFailedToolResultsAreMarked:
 
         agent = TestEveryPendingIdIsAnswered._agent(["call_a", "call_b"])
 
-        Agent._emit_tool_observations(
-            agent, tool_result="Sub-agent invocation limit exceeded.", tool_name="researcher", success=False
-        )
+        Agent._emit_tool_observations(agent, tool_result="Sub-agent invocation limit exceeded.", success=False)
 
         assert all(m.content.startswith(TOOL_ERROR_PREFIX) for m in agent._prompt.messages)
 
@@ -632,6 +628,7 @@ class TestNoToolCallIsDropped:
             ),
             tools=[ProbeTool()],
             inference_mode=InferenceMode.FUNCTION_CALLING,
+            parallel_tool_calls_enabled=False,
             max_loops=3,
             **kwargs,
         )
@@ -673,7 +670,7 @@ class TestNoToolCallIsDropped:
     def test_every_call_runs_when_parallel_is_disabled(self):
         """The batch used to execute one call and discard the rest."""
         probe = {"inflight": 0, "peak": 0, "order": []}
-        agent = self._agent_with_probe(probe, parallel_tool_calls_enabled=False)
+        agent = self._agent_with_probe(probe)
 
         self._run(agent, 5)
 
@@ -686,7 +683,7 @@ class TestNoToolCallIsDropped:
         from dynamiq.prompts.prompts import MessageRole
 
         probe = {"inflight": 0, "peak": 0, "order": []}
-        agent = self._agent_with_probe(probe, parallel_tool_calls_enabled=False)
+        agent = self._agent_with_probe(probe)
 
         self._run(agent, 4)
 
@@ -705,7 +702,7 @@ class TestNoToolCallIsDropped:
         from dynamiq.prompts.prompts import MessageRole
 
         probe = {"inflight": 0, "peak": 0, "order": []}
-        agent = self._agent_with_probe(probe, parallel_tool_calls_enabled=False)
+        agent = self._agent_with_probe(probe)
 
         self._run(agent, 3)
 

--- a/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
+++ b/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
@@ -772,3 +772,188 @@ class TestParallelToolConcurrencyIsBounded:
 
         assert stats["completed"] == 12, "capping must queue calls, never drop them"
         assert stats["peak"] <= 3, "more tools ran at once than max_parallel_tool_calls allows"
+
+
+class TestDelegateFinalMustStandAlone:
+    """``delegate_final`` answers for the whole step, so it is only honoured when it is the
+    step's only call. Batched with other tools it is refused before it runs — otherwise the
+    sub-agent's answer is logged and streamed as the run's answer while the ReAct loop keeps
+    going, and the client is handed a second, different answer."""
+
+    @staticmethod
+    def _parent_with_sub_agent(probe, **kwargs):
+        from typing import ClassVar
+
+        from pydantic import BaseModel
+
+        from dynamiq import connections
+        from dynamiq.nodes import llms
+        from dynamiq.nodes.agents import Agent
+        from dynamiq.nodes.node import Node, NodeGroup
+        from dynamiq.nodes.tools.agent_tool import SubAgentTool
+        from dynamiq.nodes.types import InferenceMode
+
+        class _Input(BaseModel):
+            i: int = 0
+
+        class ProbeTool(Node):
+            group: NodeGroup = NodeGroup.TOOLS
+            name: str = "probe"
+            description: str = "records execution"
+            input_schema: ClassVar[type[BaseModel]] = _Input
+
+            def execute(self, input_data, config=None, **kw):
+                probe["ran"].append(input_data.i)
+                return {"content": f"done-{input_data.i}"}
+
+        def _llm(node_id):
+            return llms.OpenAI(
+                id=node_id,
+                model="gpt-4o-mini",
+                connection=connections.OpenAI(api_key="not-used"),
+                is_postponed_component_init=True,
+            )
+
+        child = Agent(id="child", name="child", llm=_llm("child-llm"), tools=[], max_loops=2)
+
+        return Agent(
+            id="agent",
+            name="agent",
+            llm=_llm("llm"),
+            tools=[ProbeTool(), SubAgentTool(agent=child, name="sub_agent", description="delegates")],
+            inference_mode=InferenceMode.FUNCTION_CALLING,
+            parallel_tool_calls_enabled=False,
+            delegation_allowed=True,
+            max_loops=3,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _run(agent, first_turn):
+        from litellm import ModelResponse
+
+        turns = [
+            first_turn,
+            [
+                {
+                    "id": "call_final",
+                    "type": "function",
+                    "function": {
+                        "name": "provide_final_answer",
+                        "arguments": json.dumps({"thought": "done", "answer": "MODEL ANSWER"}),
+                    },
+                }
+            ],
+        ]
+        state = {"n": 0}
+
+        def _completion(stream=False, *a, **kw):
+            calls = turns[min(state["n"], len(turns) - 1)]
+            state["n"] += 1
+            return ModelResponse(choices=[{"message": {"content": None, "tool_calls": calls}}])
+
+        with patch("dynamiq.nodes.llms.base.BaseLLM._completion", side_effect=_completion) as completion:
+            result = agent.run(input_data={"input": "go"})
+        return result, state, completion
+
+    def test_a_batched_delegation_is_refused_and_never_runs(self):
+        """The sub-agent must not be invoked at all: running it and then discarding the flag
+        still streams its answer and bills the call."""
+        from dynamiq.prompts.prompts import MessageRole
+
+        probe = {"ran": []}
+        agent = self._parent_with_sub_agent(probe)
+
+        batch = [
+            {
+                "id": "call_delegate",
+                "type": "function",
+                "function": {
+                    "name": "sub_agent",
+                    "arguments": json.dumps({"thought": "t", "input": "do it", "delegate_final": True}),
+                },
+            },
+            {
+                "id": "call_probe",
+                "type": "function",
+                "function": {"name": "probe", "arguments": json.dumps({"thought": "t", "i": 7})},
+            },
+        ]
+        result, state, completion = self._run(agent, batch)
+
+        by_id = {m.tool_call_id: m.content for m in agent._prompt.messages if m.role == MessageRole.TOOL}
+        assert "was not executed" in by_id["call_delegate"], "the refusal must reach the call that asked"
+        assert probe["ran"] == [7], "the siblings of a refused delegation must still run"
+        assert "done-7" in by_id["call_probe"]
+        assert state["n"] == 2, "the sub-agent must never have been invoked"
+        assert result.output["content"] == "MODEL ANSWER", "the run must end on the model's own single answer"
+
+    def test_a_lone_delegation_still_ends_the_run_with_its_result(self):
+        """The flag survives the batch path when nothing else was called — dropping it here
+        is what let the loop run on and produce a second answer."""
+        from dynamiq.runnables import RunnableConfig
+
+        probe = {"ran": []}
+        agent = self._parent_with_sub_agent(probe)
+
+        with patch.object(type(agent), "_execute_single_tool", return_value=("SUB ANSWER", [], True, True, None)):
+            answer = agent._execute_tools_and_update_prompt(
+                PARALLEL_TOOL_NAME,
+                {"tools": [{"name": "sub_agent", "input": {"input": "do it", "delegate_final": True}, "thought": "t"}]},
+                "t",
+                1,
+                RunnableConfig(),
+            )
+
+        assert answer == "SUB ANSWER", "a delegated result must end the loop, not become an observation"
+
+
+class TestParallelToolInjectionSeesEveryTool:
+    """``run-parallel`` is withheld only from an agent that truly has nothing to batch, so
+    the emptiness check has to run after every tool is in place — ``SkillsTool`` is appended
+    late enough that a skills-only agent used to be treated as tool-less."""
+
+    @staticmethod
+    def _agent(tools, **kwargs):
+        from dynamiq import connections
+        from dynamiq.nodes import llms
+        from dynamiq.nodes.agents import Agent
+        from dynamiq.nodes.types import InferenceMode
+
+        return Agent(
+            id="agent",
+            name="agent",
+            llm=llms.OpenAI(
+                id="llm",
+                model="gpt-4o-mini",
+                connection=connections.OpenAI(api_key="not-used"),
+                is_postponed_component_init=True,
+            ),
+            tools=tools,
+            inference_mode=InferenceMode.XML,
+            parallel_tool_calls_enabled=True,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _skills():
+        from dynamiq.skills.config import SkillsConfig
+        from dynamiq.skills.registries import FileSystem
+        from dynamiq.skills.registries.filesystem import FileSystemSkillEntry
+
+        return SkillsConfig(
+            enabled=True,
+            source=FileSystem(base_path="/nonexistent", skills=[FileSystemSkillEntry(name="a", description="A")]),
+        )
+
+    def test_a_skills_only_agent_can_still_batch(self):
+        agent = self._agent([], skills=self._skills())
+
+        names = [t.name for t in agent.tools]
+        assert "skills-tool" in names, f"expected SkillsTool among {names}"
+        assert PARALLEL_TOOL_NAME in names, f"a skills-only agent has a tool to batch, got {names}"
+
+    def test_a_genuinely_tool_less_agent_is_left_alone(self):
+        agent = self._agent([])
+
+        assert agent.tools == [], "nothing to batch means no run-parallel and no tools prompt block"

--- a/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
+++ b/tests/unit/nodes/agents/test_native_parallel_tool_calls.py
@@ -874,6 +874,47 @@ class TestDelegateFinalMustStandAlone:
         assert state["n"] == 2, "the sub-agent must never have been invoked"
         assert result.output["content"] == "MODEL ANSWER", "the run must end on the model's own single answer"
 
+    def test_a_refused_call_keeps_its_place_in_the_batch_stream(self):
+        """Each tool_run_id was already bound to a tool name client-side while the calls were
+        streaming. Dropping the refused call from the batch shifted every later tool onto an id
+        that belonged to a different tool, so its result landed on the wrong card."""
+        from dynamiq.runnables import RunnableConfig, RunnableStatus
+
+        probe = {"ran": []}
+        agent = self._parent_with_sub_agent(probe)
+        # One id per streamed tool call, minted by the streaming callback in call order.
+        agent._streaming_tool_run_ids = ["id-A", "id-B", "id-C"]
+
+        tools_data = [
+            {"name": "probe", "input": {"i": 1}, "thought": "t", "tool_call_id": "call_1"},
+            {
+                "name": "sub_agent",
+                "input": {"input": "do it", "delegate_final": True},
+                "thought": "t",
+                "tool_call_id": "call_2",
+            },
+            {"name": "probe", "input": {"i": 2}, "thought": "t", "tool_call_id": "call_3"},
+        ]
+
+        with patch.object(type(agent), "_stream_agent_event") as stream:
+            agent._execute_tools(tools_data, "batch", 1, RunnableConfig())
+
+        events = [call[0] for call in stream.call_args_list]
+        reasoning = next(e[0] for e in events if e[1] == "reasoning" and e[0].action == PARALLEL_TOOL_NAME)
+        completion = next(e[0] for e in events if e[1] == "tool" and e[0].name == PARALLEL_TOOL_NAME)
+
+        assert [(entry["action"], entry["tool_run_id"]) for entry in reasoning.action_input] == [
+            ("probe", "id-A"),
+            ("sub_agent", "id-B"),
+            ("probe", "id-C"),
+        ], "a refused call must keep its slot so the surviving tools keep their own ids"
+
+        assert [entry["name"] for entry in completion.result] == ["probe", "sub_agent", "probe"]
+        by_run_id = {entry["tool_run_id"]: entry["status"] for entry in completion.result}
+        assert by_run_id["id-B"] == RunnableStatus.FAILURE, "the refused call must not stream as a success"
+        assert completion.status == RunnableStatus.FAILURE, "a batch holding a refusal did not succeed"
+        assert probe["ran"] == [1, 2], "the siblings of a refused delegation must still run"
+
     def test_a_lone_delegation_still_ends_the_run_with_its_result(self):
         """The flag survives the batch path when nothing else was called — dropping it here
         is what let the loop run on and produce a second answer."""


### PR DESCRIPTION
Six defects in the agent's function-calling loop, each with a regression test verified to fail without its fix.

Tool calls were being discarded. With parallel_tool_calls_enabled=False -- the default -- a step containing several tool calls executed the first and dropped the rest. The loss was silent: the extra calls were erased before the assistant message was written, so the transcript showed one call requested and one answered, the provider raised nothing, and the model could not tell work had gone missing. This is not an edge case -- we never ask the provider to disable parallel calls, so a model that decides to batch will do so. The flag now means "do not run these concurrently" rather than "throw the extras away": every call runs, one after another, in the order requested.

Results were paired to calls by position. Nothing in a result identified which call it answered; the link held only because four separate code paths happened to agree on ordering, across a thread pool that returns in completion order. The provider's tool_call_id now travels with the call -- through ToolCallItem, as a SkipJsonSchema field so it stays out of the prompt the model sees -- into each result, and replies are matched by that id. A result arriving without one now costs its call the content rather than handing it another tool's output.

Requested calls could go unanswered, which kills the run. A request carrying an unanswered tool_call_id is rejected outright, discarding every completed loop. Two paths that end a batch early -- a refused sub-agent budget, a batch that failed to parse -- wrote a bare user-role observation and left their ids owing. Every pending id is now answered in one place.

A final answer batched alongside tool calls was returned as though those results had informed it. They cannot have: the model wrote the answer in the same step that requested them. Anchoring on the first call made the outcome depend on ordering that carries no meaning -- a batch placing the answer last had it discarded and looped to max_loops, one placing it first returned a guess and threw the tools away. An answer is now accepted only when nothing else was requested; batched with tools, the tools run and the reply to the declined call says why. The trade-off is deliberate: a model that attaches an answer to the same repeated calls now exhausts max_loops instead of returning a guess.

Structured-output mode crashed the run on valid-but-unexpected JSON. `null`, a bare list, or a quoted string all parse cleanly and then failed a membership test with TypeError; a response omitting `action_input` failed the read below it with KeyError. Neither is recoverable, so both ended the run. They are parse failures like any other and are now reported as such, naming what is missing.

Tool concurrency was unbounded -- the number of threads spawned was whatever the model asked for. max_parallel_tool_calls (default 8) bounds the pool; calls beyond the limit queue rather than being dropped.

Tool failures were indistinguishable from successes in function-calling mode. The status is computed either way and used to build SUCCESS/ERROR headers for the other inference modes, but the function-calling path reads the per-call results and never those headers. Failures now carry a short marker; successful results are unchanged byte-for-byte.

Also: `run-parallel` is no longer injected into an agent constructed with no tools, where it advertised a tool that could never run, along with the whole tools prompt block.

Behaviour change to note: a function-calling agent with parallel_tool_calls_enabled=False now performs N tool executions per step where it previously performed one. That is work the model requested, but it is a real cost and latency change.

Not included: defaulting parallel_tool_calls_enabled by inference mode. Enabling it outside FUNCTION_CALLING injects `run-parallel`, and workflow schema generation requires every tool to expose a `connection` field, which that tool lacks (node_generation.py:127). That is reachable today by setting the flag explicitly, and should be fixed separately.