### PR TITLE
feat(composio): add Composio tool node

### DIFF
--- a/dynamiq/connections/connections.py
+++ b/dynamiq/connections/connections.py
@@ -1887,6 +1887,39 @@ class PipedreamOAuth2(BaseConnection):
         }
 
 
+class Composio(BaseConnection):
+    """Composio connection configuration.
+
+    Composio authenticates with a single project-scoped API key; the project is implied by the
+    key itself, so no project identifier is sent alongside it.
+    """
+
+    api_key: str = Field(default_factory=partial(get_env_var, "COMPOSIO_API_KEY"))
+    url: str = "https://backend.composio.dev/api/v3"
+
+    def connect(self):
+        import requests
+
+        return requests
+
+    async def connect_async(self):
+        """Build an httpx.AsyncClient mirroring requests defaults."""
+        import httpx
+
+        return httpx.AsyncClient(  # nosec B113 - timeout=None is intentional; matches requests defaults
+            follow_redirects=True,
+            trust_env=True,
+            timeout=httpx.Timeout(None),
+        )
+
+    @property
+    def conn_params(self) -> dict:
+        return {
+            "x-api-key": self.api_key,
+            "Content-Type": "application/json",
+        }
+
+
 class StagehandEnvironment(str, enum.Enum):
     BROWSERBASE = "BROWSERBASE"
     LOCAL = "LOCAL"

--- a/dynamiq/nodes/tools/__init__.py
+++ b/dynamiq/nodes/tools/__init__.py
@@ -1,6 +1,7 @@
 from .agent_tool import SubAgentTool
 from .bedrock_agentcore_runtime_sandbox import BedrockAgentCoreRuntimeInterpreterTool
 from .bedrock_agentcore_sandbox import BedrockAgentCoreInterpreterTool
+from .composio import Composio
 from .cua_desktop import CuaDesktopTool
 from .cypher_executor import CypherExecutor
 from .daytona_sandbox import DaytonaInterpreterTool

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -200,8 +200,13 @@ class Composio(ConnectionNode):
         """Fail on a tool-level error.
 
         Composio answers 200 even when the action itself failed, so `successful` in the body -
-        not the HTTP status - carries the real outcome. The failure is reported as unrecoverable
-        because an execute must never be replayed: it may have side effects.
+        not the HTTP status - carries the real outcome.
+
+        `recoverable=False` records that an execute should not be replayed - it may have side
+        effects - but it does not currently stop one: `Node._handle_failure` derives the flag
+        from the exception type rather than from this value, and every `ToolExecutionException`
+        is a `RecoverableAgentException`. The same is true of `RECOVERABLE_CODES` above and of
+        every other tool in the repo that passes the argument.
         """
         if not response_json.get("successful", True):
             error_message = f"Composio tool {self.tool_slug} execution failed"

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -6,7 +6,12 @@ from dynamiq.connections import Composio as ComposioConnection
 from dynamiq.nodes import NodeGroup
 from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import ConnectionNode, ensure_config
-from dynamiq.nodes.tools.mcp import create_input_schema_from_json_schema, rename_keys_recursive
+from dynamiq.nodes.tools.mcp import (
+    create_input_schema_from_json_schema,
+    get_json_schema_definitions,
+    rename_keys_recursive,
+    resolve_root_object_schema,
+)
 from dynamiq.runnables import RunnableConfig
 from dynamiq.types.cancellation import check_cancellation
 from dynamiq.utils.logger import logger
@@ -140,6 +145,13 @@ class Composio(ConnectionNode):
             schema_dict = {}
         schema_dict = rename_keys_recursive(schema_dict, {"type_": "type"})
 
+        # A root composed purely of $ref/allOf is resolved to the object schema it stands for before
+        # anything below inspects it. The schema builder resolves the same way, so rewriting the
+        # unresolved root instead would edit keys it goes on to discard. The definitions live on the
+        # original root and have to be carried across, since the resolved schema no longer holds them.
+        definitions = get_json_schema_definitions(schema_dict)
+        schema_dict = resolve_root_object_schema(schema_dict, definitions)
+
         # Composio marks optionality the Pydantic way, so only `required` is authoritative. A parameter
         # already configured at design time is dropped from it: the runtime input may override the
         # configured value, but does not have to supply one.
@@ -157,7 +169,7 @@ class Composio(ConnectionNode):
                 if isinstance(prop, dict) and "default" in prop:
                     schema_dict["properties"][name] = {key: value for key, value in prop.items() if key != "default"}
 
-        return create_input_schema_from_json_schema(schema_dict, "ComposioToolSchema")
+        return create_input_schema_from_json_schema(schema_dict, "ComposioToolSchema", definitions=definitions)
 
     def _build_request(self, input_data: BaseModel) -> tuple[str, dict]:
         base_url = (self.connection.url or DEFAULT_COMPOSIO_URL).rstrip("/")

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 from dynamiq.connections import Composio as ComposioConnection
 from dynamiq.nodes import NodeGroup
@@ -49,6 +49,11 @@ class Composio(ConnectionNode):
     connected_account_id: str | None = None
     arguments: dict[str, Any] = {}
 
+    # The description Composio supplied for the action, before `_generate_description` appends the
+    # parameter listing onto it. `None` means it was never captured, which only happens if the node
+    # was built without running `__init__`.
+    _source_description: str | None = PrivateAttr(default=None)
+
     def __init__(self, input_props: dict[str, Any] | None = None, **kwargs):
         arguments = kwargs.get("arguments") or {}
         # A tool that declares no parameters is persisted with an empty or absent schema - the node
@@ -64,7 +69,17 @@ class Composio(ConnectionNode):
             input_props=input_props,
             **kwargs,
         )
+        self._source_description = self.description
         self.description = self._generate_description()
+
+    def to_dict(self, **kwargs) -> dict:
+        data = super().to_dict(**kwargs)
+        # At runtime `description` carries the parameter listing that `_generate_description` appended
+        # to the description Composio supplied. Persisting that listing would feed it back in on the
+        # next load, where it is appended again, so it would compound on every save/load cycle.
+        if self._source_description is not None and "description" in data:
+            data["description"] = self._source_description
+        return data
 
     @property
     def to_dict_exclude_params(self):

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -40,7 +40,7 @@ class Composio(ConnectionNode):
     connection: ComposioConnection
     timeout: float = 180
     input_schema: type[BaseModel]
-    input_props: dict[str, Any]
+    input_props: dict[str, Any] = {}
     description: str = ""
     user_id: str
     toolkit_slug: str
@@ -49,8 +49,14 @@ class Composio(ConnectionNode):
     connected_account_id: str | None = None
     arguments: dict[str, Any] = {}
 
-    def __init__(self, input_props: dict[str, Any], **kwargs):
+    def __init__(self, input_props: dict[str, Any] | None = None, **kwargs):
         arguments = kwargs.get("arguments") or {}
