### PR TITLE
fix(agents): count tool schemas toward the context estimate

### DIFF
--- a/dynamiq/nodes/agents/components/history_manager.py
+++ b/dynamiq/nodes/agents/components/history_manager.py
@@ -1,5 +1,7 @@
 """History and context management mixin for agents."""
 
+import json
+
 from litellm import token_counter
 
 from dynamiq.nodes.agents.prompts.secondary_instructions import AGENT_NOTES_FILENAME, NOTES_REVISIT_INSTRUCTION_TEMPLATE
@@ -35,6 +37,44 @@ class HistoryManagerMixin:
             return f"{sandbox.base_path.rstrip('/')}/{AGENT_NOTES_FILENAME}"
         return None
 
+    def count_context_tokens(self) -> dict[str, int]:
+        """Tokens the request will carry, by component.
+
+        ``tools`` and ``response_format`` are sent as request parameters rather than
+        messages, so they are invisible to a message-only count. In FUNCTION_CALLING mode
+        the schemas alone can be several thousand tokens.
+
+        Split rather than summed because they are different levers: compaction shrinks the
+        conversation and can do nothing about the schemas.
+        """
+        messages = self._prompt.count_tokens(self.llm.model)
+
+        # same accessor the request uses, so a run-time tool overlay is counted too
+        if effective := getattr(self, "_effective_inference_schemas", None):
+            tool_schemas, response_schema = effective()
+        else:
+            tool_schemas = getattr(self, "_tools", None)
+            response_schema = getattr(self, "_response_format", None)
+
+        tools = 0
+        if tool_schemas:
+            tools = token_counter(
+                model=self.llm.model,
+                messages=[],
+                tools=[s if isinstance(s, dict) else s.model_dump() for s in tool_schemas],
+            )
+
+        response_format = 0
+        if response_schema:
+            response_format = token_counter(model=self.llm.model, text=json.dumps(response_schema))
+
+        return {
+            "messages": messages,
+            "tools": tools,
+            "response_format": response_format,
+            "total": messages + tools + response_format,
+        }
+
     def is_token_limit_exceeded(self) -> bool:
         """
         Check whether token limit for summarization is exceeded.
@@ -42,12 +82,23 @@ class HistoryManagerMixin:
         Returns:
             bool: Whether token limit is exceeded
         """
-        prompt_tokens = self._prompt.count_tokens(self.llm.model)
+        tokens = self.count_context_tokens()
+        prompt_tokens = tokens["total"]
 