+        # A tool that declares no parameters is persisted with an empty or absent schema - the node
+        # type serializes `input_props` with `omitempty`, and Composio itself reports "no declared
+        # schema" as either `{}` or `null` - so every such spelling has to yield an empty schema
+        # rather than a construction error.
+        if not isinstance(input_props, dict):
+            input_props = {}
         input_props = rename_keys_recursive(input_props, {"type": "type_"})
         input_schema = self.get_input_schema(input_props, arguments=arguments)
         super().__init__(
@@ -111,9 +117,9 @@ class Composio(ConnectionNode):
             schema_dict (dict[str, Any]): A JSON schema dictionary describing the tool's expected input.
             arguments (dict[str, Any]): Argument values already configured at design time.
         """
-        schema_dict = rename_keys_recursive(schema_dict, {"type_": "type"})
         if not isinstance(schema_dict, dict):
             schema_dict = {}
+        schema_dict = rename_keys_recursive(schema_dict, {"type_": "type"})
 
         # Composio marks optionality the Pydantic way, so only `required` is authoritative. A parameter
         # already configured at design time is dropped from it: the runtime input may override the

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -1,0 +1,234 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from dynamiq.connections import Composio as ComposioConnection
+from dynamiq.nodes import NodeGroup
+from dynamiq.nodes.agents.exceptions import ToolExecutionException
+from dynamiq.nodes.node import ConnectionNode, ensure_config
+from dynamiq.nodes.tools.mcp import create_input_schema_from_json_schema, rename_keys_recursive
+from dynamiq.runnables import RunnableConfig
+from dynamiq.types.cancellation import check_cancellation
+from dynamiq.utils.logger import logger
+
+DEFAULT_COMPOSIO_URL = "https://backend.composio.dev/api/v3"
+SUCCESS_CODES = [200]
+RECOVERABLE_CODES = [400, 401, 402, 422, 429]
+
+
+class Composio(ConnectionNode):
+    """
+    A tool for executing a single Composio action (tool) on behalf of a Composio user.
+
+    Attributes:
+        name (str): Name of the tool
+        description (str): Description of the tool
+        group (Literal[NodeGroup.TOOLS]): The group the node belongs to
+        connection (ComposioConnection): The Composio API connection
+        timeout (float): Request timeout in seconds
+        input_props (dict[str, Any]): The tool's `input_parameters` JSON Schema
+        user_id (str): The Composio user id the action runs as
+        toolkit_slug (str): Slug of the Composio toolkit (app), e.g. `gmail`
+        tool_slug (str): Slug of the Composio tool (action), e.g. `GMAIL_SEND_EMAIL`
+        tool_version (str | None): Pins the tool version the arguments were configured against
+        connected_account_id (str | None): Pins the action to a specific connected account
+        arguments (dict[str, Any]): Argument values configured at design time
+    """
+
+    name: str = "composio"
+    group: Literal[NodeGroup.TOOLS] = NodeGroup.TOOLS
+    connection: ComposioConnection
+    timeout: float = 180
+    input_schema: type[BaseModel]
+    input_props: dict[str, Any]
+    description: str = ""
+    user_id: str
+    toolkit_slug: str
+    tool_slug: str
+    tool_version: str | None = None
+    connected_account_id: str | None = None
+    arguments: dict[str, Any] = {}
+
+    def __init__(self, input_props: dict[str, Any], **kwargs):
+        arguments = kwargs.get("arguments") or {}
+        input_props = rename_keys_recursive(input_props, {"type": "type_"})
+        input_schema = self.get_input_schema(input_props, arguments=arguments)
+        super().__init__(
+            input_schema=input_schema,
+            input_props=input_props,
+            **kwargs,
+        )
+        self.description = self._generate_description()
+
+    @property
+    def to_dict_exclude_params(self):
+        parent_dict = super().to_dict_exclude_params.copy()
+        parent_dict.update(
+            {
+                "input_schema": True,
+            }
+        )
+        return parent_dict
+
+    def _generate_description(self) -> str:
+        """
+        Generates a detailed description of the tool based on the input schema.
+
+        Returns:
+            str: A formatted description of the tool and its capabilities
+        """
+        schema_fields: dict[str, Any] = self.input_schema.model_fields
+        logger.debug(f"Tool {self.name} - Generating description from schema fields")
+
+        desc: list[str] = [self.description if self.description else f"{self.name} tool"]
+
+        required_fields: list[str] = [name for name, field in schema_fields.items() if field.is_required() is not False]
+        if required_fields:
+            desc.append("\nRequired Parameters:")
+            for field_name in sorted(required_fields):
+                field = schema_fields[field_name]
+                desc.append(f"- {field_name} ({str(field.annotation)}): {field.description}")
+
+        optional_fields: list[str] = [name for name, field in schema_fields.items() if field.is_required() is False]
+        if optional_fields:
+            desc.append("\nOptional Parameters:")
+            for field_name in sorted(optional_fields):
+                field = schema_fields[field_name]
+                desc.append(f"- {field_name} ({str(field.annotation)}): {field.description}")
+
+        if self.arguments:
+            desc.append("\nAlready configured parameters, that can be overridden:")
+            for field_name in sorted(self.arguments):
+                desc.append(f"- {field_name}: {self.arguments[field_name]}")
+
+        return "\n".join(desc)
+
+    def get_input_schema(self, schema_dict: dict[str, Any], arguments: dict[str, Any]) -> type[BaseModel]:
+        """
+        Creates an input schema based on the tool's `input_parameters` JSON Schema.
+
+        Args:
+            schema_dict (dict[str, Any]): A JSON schema dictionary describing the tool's expected input.
+            arguments (dict[str, Any]): Argument values already configured at design time.
+        """
+        schema_dict = rename_keys_recursive(schema_dict, {"type_": "type"})
+        if not isinstance(schema_dict, dict):
+            schema_dict = {}
+
+        # Composio marks optionality the Pydantic way, so only `required` is authoritative. A parameter
+        # already configured at design time is dropped from it: the runtime input may override the
+        # configured value, but does not have to supply one.
+        required = schema_dict.get("required") or []
+        schema_dict = {**schema_dict, "required": [name for name in required if name not in arguments]}
+
+        return create_input_schema_from_json_schema(schema_dict, "ComposioToolSchema")
+
+    def _build_request(self, input_data: BaseModel) -> tuple[str, dict]:
+        base_url = (self.connection.url or DEFAULT_COMPOSIO_URL).rstrip("/")
+        url = f"{base_url}/tools/execute/{self.tool_slug}"
+        payload = {
+            "arguments": {
+                **self.arguments,
+                # by_alias restores the original JSON Schema property names for parameters whose
+                # names are not valid Python identifiers.
+                **{k: v for k, v in input_data.model_dump(by_alias=True).items() if v is not None},
+            },
+            "user_id": self.user_id,
+            # Omitting the version lets Composio resolve its own default, which could differ
+            # from the schema the arguments were configured against.
+            **({"version": self.tool_version} if self.tool_version else {}),
+            **({"connected_account_id": self.connected_account_id} if self.connected_account_id else {}),
+        }
+        return url, payload
+
+    def _check_response_status(self, response: Any) -> None:
+        if response.status_code not in SUCCESS_CODES:
+            error_message = f"Composio API request failed with status code: {response.status_code}"
+            logger.error(f"Tool {self.name} - {error_message}")
+            recoverable = response.status_code in RECOVERABLE_CODES
+            raise ToolExecutionException(f"{error_message} and response: {response.text}", recoverable=recoverable)
+
+    def _check_execution_result(self, response_json: dict) -> None:
+        """Fail on a tool-level error.
+
+        Composio answers 200 even when the action itself failed, so `successful` in the body -
+        not the HTTP status - carries the real outcome. The failure is reported as unrecoverable
+        because an execute must never be replayed: it may have side effects.
+        """
+        if not response_json.get("successful", True):
+            error_message = f"Composio tool {self.tool_slug} execution failed"
+            logger.error(f"Tool {self.name} - {error_message}")
+            raise ToolExecutionException(f"{error_message} with error: {response_json.get('error')}", recoverable=False)
+
+    def _build_output(self, response: Any) -> dict[str, Any]:
+        if self.is_optimized_for_agents:
+            return {"content": response.text}
+        return {"content": response.json().get("data")}
+
+    def execute(self, input_data: BaseModel, config: RunnableConfig = None, **kwargs):
+        """Execute the Composio action.
+
+        Args:
+            input_data (BaseModel): The action arguments, validated against the tool's input schema
+            config (RunnableConfig, optional): Configuration for the execution
+            **kwargs: Additional keyword arguments
+
+        Returns:
+            dict: A dictionary containing:
+                - content (Any): The `data` payload of the Composio response
+
+        Raises:
+            ToolExecutionException: If the API request fails or the action itself reports a failure
+        """
+        logger.debug(f"Tool {self.name} - Starting execution with input data: {input_data.model_dump()}")
+
+        config = ensure_config(config)
+        check_cancellation(config)
+        self.run_on_node_execute_run(config.callbacks, **kwargs)
+
+        try:
+            url, payload = self._build_request(input_data)
+            response = self.client.request(
+                method="POST",
+                url=url,
+                headers=self.connection.conn_params,
+                json=payload,
+                timeout=self.timeout,
+            )
+            self._check_response_status(response)
+            self._check_execution_result(response.json())
+
+            return self._build_output(response)
+        except ToolExecutionException:
+            raise
+        except Exception as e:
+            logger.error(f"Tool {self.name} - Unexpected error during execution: {str(e)}")
+            raise ToolExecutionException(f"Unexpected error during execution:  {str(e)}", recoverable=False)
+
+    async def execute_async(self, input_data: BaseModel, config: RunnableConfig = None, **kwargs):
+        """Native async execution path mirroring ``execute``."""
+        logger.debug(f"Tool {self.name} - Starting execution with input data: {input_data.model_dump()}")
+
+        config = ensure_config(config)
+        check_cancellation(config)
+        self.run_on_node_execute_run(config.callbacks, **kwargs)
+
+        try:
+            url, payload = self._build_request(input_data)
+            client = await self.get_async_client()
+            response = await client.request(
+                method="POST",
+                url=url,
+                headers=self.connection.conn_params,
+                json=payload,
+                timeout=self.timeout,
+            )
+            self._check_response_status(response)
+            self._check_execution_result(response.json())
+
+            return self._build_output(response)
+        except ToolExecutionException:
+            raise
+        except Exception as e:
+            logger.error(f"Tool {self.name} - Unexpected error during execution: {str(e)}")
+            raise ToolExecutionException(f"Unexpected error during execution:  {str(e)}", recoverable=False)

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -131,6 +131,17 @@ class Composio(ConnectionNode):
         required = schema_dict.get("required") or []
         schema_dict = {**schema_dict, "required": [name for name in required if name not in arguments]}
 
+        properties = schema_dict.get("properties")
+        if arguments and isinstance(properties, dict):
+            # A configured parameter falls back to its configured value, so it must not keep the schema
+            # default as well: the model emits that default whenever the caller leaves the parameter
+            # out, and it wins over `arguments` when the request payload is assembled.
+            schema_dict = {**schema_dict, "properties": dict(properties)}
+            for name in arguments:
+                prop = properties.get(name)
+                if isinstance(prop, dict) and "default" in prop:
+                    schema_dict["properties"][name] = {key: value for key, value in prop.items() if key != "default"}
+
         return create_input_schema_from_json_schema(schema_dict, "ComposioToolSchema")
 
     def _build_request(self, input_data: BaseModel) -> tuple[str, dict]:

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -86,7 +86,11 @@ class Composio(ConnectionNode):
         schema_fields: dict[str, Any] = self.input_schema.model_fields
         logger.debug(f"Tool {self.name} - Generating description from schema fields")
 
-        desc: list[str] = [self.description if self.description else f"{self.name} tool"]
+        # The platform supplies a description snapshotted from Composio when the action was picked.
+        # Constructed directly, there is none, so fall back to the slugs rather than the node name:
+        # an agent picking between tools needs to know which action this is.
+        fallback = f"Executes the Composio tool {self.tool_slug} from the {self.toolkit_slug} toolkit."
+        desc: list[str] = [self.description or fallback]
 
         required_fields: list[str] = [name for name, field in schema_fields.items() if field.is_required() is not False]
         if required_fields:

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -26,7 +26,7 @@ class Composio(ConnectionNode):
     A tool for executing a single Composio action (tool) on behalf of a Composio user.
 
     Attributes:
-        name (str): Name of the tool
+        name (str): Name of the tool, defaulting to the lowercased `tool_slug`
         description (str): Description of the tool
         group (Literal[NodeGroup.TOOLS]): The group the node belongs to
         connection (ComposioConnection): The Composio API connection
@@ -60,6 +60,12 @@ class Composio(ConnectionNode):
     _source_description: str | None = PrivateAttr(default=None)
 
     def __init__(self, input_props: dict[str, Any] | None = None, **kwargs):
+        # One node is one action, and an agent keys its tool registry, its prompt listing and its
+        # result cache on `name`. Two actions sharing the class default would collapse to a single
+        # entry, leaving the first unreachable, so an unnamed node is named after its action.
+        if not kwargs.get("name"):
+            kwargs["name"] = (kwargs.get("tool_slug") or self.model_fields["name"].default).lower()
+
         arguments = kwargs.get("arguments") or {}
         # A tool that declares no parameters is persisted with an empty or absent schema - the node
         # type serializes `input_props` with `omitempty`, and Composio itself reports "no declared

--- a/dynamiq/nodes/tools/composio.py
+++ b/dynamiq/nodes/tools/composio.py
@@ -178,8 +178,10 @@ class Composio(ConnectionNode):
             "arguments": {
                 **self.arguments,
                 # by_alias restores the original JSON Schema property names for parameters whose
-                # names are not valid Python identifiers.
-                **{k: v for k, v in input_data.model_dump(by_alias=True).items() if v is not None},
+                # names are not valid Python identifiers. exclude_none drops what the caller left
+                # unset at every depth: an optional property is typed `X | None` with default None,
+                # so nested objects would otherwise post an explicit null for each unsupplied field.
+                **input_data.model_dump(by_alias=True, exclude_none=True),
             },
             "user_id": self.user_id,
             # Omitting the version lets Composio resolve its own default, which could differ

--- a/dynamiq/nodes/tools/mcp.py
+++ b/dynamiq/nodes/tools/mcp.py
@@ -343,6 +343,20 @@ class _SchemaModelBuilder:
         return root
 
 
+def resolve_root_object_schema(
+    schema_dict: dict[str, Any], definitions: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Resolve a root defined purely through $ref/allOf composition to the object schema it stands for.
+
+    This is the same resolution `create_input_schema_from_json_schema` applies before building the
+    model, exposed for callers that need to inspect or rewrite the properties the model is built
+    from. The result carries no `$defs` of its own, so pass the original definitions alongside it.
+    """
+    builder = _SchemaModelBuilder(dict(definitions or {}))
+    builder._definitions = {**builder._definitions, **get_json_schema_definitions(schema_dict)}
+    return builder._resolve_to_object_schema(schema_dict)
+
+
 def create_input_schema_from_json_schema(
     schema_dict: dict[str, Any], model_name: str = "MCPToolSchema", definitions: dict[str, Any] | None = None
 ) -> type[BaseModel]:

--- a/examples/components/tools/composio/agent_composio.yaml
+++ b/examples/components/tools/composio/agent_composio.yaml
@@ -55,3 +55,14 @@ nodes:
               type: boolean
               default: false
               description: Whether the body is HTML.
+
+flows:
+  composio-agent-flow:
+    name: Composio Agent Flow
+    nodes:
+      - agent-composio
+
+workflows:
+  composio-agent-workflow:
+    flow: composio-agent-flow
+    version: 1

--- a/examples/components/tools/composio/agent_composio.yaml
+++ b/examples/components/tools/composio/agent_composio.yaml
@@ -1,0 +1,57 @@
+connections:
+  composio-conn:
+    type: dynamiq.connections.Composio
+    api_key: ${oc.env:COMPOSIO_API_KEY}
+
+  openai-conn:
+    type: dynamiq.connections.OpenAI
+    api_key: ${oc.env:OPENAI_API_KEY}
+
+nodes:
+  agent-composio:
+    type: dynamiq.nodes.agents.Agent
+    name: Mailer Agent
+    role: |
+      Assistant that sends short, factual status emails on request.
+      Keep the subject under ten words and the body to a few sentences.
+    llm:
+      id: mailer-llm
+      type: dynamiq.nodes.llms.OpenAI
+      connection: openai-conn
+      model: gpt-4o-mini
+    tools:
+      - id: composio-tool
+        type: dynamiq.nodes.tools.composio.Composio
+        connection: composio-conn
+        # Always the project id on the platform.
+        user_id: ${oc.env:COMPOSIO_USER_ID}
+        toolkit_slug: gmail
+        tool_slug: GMAIL_SEND_EMAIL
+        is_optimized_for_agents: true
+        # Configured up front: the agent may override it, but need not supply it.
+        arguments:
+          recipient_email: someone@example.com
+        # The tool's `input_parameters` JSON Schema, from GET /api/v3/tools/{slug}.
+        input_props:
+          type: object
+          title: SendEmailRequest
+          required:
+            - recipient_email
+            - body
+          properties:
+            recipient_email:
+              type: string
+              description: Address of the recipient.
+            body:
+              type: string
+              description: Body of the email.
+            subject:
+              anyOf:
+                - type: string
+                - type: "null"
+              default: null
+              description: Subject of the email.
+            is_html:
+              type: boolean
+              default: false
+              description: Whether the body is HTML.

--- a/examples/components/tools/composio/use_composio.py
+++ b/examples/components/tools/composio/use_composio.py
@@ -11,7 +11,7 @@ import os
 from dynamiq.connections import Composio as ComposioConnection
 from dynamiq.nodes.agents import Agent
 from dynamiq.nodes.tools import Composio
-from examples.utils.utils_llm import setup_llm
+from examples.components.tools.extra_utils.utils_llm import setup_llm
 
 # The Composio user the action runs as. On the platform this is always the project id.
 USER_ID = os.environ.get("COMPOSIO_USER_ID", "")

--- a/examples/components/tools/composio/use_composio.py
+++ b/examples/components/tools/composio/use_composio.py
@@ -1,0 +1,91 @@
+"""Run a Composio action directly and as an agent tool.
+
+The node executes one Composio tool (an action of a toolkit) on behalf of a Composio user.
+Unlike the builder, which snapshots the tool's schema when the action is picked, a script has
+to supply `input_props` itself - it is the tool's `input_parameters` JSON Schema, available
+from `GET /api/v3/tools/{slug}`.
+"""
+
+import os
+
+from dynamiq.connections import Composio as ComposioConnection
+from dynamiq.nodes.agents import Agent
+from dynamiq.nodes.tools import Composio
+from examples.utils.utils_llm import setup_llm
+
+# The Composio user the action runs as. On the platform this is always the project id.
+USER_ID = os.environ.get("COMPOSIO_USER_ID", "")
+
+# Pins the action to one connected account. Without it Composio resolves an account for USER_ID.
+CONNECTED_ACCOUNT_ID = os.environ.get("COMPOSIO_CONNECTED_ACCOUNT_ID") or None
+
+# The tool's `input_parameters` JSON Schema, as returned by GET /api/v3/tools/{slug}.
+GMAIL_SEND_EMAIL_PROPS = {
+    "type": "object",
+    "title": "SendEmailRequest",
+    "required": ["recipient_email", "body"],
+    "properties": {
+        "recipient_email": {"type": "string", "description": "Address of the recipient."},
+        "body": {"type": "string", "description": "Body of the email."},
+        "subject": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "default": None,
+            "description": "Subject of the email.",
+        },
+        "is_html": {"type": "boolean", "default": False, "description": "Whether the body is HTML."},
+    },
+}
+
+
+def build_tool(**kwargs) -> Composio:
+    return Composio(
+        connection=ComposioConnection(),
+        input_props=GMAIL_SEND_EMAIL_PROPS,
+        user_id=USER_ID,
+        toolkit_slug="gmail",
+        tool_slug="GMAIL_SEND_EMAIL",
+        connected_account_id=CONNECTED_ACCOUNT_ID,
+        # Pinning the version keeps execution on the schema the arguments were written against.
+        tool_version=os.environ.get("COMPOSIO_TOOL_VERSION") or None,
+        **kwargs,
+    )
+
+
+def send_email_directly() -> None:
+    """Run the action on its own, supplying every argument at call time."""
+    result = build_tool().run(
+        input_data={
+            "recipient_email": "someone@example.com",
+            "subject": "Sent from Dynamiq",
+            "body": "Hello from the Composio action node.",
+        }
+    )
+    print(result)
+
+
+def send_email_from_an_agent() -> None:
+    """Hand the action to an agent.
+
+    Values in `arguments` are configured up front: they are dropped from the required set, so the
+    agent may override them but does not have to supply them. The generated tool description lists
+    them, along with the required and optional parameters.
+    """
+    tool = build_tool(
+        # `is_optimized_for_agents` makes the node return the raw response body, which the agent
+        # reads directly rather than through a parsed payload.
+        is_optimized_for_agents=True,
+        arguments={"recipient_email": "someone@example.com"},
+    )
+    print(f"\nTool description the agent sees:\n{tool.description}\n")
+
+    agent = Agent(name="Mailer", llm=setup_llm(), tools=[tool])
+    result = agent.run(input_data={"input": "Send a short note saying the deploy finished."})
+    print(result.output)
+
+
+if __name__ == "__main__":
+    if not USER_ID:
+        raise SystemExit("Set COMPOSIO_USER_ID (and COMPOSIO_API_KEY) to run this example.")
+
+    send_email_directly()
+    send_email_from_an_agent()

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -40,6 +40,18 @@ def _mock_response(status_code=200, json_payload=None, text="ok"):
     return resp
 
 
+def _composed_root(inner: dict, style: str) -> dict:
+    """Express `inner` as a root that only reaches its properties through $ref or allOf."""
+    if style == "inline":
+        return inner
+    if style == "$ref":
+        return {"$defs": {"Req": inner}, "$ref": "#/$defs/Req"}
+    return {"$defs": {"Req": inner}, "allOf": [{"$ref": "#/$defs/Req"}]}
+
+
+COMPOSED_ROOT_STYLES = ["inline", "$ref", "allOf"]
+
+
 def _build_node(**kwargs) -> Composio:
     kwargs.setdefault("input_props", INPUT_PROPS)
     kwargs.setdefault("user_id", "project-uuid")
@@ -66,6 +78,67 @@ class TestComposioInputSchema:
         required = {name for name, field in fields.items() if field.is_required()}
 
         assert required == {"recipient_email"}
+
+    @pytest.mark.parametrize("style", COMPOSED_ROOT_STYLES)
+    def test_configured_argument_stops_being_required_on_a_composed_root(self, style):
+        # Composio may express a tool's schema through a root-level $ref or allOf. The schema builder
+        # resolves such a root before reading its properties, so the configured-argument handling has
+        # to resolve it too - otherwise the agent is asked for a parameter it already has.
+        inner = {
+            "type": "object",
+            "required": ["recipient", "body"],
+            "properties": {"recipient": {"type": "string"}, "body": {"type": "string"}},
+        }
+        node = _build_node(
+            input_props=_composed_root(inner, style),
+            arguments={"recipient": "configured@example.com"},
+        )
+
+        required = {name for name, field in node.input_schema.model_fields.items() if field.is_required()}
+
+        assert required == {"body"}
+
+    @pytest.mark.parametrize("style", COMPOSED_ROOT_STYLES)
+    def test_configured_argument_survives_the_schema_default_on_a_composed_root(self, style):
+        # The silent case: no validation error, the action just executes against Composio's default
+        # instead of the value configured at design time.
+        inner = {
+            "type": "object",
+            "required": ["body"],
+            "properties": {
+                "recipient": {"type": "string", "default": "composio-default@example.com"},
+                "body": {"type": "string"},
+            },
+        }
+        node = _build_node(
+            input_props=_composed_root(inner, style),
+            arguments={"recipient": "configured@example.com"},
+        )
+
+        _, payload = node._build_request(node.input_schema(body="hi"))
+
+        assert payload["arguments"]["recipient"] == "configured@example.com"
+
+    def test_definitions_survive_a_resolved_root(self):
+        # Resolving the root drops the `$defs` that lived on it, so they have to be carried across
+        # or a property referencing one of them would fail to build.
+        input_props = {
+            "$defs": {
+                "Req": {
+                    "type": "object",
+                    "required": ["addr"],
+                    "properties": {"addr": {"$ref": "#/$defs/Addr"}, "note": {"type": "string"}},
+                },
+                "Addr": {"type": "object", "properties": {"city": {"type": "string"}}},
+            },
+            "$ref": "#/$defs/Req",
+        }
+        node = _build_node(input_props=input_props)
+
+        _, payload = node._build_request(node.input_schema(addr={"city": "Kyiv"}, note="x"))
+
+        assert sorted(node.input_schema.model_fields) == ["addr", "note"]
+        assert payload["arguments"]["addr"] == {"city": "Kyiv"}
 
     def test_property_name_that_is_not_an_identifier_keeps_its_alias(self):
         node = _build_node()

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -173,6 +173,18 @@ class TestComposioExecute:
 
         assert client.request.call_args.kwargs["json"]["arguments"]["body"] == "Runtime body"
 