-        return (
-            self.summarization_config.max_token_context_length
-            and prompt_tokens > self.summarization_config.max_token_context_length
-        ) or (prompt_tokens / self.llm.get_token_limit() > self.summarization_config.context_usage_ratio)
+        exceeded = bool(
+            (
+                self.summarization_config.max_token_context_length
+                and prompt_tokens > self.summarization_config.max_token_context_length
+            )
+            or (prompt_tokens / self.llm.get_token_limit() > self.summarization_config.context_usage_ratio)
+        )
+        if exceeded:
+            logger.info(
+                f"Agent {self.name} - {self.id}: context at {prompt_tokens}/{self.llm.get_token_limit()} tokens "
+                f"(messages={tokens['messages']}, tools={tokens['tools']}, "
+                f"response_format={tokens['response_format']})."
+            )
+        return exceeded
 
     def _split_history(
         self,

--- a/tests/unit/nodes/agents/test_context_token_accounting.py
+++ b/tests/unit/nodes/agents/test_context_token_accounting.py
@@ -1,0 +1,90 @@
+"""The context estimate must count what the request carries, not just the messages.
+
+`tools` and `response_format` are sent as request parameters, so a message-only count
+misses them entirely — and compaction, which keys off that count, never fires.
+"""
+
+import pytest
+
+from dynamiq import connections
+from dynamiq.nodes import llms
+from dynamiq.nodes.agents import Agent
+from dynamiq.nodes.agents.utils import SummarizationConfig
+from dynamiq.nodes.tools.tavily import TavilyTool
+from dynamiq.nodes.types import InferenceMode
+from dynamiq.prompts import Message, MessageRole
+
+
+def _agent(mode, *, with_tools=True, **kwargs):
+    tools = [TavilyTool(connection=connections.Tavily(api_key="not-used"))] if with_tools else []
+    agent = Agent(
+        name="agent",
+        llm=llms.OpenAI(
+            model="gpt-4o-mini",
+            connection=connections.OpenAI(api_key="not-used"),
+            is_postponed_component_init=True,
+        ),
+        tools=tools,
+        inference_mode=mode,
+        **kwargs,
+    )
+    agent._prompt.messages = [Message(role=MessageRole.USER, content="find something", static=True)]
+    return agent
+
+
+class TestRequestParametersAreCounted:
+    def test_function_calling_counts_tool_schemas(self):
+        """The schemas ride on `tools=`, never in the messages."""
+        tokens = _agent(InferenceMode.FUNCTION_CALLING).count_context_tokens()
+
+        assert tokens["tools"] > 0
+        assert tokens["total"] == tokens["messages"] + tokens["tools"] + tokens["response_format"]
+        assert tokens["total"] > tokens["messages"], "a message-only count misses the schemas"
+
+    def test_structured_output_counts_the_response_schema(self):
+        """The per-step schema rides on `response_format=`."""
+        tokens = _agent(InferenceMode.STRUCTURED_OUTPUT).count_context_tokens()
+
+        assert tokens["response_format"] > 0
+        assert tokens["total"] > tokens["messages"]
+
+    @pytest.mark.parametrize("mode", [InferenceMode.XML, InferenceMode.DEFAULT])
+    def test_prompt_based_modes_are_unchanged(self, mode):
+        """These render tool descriptions into the system prompt, so they were already
+        counted — adding request parameters must not double-count them."""
+        tokens = _agent(mode).count_context_tokens()
+
+        assert tokens["tools"] == 0
+        assert tokens["response_format"] == 0
+        assert tokens["total"] == tokens["messages"]
+
+    def test_the_injected_final_answer_schema_costs_tokens_too(self):
+        """FUNCTION_CALLING always ships `provide_final_answer`, so even a tool-less agent
+        sends a schema — and adding a real tool costs more on top."""
+        bare = _agent(InferenceMode.FUNCTION_CALLING, with_tools=False).count_context_tokens()
+        with_tool = _agent(InferenceMode.FUNCTION_CALLING).count_context_tokens()
+
+        assert bare["tools"] > 0
+        assert with_tool["tools"] > bare["tools"]
+
+
+class TestTokenLimitUsesTheFullRequest:
+    def test_schemas_can_be_what_pushes_it_over(self):
+        """The case the old count missed: messages fit, the request does not."""
+        agent = _agent(InferenceMode.FUNCTION_CALLING)
+        tokens = agent.count_context_tokens()
+        assert tokens["tools"] > 0
+
+        # a ceiling between the two: messages alone are under it, the whole request is over
+        ceiling = (tokens["messages"] + tokens["total"]) // 2
+        agent.summarization_config = SummarizationConfig(enabled=True, max_token_context_length=ceiling)
+
+        assert tokens["messages"] < ceiling < tokens["total"]
+        assert agent.is_token_limit_exceeded(), "compaction must fire on the real request size"
+
+    def test_headroom_is_still_headroom(self):
+        agent = _agent(InferenceMode.FUNCTION_CALLING)
+        total = agent.count_context_tokens()["total"]
+        agent.summarization_config = SummarizationConfig(enabled=True, max_token_context_length=total * 10)
+
+        assert not agent.is_token_limit_exceeded()


### PR DESCRIPTION
The estimate that decides when to compact history counted only the messages:

    prompt_tokens = self._prompt.count_tokens(self.llm.model)

The request carries more than that. `tools` and `response_format` are sent as request parameters, not as messages, so they were invisible to the count -- and both grow with the number of tools. With a single real tool the gap is 485 tokens in FUNCTION_CALLING mode against 648 counted, a 43% undercount; a dozen tools puts it in the thousands.

Both checks in is_token_limit_exceeded are computed from that number, so an agent at 90% of the real window reports around 60% and compaction never fires. The provider then rejects a prompt our own code believed had headroom, and the run dies -- discarding every completed loop.

The undercount is mode-specific. XML and DEFAULT render tool descriptions into the system prompt, which is a message and was already counted; nothing changes for them. FUNCTION_CALLING sends JSON schemas out of band, and STRUCTURED_OUTPUT sends the per-step schema the same way, so those two were affected.

count_context_tokens() now returns the components separately -- messages, tools, response_format -- rather than a single total, because they are different levers: compaction shrinks the conversation and can do nothing about the schemas. When the limit trips, the breakdown is logged, so "why did this overflow" is answerable from the log rather than by guessing. This mirrors how Letta accounts for its context window, where tool definitions are a named component alongside messages and system prompt rather than folded into a sum.

Schemas are read through _effective_inference_schemas(), the same accessor the request uses, so a run-time tool overlay -- long-term memory, a borrowed shared sandbox -- is counted rather than missed. It returns the cached tuple unless an overlay is active, so the common path costs nothing extra.

One caveat worth stating: the tool figure comes from litellm's token_counter, which implements the provider's documented function-definition counting. The response_format figure is that schema tokenized as text; whether providers bill a strict-mode schema as input tokens the same way has not been verified. It is included because this is a threshold for compaction rather than a billing calculation, and under-counting is the failure mode being fixed.