+    def test_configured_argument_survives_the_schema_default(self):
+        # `is_html` declares `default: false`, so a runtime input that leaves it out would otherwise
+        # carry that default into the payload and silently discard the configured value.
+        node = _build_node(arguments={"is_html": True})
+        client = MagicMock()
+        client.request = MagicMock(return_value=_mock_response(json_payload={"data": {}, "successful": True}))
+        node.client = client
+
+        node.execute(node.input_schema(recipient_email="a@b.c", body="Body"))
+
+        assert client.request.call_args.kwargs["json"]["arguments"]["is_html"] is True
+
     def test_tool_version_is_sent_as_version(self):
         node = _build_node(tool_version="20250905_00")
         client = MagicMock()

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -124,6 +124,13 @@ class TestComposioInputSchema:
         assert "Already configured parameters, that can be overridden:" in node.description
         assert "- body: Configured body" in node.description
 
+    def test_description_falls_back_to_the_slugs_when_none_is_supplied(self):
+        # Without a description the agent would otherwise see only the node name, which says
+        # nothing about which action this is.
+        node = _build_node()
+
+        assert node.description.startswith("Executes the Composio tool GMAIL_SEND_EMAIL from the gmail toolkit.")
+
     def test_to_dict_excludes_input_schema(self):
         node = _build_node()
 

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -1,0 +1,252 @@
+"""Unit tests for the Composio action tool.
+
+A Composio execute answers HTTP 200 even when the action itself failed, so the tests below pin
+both the transport-level and the body-level failure handling, and assert the request is never
+replayed - an execute can have side effects.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dynamiq.connections.connections import Composio as ComposioConnection
+from dynamiq.nodes.agents.exceptions import ToolExecutionException
+from dynamiq.nodes.node import Node
+from dynamiq.nodes.tools.composio import Composio
+
+INPUT_PROPS = {
+    "type": "object",
+    "title": "SendEmailRequest",
+    "required": ["recipient_email", "body"],
+    "properties": {
+        "recipient_email": {"type": "string", "description": "Address of the recipient."},
+        "body": {"type": "string", "description": "Body of the email."},
+        "subject": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "default": None,
+            "description": "Subject of the email.",
+        },
+        "is_html": {"type": "boolean", "default": False, "description": "Whether the body is HTML."},
+        "extra-header": {"type": "string", "description": "Header that is not a python identifier."},
+    },
+}
+
+
+def _mock_response(status_code=200, json_payload=None, text="ok"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.json = MagicMock(return_value=json_payload if json_payload is not None else {})
+    return resp
+
+
+def _build_node(**kwargs) -> Composio:
+    kwargs.setdefault("input_props", INPUT_PROPS)
+    kwargs.setdefault("user_id", "project-uuid")
+    kwargs.setdefault("toolkit_slug", "gmail")
+    kwargs.setdefault("tool_slug", "GMAIL_SEND_EMAIL")
+    return Composio(connection=ComposioConnection(api_key="key"), **kwargs)
+
+
+class TestComposioInputSchema:
+    def test_required_props_are_required_and_the_rest_optional(self):
+        node = _build_node()
+
+        fields = node.input_schema.model_fields
+        required = {name for name, field in fields.items() if field.is_required()}
+
+        assert required == {"recipient_email", "body"}
+        assert fields["subject"].default is None
+        assert fields["is_html"].default is False
+
+    def test_configured_argument_stops_being_required(self):
+        node = _build_node(arguments={"body": "Configured body"})
+
+        fields = node.input_schema.model_fields
+        required = {name for name, field in fields.items() if field.is_required()}
+
+        assert required == {"recipient_email"}
+
+    def test_property_name_that_is_not_an_identifier_keeps_its_alias(self):
+        node = _build_node()
+
+        field = node.input_schema.model_fields["extra_header"]
+
+        assert field.alias == "extra-header"
+
+    def test_empty_schema_builds_a_model_without_fields(self):
+        node = _build_node(input_props={})
+
+        assert node.input_schema.model_fields == {}
+
+    def test_description_lists_parameters_and_configured_arguments(self):
+        node = _build_node(description="Send an email.", arguments={"body": "Configured body"})
+
+        assert node.description.startswith("Send an email.")
+        assert "Required Parameters:" in node.description
+        assert "- recipient_email" in node.description
+        assert "Optional Parameters:" in node.description
+        assert "- subject" in node.description
+        assert "Already configured parameters, that can be overridden:" in node.description
+        assert "- body: Configured body" in node.description
+
+    def test_to_dict_excludes_input_schema(self):
+        node = _build_node()
+
+        assert "input_schema" not in node.to_dict()
+
+
+class TestComposioExecute:
+    def test_execute_posts_to_the_tool_execute_endpoint(self):
+        node = _build_node(arguments={"body": "Configured body"})
+        client = MagicMock()
+        client.request = MagicMock(return_value=_mock_response(json_payload={"data": {"id": "1"}, "successful": True}))
+        node.client = client
+
+        result = node.execute(
+            node.input_schema(recipient_email="a@b.c", **{"extra-header": "x"}),
+        )
+
+        assert result == {"content": {"id": "1"}}
+        call = client.request.call_args.kwargs
+        assert call["method"] == "POST"
+        assert call["url"] == "https://backend.composio.dev/api/v3/tools/execute/GMAIL_SEND_EMAIL"
+        assert call["headers"] == {"x-api-key": "key", "Content-Type": "application/json"}
+        assert call["json"] == {
+            "arguments": {
+                "body": "Configured body",
+                "recipient_email": "a@b.c",
+                "is_html": False,
+                "extra-header": "x",
+            },
+            "user_id": "project-uuid",
+        }
+
+    def test_runtime_input_overrides_a_configured_argument(self):
+        node = _build_node(arguments={"body": "Configured body"})
+        client = MagicMock()
+        client.request = MagicMock(return_value=_mock_response(json_payload={"data": {}, "successful": True}))
+        node.client = client
+
+        node.execute(node.input_schema(recipient_email="a@b.c", body="Runtime body"))
+
+        assert client.request.call_args.kwargs["json"]["arguments"]["body"] == "Runtime body"
+
+    def test_connected_account_id_is_sent_only_when_set(self):
+        node = _build_node(connected_account_id="ca_1")
+        client = MagicMock()
+        client.request = MagicMock(return_value=_mock_response(json_payload={"data": {}, "successful": True}))
+        node.client = client
+
+        node.execute(node.input_schema(recipient_email="a@b.c", body="Body"))
+
+        assert client.request.call_args.kwargs["json"]["connected_account_id"] == "ca_1"
+
+    def test_output_is_raw_text_when_optimized_for_agents(self):
+        node = _build_node(is_optimized_for_agents=True)
+        client = MagicMock()
+        client.request = MagicMock(
+            return_value=_mock_response(json_payload={"data": {}, "successful": True}, text="raw body")
+        )
+        node.client = client
+
+        result = node.execute(node.input_schema(recipient_email="a@b.c", body="Body"))
+
+        assert result == {"content": "raw body"}
+
+    def test_failed_tool_call_raises_even_though_the_status_is_200(self):
+        node = _build_node()
+        client = MagicMock()
+        client.request = MagicMock(
+            return_value=_mock_response(
+                json_payload={"data": {}, "error": "Invalid recipient", "successful": False},
+            )
+        )
+        node.client = client
+
+        with pytest.raises(ToolExecutionException) as exc_info:
+            node.execute(node.input_schema(recipient_email="a@b.c", body="Body"))
+
+        assert "Invalid recipient" in str(exc_info.value)
+        assert exc_info.value.recoverable is False
+        assert client.request.call_count == 1  # an execute is never replayed
+
+    @pytest.mark.parametrize(
+        ("status_code", "recoverable"),
+        [(400, True), (429, True), (500, False)],
+    )
+    def test_error_status_raises(self, status_code, recoverable):
+        node = _build_node()
+        client = MagicMock()
+        client.request = MagicMock(return_value=_mock_response(status_code=status_code, text="boom"))
+        node.client = client
+
+        with pytest.raises(ToolExecutionException) as exc_info:
+            node.execute(node.input_schema(recipient_email="a@b.c", body="Body"))
+
+        assert str(status_code) in str(exc_info.value)
+        assert exc_info.value.recoverable is recoverable
+        assert client.request.call_count == 1
+
+    def test_run_reports_failure_when_the_tool_reports_failure(self):
+        node = _build_node()
+        client = MagicMock()
+        client.request = MagicMock(
+            return_value=_mock_response(json_payload={"data": {}, "error": "boom", "successful": False})
+        )
+        node.client = client
+
+        result = node.run(input_data={"recipient_email": "a@b.c", "body": "Body"})
+
+        assert result.status.value == "failure"
+
+
+class TestComposioAsync:
+    def test_composio_has_native_async(self):
+        assert Composio.execute_async is not Node.execute_async
+
+    @pytest.mark.asyncio
+    async def test_execute_async_success(self):
+        node = _build_node()
+        client = MagicMock()
+        client.request = AsyncMock(return_value=_mock_response(json_payload={"data": {"id": "1"}, "successful": True}))
+
+        with patch.object(Composio, "get_async_client", AsyncMock(return_value=client)):
+            result = await node.run_async(input_data={"recipient_email": "a@b.c", "body": "Body"})
+
+        assert result.status.value == "success"
+        assert result.output["content"] == {"id": "1"}
+        client.request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_async_fails_when_the_tool_reports_failure(self):
+        node = _build_node()
+        client = MagicMock()
+        client.request = AsyncMock(
+            return_value=_mock_response(json_payload={"data": {}, "error": "boom", "successful": False})
+        )
+
+        with patch.object(Composio, "get_async_client", AsyncMock(return_value=client)):
+            result = await node.run_async(input_data={"recipient_email": "a@b.c", "body": "Body"})
+
+        assert result.status.value == "failure"
+        assert client.request.await_count == 1
+
+
+class TestComposioConnection:
+    def test_conn_params_carry_the_api_key(self):
+        connection = ComposioConnection(api_key="key")
+
+        assert connection.conn_params == {"x-api-key": "key", "Content-Type": "application/json"}
+        assert connection.type == "dynamiq.connections.Composio"
+
+    @pytest.mark.asyncio
+    async def test_connection_supports_connect_async(self):
+        import httpx
+
+        connection = ComposioConnection(api_key="key")
+        client = await connection.connect_async()
+        try:
+            assert isinstance(client, httpx.AsyncClient)
+        finally:
+            await client.aclose()

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -41,6 +41,33 @@ def _mock_response(status_code=200, json_payload=None, text="ok"):
     return resp
 
 
+NESTED_INPUT_PROPS = {
+    "$defs": {
+        "Req": {
+            "type": "object",
+            "required": ["addr"],
+            "properties": {
+                "addr": {"$ref": "#/$defs/Addr"},
+                "stops": {"type": "array", "items": {"$ref": "#/$defs/Addr"}},
+                "note": {"type": "string"},
+            },
+        },
+        # More than one optional sub-field, so a test asserting the payload shape cannot pass
+        # merely because there was nothing left to leak.
+        "Addr": {
+            "type": "object",
+            "required": ["city"],
+            "properties": {
+                "city": {"type": "string"},
+                "zip": {"type": "string"},
+                "street": {"type": "string"},
+            },
+        },
+    },
+    "$ref": "#/$defs/Req",
+}
+
+
 def _composed_root(inner: dict, style: str) -> dict:
     """Express `inner` as a root that only reaches its properties through $ref or allOf."""
     if style == "inline":
@@ -123,23 +150,29 @@ class TestComposioInputSchema:
     def test_definitions_survive_a_resolved_root(self):
         # Resolving the root drops the `$defs` that lived on it, so they have to be carried across
         # or a property referencing one of them would fail to build.
-        input_props = {
-            "$defs": {
-                "Req": {
-                    "type": "object",
-                    "required": ["addr"],
-                    "properties": {"addr": {"$ref": "#/$defs/Addr"}, "note": {"type": "string"}},
-                },
-                "Addr": {"type": "object", "properties": {"city": {"type": "string"}}},
-            },
-            "$ref": "#/$defs/Req",
-        }
-        node = _build_node(input_props=input_props)
+        node = _build_node(input_props=NESTED_INPUT_PROPS)
 
         _, payload = node._build_request(node.input_schema(addr={"city": "Kyiv"}, note="x"))
 
-        assert sorted(node.input_schema.model_fields) == ["addr", "note"]
+        assert sorted(node.input_schema.model_fields) == ["addr", "note", "stops"]
         assert payload["arguments"]["addr"] == {"city": "Kyiv"}
+
+    def test_unset_fields_are_dropped_at_every_depth(self):
+        # The payload must carry only what the caller supplied: an optional property is typed
+        # `X | None` with default None, so a nested object would otherwise post an explicit null
+        # for every sub-field nobody set.
+        node = _build_node(input_props=NESTED_INPUT_PROPS)
+
+        _, payload = node._build_request(node.input_schema(addr={"city": "Kyiv"}, stops=[{"city": "Lviv"}]))
+
+        assert payload["arguments"] == {"addr": {"city": "Kyiv"}, "stops": [{"city": "Lviv"}]}
+
+    def test_supplied_nested_values_are_kept(self):
+        node = _build_node(input_props=NESTED_INPUT_PROPS)
+
+        _, payload = node._build_request(node.input_schema(addr={"city": "Kyiv", "zip": "01001"}, note="n"))
+
+        assert payload["arguments"] == {"addr": {"city": "Kyiv", "zip": "01001"}, "note": "n"}
 
     def test_property_name_that_is_not_an_identifier_keeps_its_alias(self):
         node = _build_node()

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -136,6 +136,24 @@ class TestComposioInputSchema:
 
         assert "input_schema" not in node.to_dict()
 
+    def test_to_dict_persists_the_supplied_description_without_the_parameter_listing(self):
+        node = _build_node(description="Send an email.")
+
+        assert "Required Parameters:" in node.description
+        assert node.to_dict()["description"] == "Send an email."
+
+    def test_description_does_not_compound_across_save_and_load_cycles(self):
+        # The parameter listing is appended onto whatever `description` holds, so persisting the
+        # generated text would make every save/load cycle append another copy of the listing.
+        node = _build_node(description="Send an email.")
+
+        for _ in range(3):
+            node = _build_node(description=node.to_dict()["description"])
+
+        assert node.description.count("Required Parameters:") == 1
+        assert node.description.count("Optional Parameters:") == 1
+        assert node.description.startswith("Send an email.")
+
 
 class TestComposioExecute:
     def test_execute_posts_to_the_tool_execute_endpoint(self):

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -199,6 +199,23 @@ class TestComposioInputSchema:
 
         assert node.input_schema.model_fields == {}
 
+    def test_two_actions_do_not_collide_on_the_default_name(self):
+        # An agent keys its tool registry on `name`, so two actions sharing one default would
+        # collapse to a single entry and leave the first unreachable.
+        fetch = _build_node(tool_slug="GMAIL_FETCH_EMAILS")
+        send = _build_node(tool_slug="GMAIL_SEND_EMAIL")
+
+        by_name = {tool.name: tool for tool in (fetch, send)}
+
+        assert fetch.name == "gmail_fetch_emails"
+        assert send.name == "gmail_send_email"
+        assert by_name == {"gmail_fetch_emails": fetch, "gmail_send_email": send}
+
+    def test_an_explicit_name_is_kept(self):
+        node = _build_node(name="Mailer")
+
+        assert node.name == "Mailer"
+
     def test_node_type_matches_the_wire_contract(self):
         assert _build_node().type == "dynamiq.nodes.tools.Composio"
 

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -1,8 +1,8 @@
 """Unit tests for the Composio action tool.
 
 A Composio execute answers HTTP 200 even when the action itself failed, so the tests below pin
-both the transport-level and the body-level failure handling, and assert the request is never
-replayed - an execute can have side effects.
+both the transport-level and the body-level failure handling, and assert a single execute issues
+a single request - an execute can have side effects.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,6 +13,7 @@ from dynamiq.connections.connections import Composio as ComposioConnection
 from dynamiq.nodes.agents.exceptions import ToolExecutionException
 from dynamiq.nodes.node import Node
 from dynamiq.nodes.tools.composio import Composio
+from dynamiq.runnables import RunnableStatus
 
 INPUT_PROPS = {
     "type": "object",
@@ -343,7 +344,29 @@ class TestComposioExecute:
 
         assert "Invalid recipient" in str(exc_info.value)
         assert exc_info.value.recoverable is False
-        assert client.request.call_count == 1  # an execute is never replayed
+        assert client.request.call_count == 1  # the node itself does not retry an execute
+
+    @pytest.mark.parametrize(
+        ("status_code", "json_payload"),
+        [(200, {"successful": False, "error": "Invalid recipient"}), (500, {}), (400, {})],
+    )
+    def test_run_reports_every_failure_as_recoverable(self, status_code, json_payload):
+        # Characterization, not endorsement: `Node._handle_failure` derives `recoverable` from the
+        # exception type, so the `recoverable=` argument at the raise site and the RECOVERABLE_CODES
+        # split never reach the result - every failure is reported as recoverable and the agent may
+        # re-issue the call. Update this test if `_handle_failure` starts honouring the argument.
+        node = _build_node()
+        client = MagicMock()
+        client.closed = False
+        client.is_closed = MagicMock(return_value=False)
+        client.request = MagicMock(return_value=_mock_response(status_code=status_code, json_payload=json_payload))
+        node.client = client
+
+        result = node.run(input_data={"recipient_email": "a@b.c", "body": "Body"})
+
+        assert result.status == RunnableStatus.FAILURE
+        assert result.error.recoverable is True
+        assert client.request.call_count == 1
 
     @pytest.mark.parametrize(
         ("status_code", "recoverable"),

--- a/tests/unit/nodes/tools/test_composio.py
+++ b/tests/unit/nodes/tools/test_composio.py
@@ -74,10 +74,44 @@ class TestComposioInputSchema:
 
         assert field.alias == "extra-header"
 
-    def test_empty_schema_builds_a_model_without_fields(self):
-        node = _build_node(input_props={})
+    @pytest.mark.parametrize("input_props", [{}, None])
+    def test_undeclared_schema_builds_a_model_without_fields(self, input_props):
+        # Composio reports "no declared schema" as either `{}` or `null`, and the persisted node omits
+        # the key entirely in that case, so all three spellings must build an empty input schema.
+        node = _build_node(input_props=input_props)
 
         assert node.input_schema.model_fields == {}
+
+    def test_absent_input_props_builds_a_model_without_fields(self):
+        node = Composio(
+            connection=ComposioConnection(api_key="key"),
+            user_id="project-uuid",
+            toolkit_slug="gmail",
+            tool_slug="GMAIL_SEND_EMAIL",
+        )
+
+        assert node.input_schema.model_fields == {}
+
+    def test_node_type_matches_the_wire_contract(self):
+        assert _build_node().type == "dynamiq.nodes.tools.Composio"
+
+    def test_to_dict_carries_the_wire_contract_keys(self):
+        node = _build_node(
+            tool_version="20250905_00",
+            connected_account_id="ca_xxx",
+            arguments={"recipient_email": "a@b.c"},
+        )
+
+        dumped = node.to_dict()
+
+        assert dumped["type"] == "dynamiq.nodes.tools.Composio"
+        assert dumped["user_id"] == "project-uuid"
+        assert dumped["toolkit_slug"] == "gmail"
+        assert dumped["tool_slug"] == "GMAIL_SEND_EMAIL"
+        assert dumped["tool_version"] == "20250905_00"
+        assert dumped["connected_account_id"] == "ca_xxx"
+        assert dumped["arguments"] == {"recipient_email": "a@b.c"}
+        assert "input_props" in dumped
 
     def test_description_lists_parameters_and_configured_arguments(self):
         node = _build_node(description="Send an email.", arguments={"body": "Configured body"})
@@ -131,6 +165,36 @@ class TestComposioExecute:
         node.execute(node.input_schema(recipient_email="a@b.c", body="Runtime body"))
 
         assert client.request.call_args.kwargs["json"]["arguments"]["body"] == "Runtime body"
+
+    def test_tool_version_is_sent_as_version(self):
+        node = _build_node(tool_version="20250905_00")
+        client = MagicMock()
+        client.request = MagicMock(return_value=_mock_response(json_payload={"data": {}, "successful": True}))
+        node.client = client
+
+        node.execute(node.input_schema(recipient_email="a@b.c", body="Body"))
+
+        assert client.request.call_args.kwargs["json"]["version"] == "20250905_00"
+
+    def test_version_is_omitted_when_no_tool_version_is_pinned(self):
+        node = _build_node()
+        client = MagicMock()
+        client.request = MagicMock(return_value=_mock_response(json_payload={"data": {}, "successful": True}))
+        node.client = client
+
+        node.execute(node.input_schema(recipient_email="a@b.c", body="Body"))
+
+        assert "version" not in client.request.call_args.kwargs["json"]
+
+    def test_connected_account_id_is_omitted_when_unset(self):
+        node = _build_node()
+        client = MagicMock()
+        client.request = MagicMock(return_value=_mock_response(json_payload={"data": {}, "successful": True}))
+        node.client = client
+
+        node.execute(node.input_schema(recipient_email="a@b.c", body="Body"))
+
+        assert "connected_account_id" not in client.request.call_args.kwargs["json"]
 
     def test_connected_account_id_is_sent_only_when_set(self):
         node = _build_node(connected_account_id="ca_1")
@@ -196,9 +260,15 @@ class TestComposioExecute:
         )
         node.client = client
 
-        result = node.run(input_data={"recipient_email": "a@b.c", "body": "Body"})
+        # `run` funnels through `execute_with_retry`, which calls `ensure_client` and would replace the
+        # stub above with a live `requests` client - the assertion below would then pass on a real
+        # network failure instead of on the tool-level failure this test is about.
+        with patch.object(Composio, "ensure_client", MagicMock()):
+            result = node.run(input_data={"recipient_email": "a@b.c", "body": "Body"})
 
         assert result.status.value == "failure"
+        assert "boom" in str(result.error.to_dict())
+        assert client.request.call_count == 1
 
 
 class TestComposioAsync:


### PR DESCRIPTION
Adds `dynamiq.nodes.tools.Composio`, the runtime counterpart of the Composio Action node, alongside the existing Pipedream tool node.

Part of a three-repo change:
- **dynamiq** (this PR) — the executing node
- **mono** — https://github.com/dynamiq-ai/mono/pull/1330
- **ui** — https://github.com/dynamiq-ai/ui/pull/1538

Without this, a Composio Action node can be built and saved but not run.

## What changed

- `Composio` connection in `dynamiq/connections/connections.py` — API key auth against `https://backend.composio.dev/api/v3`.
- `Composio` node in `dynamiq/nodes/tools/composio.py`. It builds its pydantic input schema from the tool's `input_parameters` JSON Schema, reusing the helper the MCP node already uses for that same shape, and merges design-time argument values with runtime input.
- `resolve_root_object_schema` in `dynamiq/nodes/tools/mcp.py` — exposes the `$ref`/`allOf` root resolution the schema builder already performs, so callers that rewrite properties operate on the schema the model is actually built from.
- Examples under `examples/components/tools/composio/` — direct execution and an agent, in Python and declarative YAML.

## Four details worth review

**One node is one action, so a node is named after its action.** An agent keys its tool registry, its prompt listing and its result cache on `name`. An unnamed node takes its lowercased `tool_slug`, so two actions on the same agent stay distinct; an explicit `name` is kept.

**A failed action still returns HTTP 200.** Composio reports the real outcome in `successful` in the response body, so the status code alone would treat a failed action as a success. The node reads `successful` and raises `ToolExecutionException`.

It passes `recoverable=False` to record that an execute should not be replayed — it may have side effects — but that argument does not currently stop one, and the docstring says so. `Node._handle_failure` derives the flag from the exception type (`isinstance(e, RecoverableAgentException)`), not from the value at the raise site, so every failure is reported as recoverable and the agent may re-issue the call. The same is true of the `RECOVERABLE_CODES` split and of every other tool in the repo that passes the argument, `pipedream.py` included. Making it effective is a framework-level change to `_handle_failure` that would alter behaviour for every tool, so it belongs in its own PR rather than here.

**The tool version is sent explicitly.** Omitting it lets Composio resolve its own default, which can differ from the schema the arguments were configured against; the node sends the version captured when the action was picked.

**A configured argument outranks the schema default.** A parameter configured at design time is dropped from the schema's `required` list, so the runtime input may override it but need not supply one. Its JSON Schema `default` is dropped along with it — otherwise the built model emits that default whenever the caller stays silent, and it wins over the configured value when the payload is assembled, silently sending Composio's default instead of what was configured. Parameters that are *not* configured keep their schema default unchanged. Both rewrites run against the resolved root, so they apply equally to schemas expressed through a root-level `$ref` or `allOf`.

## Review findings fixed after the first approval

- `description` compounded a fresh copy of the parameter listing on every save/load cycle; `to_dict` now persists the description Composio supplied rather than the generated one.
- The declarative example defined no `flows:`/`workflows:`, so `Workflow.from_yaml_file` raised `IndexError` on it.
- Configured arguments were silently ignored when the schema root was a `$ref`/`allOf` composition — the action executed against Composio's default instead of the configured value, with no error raised.
- The docstring claimed `recoverable=False` prevented replay; it does not (see above).
- Nested objects, and objects inside arrays, posted an explicit `null` for every sub-field the caller left unset.
- Every node took the same default `name`, so two actions on one agent collapsed to a single entry in `BaseAgent.tool_by_names` and the first became unreachable.

## Verification

`pytest tests/unit` — 2715 passed, 1 skipped, including 45 tests for this node. `black` and `isort` clean at the repo's configured line length.